### PR TITLE
Expose package-fs

### DIFF
--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,6 +1,7 @@
 import type { Project } from "./project";
 export { Project } from "./project";
 export { Pack } from "./pack";
+export * from './package-fs';
 
 type FunctionDescription = {
   name: string;


### PR DESCRIPTION
This PR adds an extra export to the compiler package.

Over in Lightning, I have a requirement to pull .d.ts files out of adaptor packages.

In order to do that, I need access to `fetchDTSListing` and  `fetchFile` from `compiler/package-fs`, which isn't currently exposed by the module.

It probably makes sense to release `@openfn/compiler` as a 0.0.2 version as a result of this change. That way, Lightning can explicitly require this version.