### PR TITLE
Ignore node modules in flatten

### DIFF
--- a/packages/compiler/src/package-fs.ts
+++ b/packages/compiler/src/package-fs.ts
@@ -18,21 +18,24 @@ interface PackageListing {
   files?: PackageListing[];
 }
 
-function* flattenFiles(
+export function* flattenFiles(
   listing: PackageListing,
+  ignoreNodeModules = false,
   path: string = ""
 ): Generator<string> {
   if (listing.type == "directory") {
     for (let i = 0; i < listing.files!.length; i++) {
       const f = listing.files![i];
-      yield* flattenFiles(f);
+      if (!ignoreNodeModules || !f.path.startsWith('/node_modules/')) {
+        yield* flattenFiles(f, ignoreNodeModules);
+      }
     }
   } else {
     yield `${path}${listing.path}`;
   }
 }
 
-export async function fetchFileListing(packageName: string) {
+export async function fetchFileListing(packageName: string, ignoreNodeModules = false) {
   // const cached = localStorage.getItem(packageName);
   // if (cached) {
   //   return flattenFiles(JSON.parse(cached));
@@ -49,7 +52,7 @@ export async function fetchFileListing(packageName: string) {
   const listing = (await response.json()) as PackageListing;
   // localStorage.setItem(packageName, JSON.stringify(listing));
 
-  return flattenFiles(listing);
+  return flattenFiles(listing, ignoreNodeModules);
 }
 
 const dtsExtension = /\.d\.ts$/;

--- a/packages/compiler/src/package-fs.ts
+++ b/packages/compiler/src/package-fs.ts
@@ -66,7 +66,7 @@ const dtsExtension = /\.d\.ts$/;
  * @param packageName string
  */
 export async function* fetchDTSListing(packageName: string) {
-  for (const f of await fetchFileListing(packageName)) {
+  for (const f of await fetchFileListing(packageName, true)) {
     if (dtsExtension.test(f)) {
       yield f;
     }

--- a/packages/compiler/test/package-fs.spec.ts
+++ b/packages/compiler/test/package-fs.spec.ts
@@ -1,5 +1,55 @@
 import { assert } from "chai";
-import { fetchDTSListing, fetchFile } from "../src/package-fs";
+import { fetchDTSListing, fetchFile, flattenFiles } from "../src/package-fs";
+
+describe("flattenFiles", () => {
+  it('should flatten a file list', async() => {
+    const listing = {
+      "path": "a",
+      "type": "directory",
+      "files": [
+        { "path": "node_modules", "type": "directory", "files": [
+          { "path": "/node_modules/x.js", "type": "file" },
+        ]},
+        { "path": "lib", "type": "directory", "files": [
+          { "path": "/lib/y.js", "type": "file" },
+        ]},
+        { "path": "/a.js", "type": "file" }
+      ]
+    };
+    const results: string[] = [];
+    for await (const f of flattenFiles(listing)) {
+      results.push(f);
+    }
+    assert.deepEqual(results.length, 3)
+    assert.include(results, '/node_modules/x.js');
+    assert.include(results, '/lib/y.js');
+    assert.include(results, '/a.js');
+  });
+
+  it('should flatten a file list ignore node_modules', async() => {
+    const listing = {
+      "path": "a",
+      "type": "directory",
+      "files": [
+        { "path": "/node_modules", "type": "directory", "files": [
+          { "path": "/node_modules/x.js", "type": "file" },
+        ]},
+        { "path": "lib", "type": "directory", "files": [
+          { "path": "/lib/y.js", "type": "file" },
+        ]},
+        { "path": "/a.js", "type": "file" }
+      ]
+    };
+    const results: string[] = [];
+    for await (const f of flattenFiles(listing, true)) {
+      results.push(f);
+    }
+    assert.deepEqual(results.length, 2)
+    assert.include(results, '/lib/y.js');
+    assert.include(results, '/a.js');
+  });
+
+});
 
 describe("fetchDTS", () => {
   it("can get a list of .d.ts files for a given package", async () => {


### PR DESCRIPTION
For some reason, when we call [https://unpkg.com/@openfn/language-common@1.7.3/?meta](https://unpkg.com/@openfn/language-common@1.7.3/?meta) for metadata, the resulting `files` list includes type definitions from node modules.

I presume this is something "wrong" with the 1.7.3 package of language-common.

In any case, what this means is that when our shiny new Monaco editor looks for the d.ts for an older module, it pulls down a lot of d.ts files which is a) kinda slow and b) could result in incorrect typings.

While we could work around this in the Lightning repo, it seems sensible to me to add a flag to ignore  node_modules paths when running `flattenFiles`. I've defaulted this to `false`, so that it doesn't break anythhing, but maybe we should default that to `true`.

`fetchDTS` is, so far as I can tell, not used by anyone else, so I've taken the liberty to defaulting that to ignoring node modules.