### PR TITLE
tsconfig refactor

### DIFF
--- a/packages/compiler/tsconfig.json
+++ b/packages/compiler/tsconfig.json
@@ -1,50 +1,5 @@
 {
-  "compilerOptions": {
-    // Allow JavaScript files to be compiled
-    "allowJs": true,
-    // Allow default imports from modules with no default export
-    "allowSyntheticDefaultImports": true,
-    "baseUrl": "src",
-    "outDir": "dist",
-    "declarationDir": ".",
-    // Generate corresponding .d.ts file
-    "declaration": true,
-    // Disables namespace imports (import * as fs from "fs") and enables CJS/AMD/UMD style imports (import fs from "fs")
-    "esModuleInterop": true,
-    // Disallow inconsistently-cased references to the same file.
-    "forceConsistentCasingInFileNames": true,
-    // Enable incremental compilation by reading/writing information from prior compilations to a file on disk
-    "incremental": true,
-    // Unconditionally emit imports for unresolved files
-    "isolatedModules": true,
-    // "jsx": "react", // Support JSX in .tsx files
-    // List of library files to be included in the compilation
-    "lib": ["ES2022", "DOM.Iterable"],
-    // Specify module code generation
-    "module": "es2022",
-    // Resolve modules using Node.js style
-    "moduleResolution": "node",
-    // Do not emit output (meaning do not compile code, only perform type checking)
-    "noEmit": false,
-    // Report errors for fallthrough cases in switch statement
-    "noFallthroughCasesInSwitch": true,
-    // Report errors on unused locals
-    "noUnusedLocals": true,
-    // Report errors on unused parameters
-    "noUnusedParameters": true,
-    // Include modules imported with .json extension
-    "resolveJsonModule": true,
-    // Skip type checking of all declaration files
-    "skipLibCheck": true,
-    // Generate corrresponding .map file
-    "sourceMap": true,
-    // Enable all strict type checking options
-    "strict": true,
-    // Specify ECMAScript target version
-    "target": "ES2020",
-    "typeRoots": ["./node_modules/@types"]
-  },
+  "extends": "../../tsconfig.common",
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "**/*.spec.ts", "dist"]
-  
 }

--- a/packages/workflow-diagram/tsconfig.json
+++ b/packages/workflow-diagram/tsconfig.json
@@ -1,29 +1,5 @@
 {
-  "compilerOptions": {
-    "allowJs": true, // Allow JavaScript files to be compiled
-    "allowSyntheticDefaultImports": true, // Allow default imports from modules with no default export
-    "baseUrl": "src",
-    "outDir": "dist",
-    "declarationDir": ".",
-    "declaration": true, // Generate corresponding .d.ts file
-    "esModuleInterop": true, // Disables namespace imports (import * as fs from "fs") and enables CJS/AMD/UMD style imports (import fs from "fs")
-    "forceConsistentCasingInFileNames": true, // Disallow inconsistently-cased references to the same file.
-    "incremental": true, // Enable incremental compilation by reading/writing information from prior compilations to a file on disk
-    "isolatedModules": true, // Unconditionally emit imports for unresolved files
-    "jsx": "react", // Support JSX in .tsx files
-    "lib": ["dom", "dom.iterable", "esnext"], // List of library files to be included in the compilation
-    "module": "es2020", // Specify module code generation
-    "moduleResolution": "node", // Resolve modules using Node.js style
-    "noEmit": false, // Do not emit output (meaning do not compile code, only perform type checking)
-    "noFallthroughCasesInSwitch": true, // Report errors for fallthrough cases in switch statement
-    "noUnusedLocals": true, // Report errors on unused locals
-    "noUnusedParameters": true, // Report errors on unused parameters
-    "resolveJsonModule": true, // Include modules imported with .json extension
-    "skipLibCheck": true, // Skip type checking of all declaration files
-    "sourceMap": true, // Generate corrresponding .map file
-    "strict": true, // Enable all strict type checking options
-    "target": "es2020" // Specify ECMAScript target version
-  },
+  "extends": "../../tsconfig.common",
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "src/dev.tsx", "dist"]
 }

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -1,0 +1,47 @@
+{
+  "compilerOptions": {
+    // Allow JavaScript files to be compiled
+    "allowJs": true,
+    // Allow default imports from modules with no default export
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": "src",
+    "outDir": "dist",
+    "declarationDir": ".",
+    // Generate corresponding .d.ts file
+    "declaration": true,
+    // Disables namespace imports (import * as fs from "fs") and enables CJS/AMD/UMD style imports (import fs from "fs")
+    "esModuleInterop": true,
+    // Disallow inconsistently-cased references to the same file.
+    "forceConsistentCasingInFileNames": true,
+    // Enable incremental compilation by reading/writing information from prior compilations to a file on disk
+    "incremental": true,
+    // Unconditionally emit imports for unresolved files
+    "isolatedModules": true,
+    // "jsx": "react", // Support JSX in .tsx files
+    // List of library files to be included in the compilation
+    "lib": ["ES2022", "DOM.Iterable"],
+    // Specify module code generation
+    "module": "es2022",
+    // Resolve modules using Node.js style
+    "moduleResolution": "node",
+    // Do not emit output (meaning do not compile code, only perform type checking)
+    "noEmit": false,
+    // Report errors for fallthrough cases in switch statement
+    "noFallthroughCasesInSwitch": true,
+    // Report errors on unused locals
+    "noUnusedLocals": true,
+    // Report errors on unused parameters
+    "noUnusedParameters": true,
+    // Include modules imported with .json extension
+    "resolveJsonModule": true,
+    // Skip type checking of all declaration files
+    "skipLibCheck": true,
+    // Generate corrresponding .map file
+    "sourceMap": true,
+    // Enable all strict type checking options
+    "strict": true,
+    // Specify ECMAScript target version
+    "target": "ES2020",
+    "typeRoots": ["./node_modules/@types"]
+  },
+}


### PR DESCRIPTION
Really small thing but I wanted to spin it out of the v2 work I'm doing.

As I'm creating more packages I'm duplicating a lot of tsconfigs - I jut wanted to take a breather and abstract out the main compiler rules into the top level and have each package extend it.

Packages are technically free to add their own rules if they want, but we should be looking to apply a consistent set of standards across everything in this repo.