### PR TITLE
Cli fixes & Improvements

### DIFF
--- a/.changeset/odd-pugs-hunt.md
+++ b/.changeset/odd-pugs-hunt.md
@@ -1,0 +1,6 @@
+---
+'@openfn/cli': patch
+'@openfn/runtime': patch
+---
+
+Bug fixes

--- a/.changeset/stale-dolls-refuse.md
+++ b/.changeset/stale-dolls-refuse.md
@@ -1,0 +1,5 @@
+---
+'@openfn/logger': patch
+---
+
+Fix state sanitisation

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,7 +15,7 @@ export const cmd = yargs(hideBin(process.argv))
   // Common options
   .option('log', {
     alias: ['l'],
-    description: 'Set the default log level to none, trace, info or default',
+    description: 'Set the default log level to none, default, info or debug',
     array: true,
   })
   .alias('v', 'version')

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -55,7 +55,6 @@ export const resolveSpecifierPath = async (
 
   const repoPath = await getModulePath(specifier, repoDir, log);
   if (repoPath) {
-    log.debug(`Resolved ${specifier} to repo module`);
     return repoPath;
   }
   return null;

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -90,7 +90,7 @@ export const loadTransformOptions = async (opts: SafeOpts, log: Logger) => {
     }
 
     if (!exports || exports.length === 0) {
-      console.warn(`WARNING: no module exports found for ${pattern}`);
+      log.debug(`No module exports found for ${pattern}`);
     }
 
     options['add-imports'] = {

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -68,7 +68,7 @@ export const loadTransformOptions = async (opts: SafeOpts, log: Logger) => {
 
   // If an adaptor is passed in, we need to look up its declared exports
   // and pass them along to the compiler
-  if (opts.adaptors) {
+  if (opts.adaptors?.length) {
     let exports;
     const [pattern] = opts.adaptors; // TODO add-imports only takes on adaptor, but the cli can take multiple
     const [specifier] = pattern.split('=');

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -53,7 +53,7 @@ export const resolveSpecifierPath = async (
     return path;
   }
 
-  const repoPath = await getModulePath(specifier, repoDir);
+  const repoPath = await getModulePath(specifier, repoDir, log);
   if (repoPath) {
     log.debug(`Resolved ${specifier} to repo module`);
     return repoPath;

--- a/packages/cli/src/repo/handler.ts
+++ b/packages/cli/src/repo/handler.ts
@@ -55,16 +55,16 @@ export const pwd = async (options: SafeOpts, logger: Logger) => {
 
 export const getDependencyList = async (options: SafeOpts, _logger: Logger) => {
   const pkg = await loadRepoPkg(options.repoDir);
-
   const result: Record<string, string[]> = {};
-  Object.keys(pkg.dependencies).forEach((key) => {
-    const [name, version] = key.split('_');
-    if (!result[name]) {
-      result[name] = [];
-    }
-    result[name].push(version);
-  });
-
+  if (pkg) {
+    Object.keys(pkg.dependencies).forEach((key) => {
+      const [name, version] = key.split('_');
+      if (!result[name]) {
+        result[name] = [];
+      }
+      result[name].push(version);
+    });
+  }
   return result;
 };
 export const list = async (options: SafeOpts, logger: Logger) => {

--- a/packages/cli/src/util/ensure-opts.ts
+++ b/packages/cli/src/util/ensure-opts.ts
@@ -78,7 +78,7 @@ export default function ensureOpts(
     force: opts.force || false,
     repoDir: opts.repoDir || process.env.OPENFN_REPO_DIR || DEFAULT_REPO_DIR,
     noCompile: Boolean(opts.noCompile),
-    expand: Boolean(opts.expand),
+    expand: opts.expand !== false,
     outputStdout: Boolean(opts.outputStdout),
     packages: opts.packages,
     stateStdin: opts.stateStdin,

--- a/packages/cli/src/util/ensure-opts.ts
+++ b/packages/cli/src/util/ensure-opts.ts
@@ -13,6 +13,8 @@ export const ERROR_MESSAGE_LOG_LEVEL =
 export const ERROR_MESSAGE_LOG_COMPONENT =
   'Unknown log component. Valid components are cli, compiler, runtime and job.';
 
+export const DEFAULT_REPO_DIR = '/tmp/openfn/repo';
+
 const componentShorthands: Record<string, string> = {
   cmp: 'compiler',
   rt: 'runtime',
@@ -74,7 +76,7 @@ export default function ensureOpts(
     autoinstall: opts.autoinstall,
     command: opts.command,
     force: opts.force || false,
-    repoDir: opts.repoDir || process.env.OPENFN_REPO_DIR,
+    repoDir: opts.repoDir || process.env.OPENFN_REPO_DIR || DEFAULT_REPO_DIR,
     noCompile: Boolean(opts.noCompile),
     expand: Boolean(opts.expand),
     outputStdout: Boolean(opts.outputStdout),

--- a/packages/cli/src/util/ensure-opts.ts
+++ b/packages/cli/src/util/ensure-opts.ts
@@ -72,7 +72,7 @@ export default function ensureOpts(
 ): SafeOpts {
   const newOpts = {
     adaptor: opts.adaptor, // only applies to install (a bit messy)
-    adaptors: opts.adaptors,
+    adaptors: opts.adaptors || [],
     autoinstall: opts.autoinstall,
     command: opts.command,
     force: opts.force || false,

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -338,6 +338,36 @@ test.serial('pwd with modules_home from env', async (t) => {
   delete process.env.OPENFN_REPO_DIR;
 });
 
+test.serial('list should return something', async (t) => {
+  const options = {
+    logger,
+    repoDir: 'a/b/c',
+  };
+  await run('repo list', '', options);
+
+  // Rough check of the shape of the output
+  const [pwd, installed] = logger._history;
+  t.assert(logger._parse(pwd).message, 'Repo working directory is: a/b/c');
+
+  t.assert(logger._parse(installed).message, 'Installed packages:');
+});
+
+// This used to throw, see #70
+test.serial('list does not throw if repo is not initialised', async (t) => {
+  mock({
+    '/repo/': {}, // empty dir
+  });
+
+  const opts = cmd.parse('repo list') as Opts;
+  opts.repoDir = '/repo/';
+  opts.logger = logger;
+
+  await commandParser('', opts, logger);
+
+  const { message } = logger._parse(logger._last);
+  t.truthy(message);
+});
+
 // TODO - need to work out a way to test agaist stdout
 // should return to stdout
 // should log stuff to console

--- a/packages/cli/test/execute/parse-adaptors.test.ts
+++ b/packages/cli/test/execute/parse-adaptors.test.ts
@@ -1,0 +1,52 @@
+import test from 'ava';
+
+import { parseAdaptors } from '../../src/execute/execute';
+
+test('parse a simple specifier', (t) => {
+  const adaptors = ['a'];
+  const result = parseAdaptors({ adaptors });
+  t.assert(Object.keys(result).length === 1);
+  t.truthy(result.a);
+  t.falsy(Object.keys(result.a).length);
+});
+
+test('parse multiple specifiers', (t) => {
+  const adaptors = ['a', 'b'];
+  const result = parseAdaptors({ adaptors });
+  t.assert(Object.keys(result).length === 2);
+  t.truthy(result.a);
+  t.truthy(result.b);
+});
+
+test('parse a specifier with a path', (t) => {
+  const adaptors = ['a=x'];
+  const result = parseAdaptors({ adaptors });
+  t.assert(Object.keys(result).length === 1);
+  t.deepEqual(result.a, { path: 'x' });
+});
+
+test('parse a specifier with a version', (t) => {
+  const adaptors = ['a@1'];
+  const result = parseAdaptors({ adaptors });
+  t.assert(Object.keys(result).length === 1);
+  t.deepEqual(result.a, { version: '1' });
+});
+
+test('parse a specifier with a path and version', (t) => {
+  const adaptors = ['a@1=x'];
+  const result = parseAdaptors({ adaptors });
+  t.assert(Object.keys(result).length === 1);
+  t.deepEqual(result.a, { path: 'x', version: '1' });
+});
+
+test('parse @openfn/language-common@1.0.0=~/repo/modules/common', (t) => {
+  const adaptors = ['@openfn/language-common@1.0.0=~/repo/modules/common'];
+  const result = parseAdaptors({ adaptors });
+  t.assert(Object.keys(result).length === 1);
+  t.deepEqual(result, {
+    '@openfn/language-common': {
+      path: '~/repo/modules/common',
+      version: '1.0.0',
+    },
+  });
+});

--- a/packages/cli/test/util/ensure-opts.test.ts
+++ b/packages/cli/test/util/ensure-opts.test.ts
@@ -88,6 +88,26 @@ test('should not append @openfn to adaptors if already prefixed', (t) => {
   t.assert(opts.adaptors[0] === '@openfn/language-common=a/b/c');
 });
 
+test('should create an empty adaptors object', (t) => {
+  const initialOpts = {} as Opts;
+
+  const opts = ensureOpts('a', initialOpts);
+
+  t.truthy(opts.adaptors);
+  t.falsy(opts.adaptors.length);
+});
+
+test('should create an empty adaptors object if undefined', (t) => {
+  const initialOpts = {
+    adaptors: undefined,
+  } as Opts;
+
+  const opts = ensureOpts('a', initialOpts);
+
+  t.truthy(opts.adaptors);
+  t.falsy(opts.adaptors.length);
+});
+
 test('preserve outputStdout', (t) => {
   const initialOpts = {
     outputStdout: true,

--- a/packages/cli/test/util/ensure-opts.test.ts
+++ b/packages/cli/test/util/ensure-opts.test.ts
@@ -120,12 +120,42 @@ test('preserve noCompile', (t) => {
 
 test('preserve expand', (t) => {
   const initialOpts = {
-    expand: true,
+    expand: false,
   } as Opts;
 
   const opts = ensureOpts('a', initialOpts);
 
-  t.truthy(opts.expand);
+  t.false(opts.expand);
+});
+
+test('default expand', (t) => {
+  const initialOpts = {} as Opts;
+
+  const opts = ensureOpts('a', initialOpts);
+
+  t.true(opts.expand);
+});
+
+test('default expand if undefined', (t) => {
+  // @ts-ignore
+  const initialOpts = {
+    expand: undefined,
+  } as Opts;
+
+  const opts = ensureOpts('a', initialOpts);
+
+  t.true(opts.expand);
+});
+
+test('default expand if null', (t) => {
+  // @ts-ignore
+  const initialOpts = {
+    expand: null,
+  } as Opts;
+
+  const opts = ensureOpts('a', initialOpts);
+
+  t.true(opts.expand);
 });
 
 test('preserve stateStdin', (t) => {

--- a/packages/logger/src/mock.ts
+++ b/packages/logger/src/mock.ts
@@ -15,6 +15,7 @@ type MockLogger = Logger & {
     namespace?: string;
     icon?: string;
     message: string | object;
+    messageRaw: any[];
   };
 };
 
@@ -56,7 +57,7 @@ const mockLogger = (name?: string, opts: LogOptions = {}): MockLogger => {
     let messageParts = [];
 
     if (log[0] === 'confirm') {
-      return { level: 'confirm', message: log[1] };
+      return { level: 'confirm', message: log[1], messageRaw: [log[1]] };
     }
 
     if (name && !opts.hideNamespace && !opts.hideIcons) {
@@ -87,6 +88,7 @@ const mockLogger = (name?: string, opts: LogOptions = {}): MockLogger => {
       namespace: namespace.substring(1, namespace.length - 1),
       icon,
       message,
+      messageRaw: messageParts,
     };
   };
 
@@ -96,7 +98,6 @@ const mockLogger = (name?: string, opts: LogOptions = {}): MockLogger => {
    * b) see a confirm message in the log history
    */
   mock.confirm = async (message: string) => {
-    console.log(message);
     history.push(['confirm', message]);
     return true;
   };

--- a/packages/logger/src/sanitize.ts
+++ b/packages/logger/src/sanitize.ts
@@ -12,15 +12,15 @@ const sanitize = (
   // TODO what if the object contains functions?
   if (typeof item !== 'string') {
     const obj = item as Record<string, unknown>;
-    if (obj.data && obj.configuration) {
-      // This is a state object, so let's sanitize it
-      const cleanConfig = {} as Record<string, unknown>;
+    if (obj.configuration) {
+      // This looks sensitive, so let's sanitize it
+      const configuration = {} as Record<string, unknown>;
       for (const k in obj.configuration) {
-        cleanConfig[k] = SECRET;
+        configuration[k] = SECRET;
       }
       const cleaned = {
-        configuration: cleanConfig,
-        data: obj.data,
+        ...obj,
+        configuration,
       };
       return cleaned;
     }

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -213,6 +213,22 @@ test('sanitize state', (t) => {
   t.is(message.configuration.x, SECRET);
 });
 
+test('sanitize state in second arg', (t) => {
+  const logger = createLogger();
+  logger.success('state', {
+    configuration: {
+      x: 'y',
+    },
+    data: {},
+  });
+
+  const { messageRaw } = logger._parse(logger._last);
+  const [message, state] = messageRaw;
+  // @ts-ignore
+  t.is(message, 'state');
+  t.is(state.configuration.x, SECRET);
+});
+
 test('timer: start', (t) => {
   const logger = createLogger();
   const result = logger.timer('t');

--- a/packages/logger/test/mock.test.ts
+++ b/packages/logger/test/mock.test.ts
@@ -93,6 +93,16 @@ test('_parse with default settings', (t) => {
   t.falsy(namespace);
 });
 
+test('_parse raw message', (t) => {
+  const logger = mockLogger();
+  logger.success('x', 1, true);
+
+  const { messageRaw } = logger._parse(logger._last);
+  t.is(messageRaw[0], 'x');
+  t.is(messageRaw[1], 1);
+  t.true(messageRaw[2]);
+});
+
 test('_parse with a namespace', (t) => {
   const logger = mockLogger('a');
   logger.success('x');

--- a/packages/logger/test/sanitize.test.ts
+++ b/packages/logger/test/sanitize.test.ts
@@ -26,6 +26,30 @@ test('sanitize state.configuration', (t) => {
   t.deepEqual(result, expectedState);
 });
 
+test('sanitize if no data is passed', (t) => {
+  const state = {
+    configuration: { password: 'password1', username: 'foo' },
+  };
+  const expectedState = {
+    configuration: { password: SECRET, username: SECRET },
+  };
+  const result = sanitize(state, options);
+  t.deepEqual(result, expectedState);
+});
+
+test('preserve top level stuff after sanitizing', (t) => {
+  const state = {
+    configuration: { password: 'password1', username: 'foo' },
+    jam: 'jar',
+  };
+  const expectedState = {
+    configuration: { password: SECRET, username: SECRET },
+    jam: 'jar',
+  };
+  const result = sanitize(state, options);
+  t.deepEqual(result, expectedState);
+});
+
 // TODO not implemented yet
 test.skip('sanitize a simple path', (t) => {
   const result = sanitize({ a: 'x' }, { sanitizePaths: ['a'] });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,4 +1,7 @@
 import run from './runtime';
 export default run;
 
+import type { ModuleInfo, ModuleInfoMap } from './modules/linker';
+export type { ModuleInfo, ModuleInfoMap };
+
 export * from './modules/repo';

--- a/packages/runtime/src/modules/linker.ts
+++ b/packages/runtime/src/modules/linker.ts
@@ -3,10 +3,15 @@
  * The tricky bit is this MUST load all linked libraries in the context of the parent module
  * https://nodejs.org/api/html#modulelinklinker
  */
+import { createMockLogger, Logger } from '@openfn/logger';
 import vm, { Module, SyntheticModule, Context } from './experimental-vm';
 import { getModulePath } from './repo';
 
+const defaultLogger = createMockLogger();
+
 export type LinkerOptions = {
+  log?: Logger;
+
   // paths to modules: '@openfn/language-common': './path/to/common.js'
   modulePaths?: Record<string, string>;
 
@@ -15,6 +20,7 @@ export type LinkerOptions = {
 
   whitelist?: RegExp[]; // whitelist packages which the linker allows to be imported
 
+  // TODO deprecated - use the logger instead
   trace?: boolean; // log module lookup information
 };
 
@@ -25,10 +31,10 @@ export type Linker = (
 ) => Promise<Module>;
 
 const linker: Linker = async (specifier, context, options = {}) => {
-  const { whitelist, trace } = options;
-  if (trace) {
-    console.log(`[linker] loading module ${specifier}`);
-  }
+  const { whitelist } = options;
+  const log = options.log || defaultLogger;
+  log.debug(`[linker] loading module ${specifier}`);
+
   if (whitelist && !whitelist.find((r) => r.exec(specifier))) {
     throw new Error(`Error: module blacklisted: ${specifier}`);
   }
@@ -77,11 +83,10 @@ const linker: Linker = async (specifier, context, options = {}) => {
 
 // Loads a module as a general specifier or from a specific path
 const loadActualModule = async (specifier: string, options: LinkerOptions) => {
+  const log = options.log || defaultLogger;
+
   // Lookup the path from an explicit specifier first
   let path = options.modulePaths?.[specifier] || null;
-  if (options.trace && path) {
-    console.log(`[linker] Loading module ${specifier} from mapped ${path}`);
-  }
 
   if (!path && options.repo) {
     // Try and load a matching path from the repo
@@ -89,19 +94,20 @@ const loadActualModule = async (specifier: string, options: LinkerOptions) => {
   }
 
   if (path) {
+    // TODO: should we log WHY this path was used? Maybe this is enough for now
+    log.debug(`[linker] Loading module ${specifier} from ${path}`);
     try {
       return import(path);
     } catch (e) {
       if (options.trace) {
-        console.warn(
-          `[linker] Failed to load module ${specifier} from ${path}`
-        );
+        log.debug(`[linker] Failed to load module ${specifier} from ${path}`);
         console.log(e);
       }
       // If we fail to load from a path, fall back to loading from a specifier
     }
   }
 
+  log.debug(`[linker] Loading ${specifier} using default import()`);
   return import(specifier);
 };
 

--- a/packages/runtime/src/modules/linker.ts
+++ b/packages/runtime/src/modules/linker.ts
@@ -25,9 +25,6 @@ export type LinkerOptions = {
   repo?: string;
 
   whitelist?: RegExp[]; // whitelist packages which the linker allows to be imported
-
-  // TODO deprecated - use the logger instead
-  trace?: boolean; // log module lookup information
 };
 
 export type Linker = (
@@ -114,10 +111,8 @@ const loadActualModule = async (specifier: string, options: LinkerOptions) => {
     try {
       return import(path);
     } catch (e) {
-      if (options.trace) {
-        log.debug(`[linker] Failed to load module ${specifier} from ${path}`);
-        console.log(e);
-      }
+      log.debug(`[linker] Failed to load module ${specifier} from ${path}`);
+      console.log(e);
       // If we fail to load from a path, fall back to loading from a specifier
     }
   }

--- a/packages/runtime/src/modules/module-loader.ts
+++ b/packages/runtime/src/modules/module-loader.ts
@@ -4,10 +4,12 @@
 import vm, { Context } from './experimental-vm';
 import mainLinker, { Linker, LinkerOptions } from './linker';
 import type { Operation } from '../runtime';
+import { Logger } from '@openfn/logger';
 
 type Options = LinkerOptions & {
   context?: Context;
   linker?: Linker;
+  log?: Logger;
 };
 
 // aka ModuleDescriptor?

--- a/packages/runtime/src/modules/repo.ts
+++ b/packages/runtime/src/modules/repo.ts
@@ -207,7 +207,7 @@ export const getModulePath = async (
 
   if (alias) {
     const p = path.resolve(`${repoPath}`, `node_modules/${alias}`);
-    log.debug(`repo resolved ${specifier} path to ${path}`);
+    log.debug(`repo resolved ${specifier} path to ${p}`);
     return p;
   } else {
     log.debug(`module not found in repo: ${specifier}`);

--- a/packages/runtime/src/modules/repo.ts
+++ b/packages/runtime/src/modules/repo.ts
@@ -36,7 +36,7 @@ const filterSpecifiers = async (
       version = await getLatestVersion(s);
     }
 
-    const exists = await getModulePath(s, repoPath);
+    const exists = await getModulePath(s, repoPath, log);
     if (exists) {
       log.info(`Skipping ${name}@${version} as already installed`);
     } else {
@@ -184,7 +184,8 @@ export const getLatestInstalledVersion = async (
 
 export const getModulePath = async (
   specifier: string,
-  repoPath: string = defaultRepoPath
+  repoPath: string = defaultRepoPath,
+  log = defaultLogger // TODO should this be a null logger?
 ) => {
   const { version } = getNameAndVersion(specifier);
   let alias;
@@ -201,7 +202,11 @@ export const getModulePath = async (
   }
 
   if (alias) {
-    return path.resolve(`${repoPath}`, `node_modules/${alias}`);
+    const p = path.resolve(`${repoPath}`, `node_modules/${alias}`);
+    log.debug(`repo resolved ${specifier} path to ${path}`);
+    return p;
+  } else {
+    log.debug(`module not found in repo: ${specifier}`);
   }
   return null;
 };

--- a/packages/runtime/src/modules/repo.ts
+++ b/packages/runtime/src/modules/repo.ts
@@ -76,7 +76,11 @@ export const install = async (
     await execFn(`npm install ${flags.join(' ')} ${aliases.join(' ')}`, {
       cwd: repoPath,
     });
-    log.success(`Installed ${filtered.map(({ name }) => name).join(', ')}!`);
+    log.success(
+      `Installed ${filtered
+        .map(({ name, version }) => `${name}@${version}`)
+        .join(', ')}`
+    );
     return true;
   }
 };

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -47,7 +47,7 @@ export default async function run(
   opts: Options = {}
 ) {
   const logger = opts.logger || defaultLogger;
-
+  console.log(opts);
   logger.debug('Intialising pipeline');
   // Setup a shared execution context
   const context = buildContext(initialState, opts);
@@ -95,7 +95,6 @@ const wrapOperation = (
   immutableState?: boolean
 ) => {
   return async (state: State) => {
-    // TODO this output isn't very interesting yet!
     logger.debug(`Starting operation ${name}`);
     const start = new Date().getTime();
     const newState = immutableState ? clone(state) : state;

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -47,7 +47,6 @@ export default async function run(
   opts: Options = {}
 ) {
   const logger = opts.logger || defaultLogger;
-  console.log(opts);
   logger.debug('Intialising pipeline');
   // Setup a shared execution context
   const context = buildContext(initialState, opts);

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -142,7 +142,11 @@ const prepareJob = async (
   opts: Options = {}
 ): Promise<JobModule> => {
   if (typeof jobs === 'string') {
-    const exports = await loadModule(jobs, { ...opts.linker, context });
+    const exports = await loadModule(jobs, {
+      ...opts.linker,
+      context,
+      log: opts.logger,
+    });
     const operations = exports.default;
     return {
       operations,

--- a/packages/runtime/test/modules/linker.test.ts
+++ b/packages/runtime/test/modules/linker.test.ts
@@ -119,8 +119,10 @@ test("Fails to load a module it can't find", async (t) => {
 
 test('loads a module from a specific path', async (t) => {
   const options = {
-    modulePaths: {
-      'ultimate-answer': path.resolve('test/__modules__/ultimate-answer'),
+    modules: {
+      'ultimate-answer': {
+        path: path.resolve('test/__modules__/ultimate-answer'),
+      },
     },
   };
   const m = await linker('ultimate-answer', context, options);

--- a/packages/runtime/test/modules/linker.test.ts
+++ b/packages/runtime/test/modules/linker.test.ts
@@ -129,11 +129,28 @@ test('loads a module from a specific path', async (t) => {
   t.assert(m.namespace.default === 42);
 });
 
-test('loads a specific module version from the repo', async (t) => {
+// while this method technically works, it's not like to be ever used like this because the specifiers
+// come straight out of import statements, and so never have versions
+test('loads a specific module version from the repo (the wrong way)', async (t) => {
   const options = {
     repo: path.resolve('test/__repo'),
   };
   const m = await linker('ultimate-answer@1.0.0', context, options);
+  t.assert(m.namespace.default === 42);
+});
+
+// This is how we expect versioned modules to be loaded: someone (whether the CLI or a directive or whatever)
+// Will pass in version metata much as they would the path to the module
+test('loads a specific module version from the repo (the right way)', async (t) => {
+  const options = {
+    repo: path.resolve('test/__repo'),
+    modules: {
+      'ultimate-answer': {
+        version: '1.0.0',
+      },
+    },
+  };
+  const m = await linker('ultimate-answer', context, options);
   t.assert(m.namespace.default === 42);
 });
 

--- a/packages/workflow-diagram/test/layout.test.ts
+++ b/packages/workflow-diagram/test/layout.test.ts
@@ -5,7 +5,7 @@ import { toElkNode, toFlow, doLayout } from '../src/layout/index';
 import { FlowElkNode, FlowNodeEdges } from '../src/layout/types';
 import { getFixture } from './helpers';
 
-test('toElkNode should convert a project space to a workflow', async (t) => {
+test.skip('toElkNode should convert a project space to a workflow', async (t) => {
   const projectSpace = await getFixture<ProjectSpace>(
     'single-workflow-projectspace'
   );

--- a/packages/workflow-diagram/test/layout.test.ts
+++ b/packages/workflow-diagram/test/layout.test.ts
@@ -5,7 +5,7 @@ import { toElkNode, toFlow, doLayout } from '../src/layout/index';
 import { FlowElkNode, FlowNodeEdges } from '../src/layout/types';
 import { getFixture } from './helpers';
 
-test.skip('toElkNode should convert a project space to a workflow', async (t) => {
+test('toElkNode should convert a project space to a workflow', async (t) => {
   const projectSpace = await getFixture<ProjectSpace>(
     'single-workflow-projectspace'
   );


### PR DESCRIPTION
Sundry fixes here:

* `openfn repo list` won't throw if the repo is uninitialised
* Better handling of the default repo path
* Fixed docs for logger (removed reference to trace)
* Better debug logging in the linker and repo
* De-emphasise the "exports could not be found" warning as it doesn't matter and looks too scary
* Globals are fine and working as I expect (if a package isn't in the repo then a general `import()` will load the global).
I think tilde in path is fine - works for me (TM) in job path, adaptor path and state path. There are until tests for this in `cli/test/commands/test/ts` (see `run a trivial job from a folder: openfn ~/openfn/jobs/the-question`)
* When a specific adaptor version is passed in, the runtime now actually uses it

Close #67 and #70