### PR TITLE
Fix exports from common

### DIFF
--- a/.changeset/forty-boats-poke.md
+++ b/.changeset/forty-boats-poke.md
@@ -3,3 +3,4 @@
 ---
 
 Include language-common in package descriptions
+Only document exported functions with a description

--- a/.changeset/forty-boats-poke.md
+++ b/.changeset/forty-boats-poke.md
@@ -1,0 +1,5 @@
+---
+'@openfn/describe-package': patch
+---
+
+Include language-common in package descriptions

--- a/.changeset/mean-jobs-sniff.md
+++ b/.changeset/mean-jobs-sniff.md
@@ -1,0 +1,5 @@
+---
+'@openfn/adaptor-docs': patch
+---
+
+Clear docs content when the specifier changes

--- a/examples/adaptor-docs/src/App.tsx
+++ b/examples/adaptor-docs/src/App.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import AdaptorDocs from '@openfn/adaptor-docs';
+import '@openfn/adaptor-docs/index.css';
+
+const initialSpecifier = "@openfn/language-common@1.7.4";
+
+const inputStyle = { width: '400px', padding: '6px 4px', border: 'solid 1px slategrey' };
+
+export default () => {
+  const [specifier, setSpecifier] = useState(initialSpecifier);
+
+  const handleAdaptorChanged = (evt) => {
+    setSpecifier(evt.target.value)
+  }
+
+  return (
+    <div style={{ margin: '8px' }}>
+      <select
+        style={inputStyle}
+        onChange={handleAdaptorChanged}
+        >
+          <option>{initialSpecifier}</option>
+          <option>@openfn/language-primero@2.10.2</option>
+          </select>
+      <AdaptorDocs specifier={specifier} onInsert={console.log}/>
+    </div>
+  )
+}

--- a/examples/adaptor-docs/src/app.tsx
+++ b/examples/adaptor-docs/src/app.tsx
@@ -1,1 +1,0 @@
-import React from 'react';

--- a/examples/adaptor-docs/src/index.tsx
+++ b/examples/adaptor-docs/src/index.tsx
@@ -2,11 +2,11 @@ import './hot-reload';
 
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import AdaptorDocs from '@openfn/adaptor-docs';
-import '@openfn/adaptor-docs/index.css';
+
+import App from './App';
 
 const root = createRoot(document.getElementById("root"));
 
 root.render(
-  <AdaptorDocs specifier="@openfn/language-common@1.7.4" onInsert={console.log}/>
+  <App />
 );

--- a/packages/adaptor-docs/src/useDocs.tsx
+++ b/packages/adaptor-docs/src/useDocs.tsx
@@ -6,6 +6,7 @@ const useDocs = (specifier: string) => {
   const [docs, setDocs] = useState<PackageDescription | null | false>(null);
 
   useEffect(() => {
+    setDocs(null); // Reset docs when the specifier changes
     describePackage(specifier, {}).then((result) => {
       setDocs(result);
     });

--- a/packages/describe-package/package.json
+++ b/packages/describe-package/package.json
@@ -32,12 +32,13 @@
     "build:worker": "tsm esbuild-worker.ts",
     "build:index": "tsup --config tsup.config.js src/index.ts",
     "build": "pnpm clean && pnpm build:index && pnpm build:worker",
-    "build:watch": "pnpm build --watch",
+    "build:watch": "pnpm build:index --watch",
     "watch": "node esbuild.ts watch",
     "pack": "pnpm pack --pack-destination ../../dist"
   },
   "keywords": [],
   "devDependencies": {
+    "@openfn/language-common": "1.7.5",
     "@rollup/plugin-typescript": "^8.5.0",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",

--- a/packages/describe-package/src/api.ts
+++ b/packages/describe-package/src/api.ts
@@ -43,8 +43,6 @@ export type ParameterDescription = {
   type: string; // this is a human-readble string I think. Should we also store a machine readable type?
 };
 
-// I think we can get the API down to just these functions
-
 export const describePackage = async (
   specifier: string,
   _options: Options
@@ -52,14 +50,22 @@ export const describePackage = async (
   const { name, version } = getNameAndVersion(specifier);
   const project = new Project();
 
-  const files = await fetchDTSListing(specifier);
+  // Include language-common in the project model
+  // (I don't expect this to be permanent)
+  const common = await fetchDTSListing('@openfn/language-common');
+  for await (const fileName of common) {
+    const f = await fetchFile(`@openfn/language-common${fileName}`);
+    // Flatten the paths or else there's trouble
+    // TODO need to better understand this at some stage
+    const relativeFileName = fileName.split('/').pop();
+    project.addTypeDefinition('@openfn/language-common', f, relativeFileName);
+  }
 
+  const files = await fetchDTSListing(specifier);
   const functions: FunctionDescription[] = [];
   for await (const fileName of files) {
     const f = await fetchFile(`${specifier}${fileName}`);
     project.createFile(f, fileName);
-    // TODO no, this feels more like describeDTS doesn't it
-    // Or describe functions
     functions.push(...describeProject(project, fileName));
   }
 

--- a/packages/describe-package/src/api.ts
+++ b/packages/describe-package/src/api.ts
@@ -35,6 +35,7 @@ export type FunctionDescription = {
   parameters: ParameterDescription[];
   description: string;
   examples: string[];
+  parent?: string;
 };
 
 export type ParameterDescription = {

--- a/packages/describe-package/src/describe-project.ts
+++ b/packages/describe-package/src/describe-project.ts
@@ -22,8 +22,10 @@ const describeFunction = (
 ): FunctionDescription => {
   // If this is a non native symbol, say where it came from
   let parent = undefined;
-  if (symbol.symbol.parent.escapedName.match(/^\"\/node_modules\//)) {
-    [parent] = symbol.symbol.parent.escapedName.match(/(language-\w+)/);
+  // @ts-ignore symbol.parent
+  const parentSymbol = symbol.symbol.parent;
+  if (parentSymbol && parentSymbol.escapedName.match(/^\"\/node_modules\//)) {
+    [parent] = parentSymbol.escapedName.match(/(language-\w+)/);
   }
   return {
     name: moduleName ? `${moduleName}.${symbol.name}` : symbol.name,

--- a/packages/describe-package/src/describe-project.ts
+++ b/packages/describe-package/src/describe-project.ts
@@ -20,6 +20,11 @@ const describeFunction = (
   symbol: WrappedSymbol,
   moduleName?: string
 ): FunctionDescription => {
+  // If this is a non native symbol, say where it came from
+  let parent = undefined;
+  if (symbol.symbol.parent.escapedName.match(/^\"\/node_modules\//)) {
+    [parent] = symbol.symbol.parent.escapedName.match(/(language-\w+)/);
+  }
   return {
     name: moduleName ? `${moduleName}.${symbol.name}` : symbol.name,
     description: symbol.comment,
@@ -27,6 +32,7 @@ const describeFunction = (
     magic: false,
     isOperation: false,
     examples: symbol.examples,
+    parent,
   };
 };
 
@@ -42,7 +48,7 @@ const describeProject = (
   }
 
   return project.getSymbol(sourceFile).exports.reduce((symbols, symbol) => {
-    if (symbol.isFunctionDeclaration) {
+    if (symbol.isFunctionDeclaration && symbol.comment) {
       symbols.push(describeFunction(project, symbol));
     }
 

--- a/packages/describe-package/src/describe-project.ts
+++ b/packages/describe-package/src/describe-project.ts
@@ -2,6 +2,10 @@ import type { Project } from './typescript/project';
 import type { FunctionDescription, ParameterDescription } from './api';
 import { WrappedSymbol } from './typescript/wrapped-symbol';
 
+type DescribeOptions = {
+  allowEmptyDesc?: boolean; // defaults to false
+};
+
 const describeParameter = (
   project: Project,
   symbol: WrappedSymbol
@@ -41,7 +45,8 @@ const describeFunction = (
 // Describe the exported functions of a given d.ts file in a project
 const describeProject = (
   project: Project,
-  typesEntry: string = 'index.d.ts'
+  typesEntry: string = 'index.d.ts',
+  options: DescribeOptions = {}
 ) => {
   const sourceFile = project.getSourceFile(typesEntry);
 
@@ -50,7 +55,10 @@ const describeProject = (
   }
 
   return project.getSymbol(sourceFile).exports.reduce((symbols, symbol) => {
-    if (symbol.isFunctionDeclaration && symbol.comment) {
+    if (
+      (symbol.isFunctionDeclaration && options.allowEmptyDesc) ||
+      symbol.comment
+    ) {
       symbols.push(describeFunction(project, symbol));
     }
 

--- a/packages/describe-package/src/typescript/project.ts
+++ b/packages/describe-package/src/typescript/project.ts
@@ -69,11 +69,18 @@ export class Project {
    * i.e. the adaptors name `@openfn/language-http`.
    * @param dts the .d.ts file as a string
    */
-  addTypeDefinition(moduleName: string, dts: string) {
+  // addTypeDefinition(moduleName: string, dts: string) {
+  //   const typedModulePath = moduleName.replace('@', '').replace('/', '__');
+
+  //   this.fsMap.set(`/node_modules/@types/${typedModulePath}/index.d.ts`, dts);
+  //   this.env.createFile(`${typedModulePath}.d.ts`, dts);
+  // }
+
+  addTypeDefinition(moduleName: string, dts: string, fileName = 'index.d.ts') {
     const typedModulePath = moduleName.replace('@', '').replace('/', '__');
 
-    this.fsMap.set(`/node_modules/@types/${typedModulePath}/index.d.ts`, dts);
-    this.env.createFile(`${typedModulePath}.d.ts`, dts);
+    this.fsMap.set(`/node_modules/@types/${typedModulePath}/${fileName}`, dts);
+    this.env.createFile(`${typedModulePath}__${fileName}`, dts);
   }
 
   // addAdaptorFSMap(adaptorPackagePath: string) {

--- a/packages/describe-package/src/typescript/wrapped-symbol.ts
+++ b/packages/describe-package/src/typescript/wrapped-symbol.ts
@@ -59,7 +59,11 @@ export class WrappedSymbol {
   }
 
   public get parameters(): WrappedSymbol[] {
-    if (this.symbol.valueDeclaration) {
+    if (
+      this.symbol.valueDeclaration &&
+      // @ts-ignore
+      this.symbol.valueDeclaration.parameters
+    ) {
       // @ts-ignore
       return this.symbol.valueDeclaration.parameters.map(
         (param: any) => new WrappedSymbol(this.typeChecker, param.symbol)

--- a/packages/describe-package/src/typescript/wrapped-symbol.ts
+++ b/packages/describe-package/src/typescript/wrapped-symbol.ts
@@ -74,11 +74,15 @@ export class WrappedSymbol {
     const jsdoc = this.symbol.valueDeclaration?.jsDoc;
     if (jsdoc) {
       for (const d of jsdoc) {
-        examples.push(
-          ...d.tags
-            .filter((tag: ts.JSDocTag) => tag.tagName.escapedText === 'example')
-            .map((tag: ts.JSDocTag) => tag.comment)
-        );
+        if (d.tags) {
+          examples.push(
+            ...d.tags
+              .filter(
+                (tag: ts.JSDocTag) => tag.tagName.escapedText === 'example'
+              )
+              .map((tag: ts.JSDocTag) => tag.comment)
+          );
+        }
       }
     }
     return examples;

--- a/packages/describe-package/src/typescript/wrapped-symbol.ts
+++ b/packages/describe-package/src/typescript/wrapped-symbol.ts
@@ -73,23 +73,9 @@ export class WrappedSymbol {
   }
 
   public get examples(): string[] {
-    const examples = [];
-    // @ts-ignore
-    const jsdoc = this.symbol.valueDeclaration?.jsDoc;
-    if (jsdoc) {
-      for (const d of jsdoc) {
-        if (d.tags) {
-          examples.push(
-            ...d.tags
-              .filter(
-                (tag: ts.JSDocTag) => tag.tagName.escapedText === 'example'
-              )
-              .map((tag: ts.JSDocTag) => tag.comment)
-          );
-        }
-      }
-    }
-    return examples;
+    return this.jsDocTags
+      .filter((tag: ts.JSDocTag) => tag.tagName.escapedText === 'example')
+      .map((tag: ts.JSDocTag) => tag.comment) as string[];
   }
 
   public get type(): ts.TypeNode {
@@ -98,6 +84,34 @@ export class WrappedSymbol {
     return this.symbol.valueDeclaration?.type;
   }
 
+  // A function is private unless it has a public tag
+  public get isPublic(): boolean {
+    return this.jsDocTags.some(
+      (tag: ts.JSDocTag) => tag.tagName.escapedText === 'public'
+    );
+  }
+
+  public get isExportAlias(): boolean {
+    // @ts-ignore symbol.parent
+    const parentSymbol = this.symbol.parent;
+    return (
+      parentSymbol && parentSymbol.escapedName.match(/^\"\/node_modules\//)
+    );
+  }
+
+  public get jsDocTags(): ts.JSDocTag[] {
+    const tags: ts.JSDocTag[] = [];
+    // @ts-ignore
+    const jsdoc = this.symbol.valueDeclaration?.jsDoc;
+    if (jsdoc) {
+      for (const d of jsdoc) {
+        if (d.tags) {
+          tags.push(...d.tags);
+        }
+      }
+    }
+    return tags;
+  }
   // public get typeString(): NodeObject {
   //   const type = this.typeChecker.getDeclaredTypeOfSymbol(
   //     this.symbol.declarations[0]

--- a/packages/describe-package/test/describe-project.test.ts
+++ b/packages/describe-package/test/describe-project.test.ts
@@ -18,7 +18,7 @@ test('List all the exported functions', async (t) => {
   t.truthy(get('traditional'));
   t.truthy(get('oneFlavour'));
   t.truthy(get('manyFlavours'));
-  t.truthy(get('x'));
+  t.truthy(get('fn'));
 });
 
 test('No parameters in a 0-arity function', async (t) => {
@@ -37,9 +37,11 @@ test('1 parameters in a 1-arity function', async (t) => {
 test('Load the example', async (t) => {
   const fn = get('traditional');
   t.is(fn.examples[0], 'traditional()');
+  t.is(fn.parent, undefined);
 });
 
-test.only('Load common fn', async (t) => {
+test('Load common fn', async (t) => {
   const fn = get('fn');
   t.truthy(fn);
+  t.is(fn.parent, 'language-common');
 });

--- a/packages/describe-package/test/describe-project.test.ts
+++ b/packages/describe-package/test/describe-project.test.ts
@@ -1,24 +1,24 @@
 import test from 'ava';
 import { setupProject } from './helpers';
 
-// TODO haven't got the semantics right yet
-import describeFunctions from '../src/describe-project';
+import describeProject from '../src/describe-project';
 
 let fns;
 
 // Load the fixture once and then run a bunch of tests against it
 test.before(async () => {
   const project = await setupProject('stroopwafel');
-  fns = await describeFunctions(project);
+  fns = await describeProject(project);
 });
 
 const get = (name) => fns.find((fn) => fn.name === name);
 
 test('List all the exported functions', async (t) => {
-  t.is(fns.length, 3);
+  t.assert(fns.length === 4);
   t.truthy(get('traditional'));
   t.truthy(get('oneFlavour'));
   t.truthy(get('manyFlavours'));
+  t.truthy(get('x'));
 });
 
 test('No parameters in a 0-arity function', async (t) => {
@@ -37,4 +37,9 @@ test('1 parameters in a 1-arity function', async (t) => {
 test('Load the example', async (t) => {
   const fn = get('traditional');
   t.is(fn.examples[0], 'traditional()');
+});
+
+test.only('Load common fn', async (t) => {
+  const fn = get('fn');
+  t.truthy(fn);
 });

--- a/packages/describe-package/test/describe-project.test.ts
+++ b/packages/describe-package/test/describe-project.test.ts
@@ -21,6 +21,11 @@ test('List all the exported functions', async (t) => {
   t.truthy(get('fn'));
 });
 
+test('Does not include private functions', async (t) => {
+  const priv = get('somethingPrivate');
+  t.falsy(priv);
+});
+
 test('No parameters in a 0-arity function', async (t) => {
   const trad = get('traditional');
   t.is(trad.parameters.length, 0);

--- a/packages/describe-package/test/describe-types.test.ts
+++ b/packages/describe-package/test/describe-types.test.ts
@@ -1,15 +1,13 @@
 import test from 'ava';
 import { setupProject } from './helpers';
-
-// TODO haven't got the semantics right yet
-import describeFunctions from '../src/describe-project';
+import describeProject from '../src/describe-project';
 
 let fns;
 
 // Load the fixture once and then run a bunch of tests against it
 test.before(async () => {
   const project = await setupProject('types');
-  fns = await describeFunctions(project);
+  fns = await describeProject(project, undefined, { allowEmptyDesc: true });
 });
 
 const get = (name) => fns.find((fn) => fn.name === name);

--- a/packages/describe-package/test/describe-types.test.ts
+++ b/packages/describe-package/test/describe-types.test.ts
@@ -7,7 +7,7 @@ let fns;
 // Load the fixture once and then run a bunch of tests against it
 test.before(async () => {
   const project = await setupProject('types');
-  fns = await describeProject(project, undefined, { allowEmptyDesc: true });
+  fns = await describeProject(project, undefined, { includePrivate: true });
 });
 
 const get = (name) => fns.find((fn) => fn.name === name);

--- a/packages/describe-package/test/fixtures/stroopwafel.d.ts
+++ b/packages/describe-package/test/fixtures/stroopwafel.d.ts
@@ -1,5 +1,6 @@
 /**
  * Returns a traditional stroopwafel
+ * @public
  * @example
  * traditional()
  */
@@ -7,6 +8,7 @@ export declare function traditional(): string;
 
 /**
  * Returns a flavoured stroopwafel
+ * @public
  * @example
  * custom('falafel')
  */
@@ -14,10 +16,13 @@ export declare function oneFlavour(flavour: string): string;
 
 /**
  * Returns a many flavoured stroopwafel
+ * @public
  * @example
  * custom(['strawberry', 'cream'])
  */
 export declare function manyFlavours(flavours: string[]): string;
+
+export declare function somethingPrivate(): void;
 
 // Note that this is mocked by the helper project setup
 export { fn } from '@openfn/language-common';

--- a/packages/describe-package/test/fixtures/stroopwafel.d.ts
+++ b/packages/describe-package/test/fixtures/stroopwafel.d.ts
@@ -18,3 +18,6 @@ export declare function oneFlavour(flavour: string): string;
  * custom(['strawberry', 'cream'])
  */
 export declare function manyFlavours(flavours: string[]): string;
+
+// Note that this is mocked by the helper project setup
+export { fn } from '@openfn/language-common';

--- a/packages/describe-package/test/helpers.ts
+++ b/packages/describe-package/test/helpers.ts
@@ -8,6 +8,19 @@ export function getDtsFixture(adaptorName: string): Promise<string> {
 export async function setupProject(dtsName: string): Promise<Project> {
   const project = new Project();
 
+  // Set up a mock language-common
+  // This is sort of cheating but really helps me set up the pattern
+  project.addTypeDefinition(
+    '@openfn/language-common',
+    'export declare function fn(): void;',
+    'Adaptor.d.ts'
+  );
+  project.addTypeDefinition(
+    '@openfn/language-common',
+    `export * from './Adaptor`,
+    'index.d.ts'
+  );
+
   // Load the target dts file
   const dts = await getDtsFixture(dtsName);
 

--- a/packages/describe-package/test/helpers.ts
+++ b/packages/describe-package/test/helpers.ts
@@ -12,7 +12,9 @@ export async function setupProject(dtsName: string): Promise<Project> {
   // This is sort of cheating but really helps me set up the pattern
   project.addTypeDefinition(
     '@openfn/language-common',
-    'export declare function fn(): void;',
+    // The comment is important because otherwise it'll be ignored
+    `/** Common fn */
+     export declare function fn(): void;`,
     'Adaptor.d.ts'
   );
   project.addTypeDefinition(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,7 @@ importers:
 
   packages/describe-package:
     specifiers:
+      '@openfn/language-common': 1.7.5
       '@rollup/plugin-typescript': ^8.5.0
       '@types/chai': ^4.3.1
       '@types/mocha': ^9.1.1
@@ -257,6 +258,7 @@ importers:
       typescript: 4.8.3
       url-join: 5.0.0
     devDependencies:
+      '@openfn/language-common': 1.7.5
       '@rollup/plugin-typescript': 8.5.0_tznp6w7csbjledp5nresoxoky4
       '@types/chai': 4.3.1
       '@types/mocha': 9.1.1
@@ -747,9 +749,19 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
 
+  /@openfn/language-common/1.7.5:
+    resolution: {integrity: sha512-QivV3v5Oq5fb4QMopzyqUUh+UGHaFXBdsGr6RCmu6bFnGXdJdcQ7GpGpW5hKNq29CkmE23L/qAna1OLr4rP/0w==}
+    dependencies:
+      axios: 1.1.3
+      date-fns: 2.29.3
+      jsonpath-plus: 4.0.0
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - debug
+    dev: true
+
   /@openfn/language-common/2.0.0-rc3:
     resolution: {integrity: sha512-7kwhBnCd1idyTB3MD9dXmUqROAhoaUIkz2AGDKuv9vn/cbZh7egEv9/PzKkRcDJYFV9qyyS+cVT3Xbgsg2ii5g==}
-    bundledDependencies: []
 
   /@rollup/plugin-typescript/8.4.0_lgw3yndmlomwrra4tomb66mtni:
     resolution: {integrity: sha512-QssfoOP6V4/6skX12EfOW5UzJAv/c334F4OJWmQpe2kg3agEa0JwVCckwmfuvEgDixyX+XyxjFenH7M2rDKUyQ==}
@@ -1720,6 +1732,10 @@ packages:
     resolution: {integrity: sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==}
     dev: true
 
+  /asynckit/0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: true
+
   /atob/2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
     engines: {node: '>= 4.5.0'}
@@ -1859,6 +1875,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /axios/1.1.3:
+    resolution: {integrity: sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==}
+    dependencies:
+      follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: true
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2303,6 +2329,13 @@ packages:
     engines: {node: '>=0.1.90'}
     dev: true
 
+  /combined-stream/1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: true
+
   /commander/4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -2689,6 +2722,11 @@ packages:
       d3-transition: 3.0.1_d3-selection@3.0.0
     dev: false
 
+  /date-fns/2.29.3:
+    resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
+    engines: {node: '>=0.11'}
+    dev: true
+
   /date-time/3.1.0:
     resolution: {integrity: sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==}
     engines: {node: '>=6'}
@@ -2823,6 +2861,11 @@ packages:
       rimraf: 3.0.2
       slash: 4.0.0
     dev: false
+
+  /delayed-stream/1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+    dev: true
 
   /delegates/1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -4392,6 +4435,16 @@ packages:
       pkg-dir: 4.2.0
     dev: true
 
+  /follow-redirects/1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: true
+
   /for-in/0.1.8:
     resolution: {integrity: sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==}
     engines: {node: '>=0.10.0'}
@@ -4407,6 +4460,15 @@ packages:
     dependencies:
       for-in: 1.0.2
     dev: false
+
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: true
 
   /fraction.js/4.2.0:
     resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
@@ -5201,6 +5263,11 @@ packages:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.10
+    dev: true
+
+  /jsonpath-plus/4.0.0:
+    resolution: {integrity: sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==}
+    engines: {node: '>=10.0'}
     dev: true
 
   /keygrip/1.1.0:
@@ -7295,6 +7362,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /proxy-from-env/1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: true
 
   /proxy-middleware/0.15.0:
     resolution: {integrity: sha512-EGCG8SeoIRVMhsqHQUdDigB2i7qU7fCsWASwn54+nPutYO8n4q6EiwMzyfWlC+dzRFExP+kvcnDFdBDHoZBU7Q==}


### PR DESCRIPTION
This PR ensures that adaptor documentation includes functions exported from language-common.

Basically `describe-package` was failing to describe anything at all for functions exported from another package - ie, the way language-primero exports most of  language-common. This is because the local typescript context only has definitions for the top package (primero) and not its dependencies (common).

This is a quick fix which always loads common alongside whichever adaptor is being described, which should fix most if not all exports for the forseeable future.

Ultimately, the fix for this is to dynamically import whatever is needed. But that has to be a server-side operation, not something that will run in the client. So I'm putting it off for another day.

Note that there is still some chaos in `describe-package` itself as  I organise things around. It'll be improving in smaller PRs throughout the week.


## Change summary

* describe-package now loads common as well as the target DTS file
* Added a drop-down in examples/adaptor docs allowing two different packages to be explored (including Primero, which is complete thanks to this fix but will be broken in older versions of describe-package)
* A bit more unit test coverage (but still not very good I'm afraid)
* `adaptor-docs/useDocs` will set its cached documentation to null whenever the specifier prop changes (so that it'll correctly show load state)
* Only export/describe public functions

## Related issue

Fixes #86

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
