### PR TITLE
Collapsible docs

### DIFF
--- a/.changeset/eight-seahorses-prove.md
+++ b/.changeset/eight-seahorses-prove.md
@@ -1,0 +1,5 @@
+---
+'@openfn/adaptor-docs': patch
+---
+
+Nested docs items in expandable sections

--- a/packages/adaptor-docs/src/DocsPanel.tsx
+++ b/packages/adaptor-docs/src/DocsPanel.tsx
@@ -25,9 +25,8 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
   return (
     <div className="block m-2">
       <h1 className="h1 text-lg font-bold text-secondary-700 mb-2">{name} v{version}</h1>
-      <div className="text-sm mb-4">Operations available for use by this adaptor are listed below.</div>
+      <div className="text-sm mb-4">API reference:</div>
       {functions
-        // TODO we ought to memo the sort really, although this won't render very often so it's probably ok
         .sort((a, b) => {
           if (a.name > b.name) return 1;
           else if (a.name < b.name) return -1;

--- a/packages/adaptor-docs/src/index.css
+++ b/packages/adaptor-docs/src/index.css
@@ -5,3 +5,8 @@
 .pad-right {
   margin-right: 80px;
 }
+/* 
+.marker::marker {
+  font-size: 12px;
+  color: 
+} */

--- a/packages/adaptor-docs/src/index.css
+++ b/packages/adaptor-docs/src/index.css
@@ -1,12 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-.pad-right {
-  margin-right: 80px;
-}
-/* 
-.marker::marker {
-  font-size: 12px;
-  color: 
-} */

--- a/packages/adaptor-docs/src/render/Function.tsx
+++ b/packages/adaptor-docs/src/render/Function.tsx
@@ -41,7 +41,9 @@ const PreButton = ({ label, onClick, tooltip }: PreButtonFunctionProps) =>
 const RenderFunction = ({ fn, onInsert }: RenderFunctionProps) => {
   return (
     <details>
-      <summary className="text-m text-secondary-700 mb-1 cursor-pointer">{getSignature(fn)}</summary>
+      <summary className="text-m text-secondary-700 mb-1 cursor-pointer marker:text-slate-600 marker:text-sm">
+        <span style={{ position: 'relative', top: '1px' }}>{getSignature(fn)}</span>
+      </summary>
       <div className="block mb-4 pl-4">
         <p className="block text-sm">{fn.description}</p>
         {fn.examples.length > 0 && <label className="block text-sm">Example:</label>}

--- a/packages/adaptor-docs/src/render/Function.tsx
+++ b/packages/adaptor-docs/src/render/Function.tsx
@@ -40,23 +40,25 @@ const PreButton = ({ label, onClick, tooltip }: PreButtonFunctionProps) =>
 
 const RenderFunction = ({ fn, onInsert }: RenderFunctionProps) => {
   return (
-    <div className="block mb-10">
-      <label className="block text-m font-bold text-secondary-700 mb-1">{getSignature(fn)}</label>
-      <p className="block text-sm">{fn.description}</p>
-      {fn.examples.length > 0 && <label className="block text-sm">Example:</label>}
-      {fn.examples.map((eg, idx) =>
-        <div key={`${fn.name}-eg-${idx}`} style={{ marginTop: '-6px'}}>
-          <div className="w-full px-5 text-right" style={{ height: '13px'}}>
-            <PreButton label="COPY" onClick={() => doCopy(eg)} tooltip="Copy this example to the clipboard"/>
-            {onInsert && <PreButton label="ADD" onClick={() => onInsert(eg)} tooltip="Add this snippet to the end of the code"/>}
+    <details>
+      <summary className="text-m text-secondary-700 mb-1 cursor-pointer">{getSignature(fn)}</summary>
+      <div className="block mb-4 pl-4">
+        <p className="block text-sm">{fn.description}</p>
+        {fn.examples.length > 0 && <label className="block text-sm">Example:</label>}
+        {fn.examples.map((eg, idx) =>
+          <div key={`${fn.name}-eg-${idx}`} style={{ marginTop: '-6px'}}>
+            <div className="w-full px-5 text-right" style={{ height: '13px'}}>
+              <PreButton label="COPY" onClick={() => doCopy(eg)} tooltip="Copy this example to the clipboard"/>
+              {onInsert && <PreButton label="ADD" onClick={() => onInsert(eg)} tooltip="Add this snippet to the end of the code"/>}
+            </div>
+            <pre
+              className="rounded-md pl-4 pr-30 py-2 mx-4 my-0 font-mono bg-slate-100 border-2 border-slate-200 text-slate-800 min-h-full text-xs overflow-x-auto"
+              >
+                {eg}
+            </pre>
           </div>
-          <pre
-            className="rounded-md pl-4 pr-30 py-2 mx-4 my-0 font-mono bg-slate-100 border-2 border-slate-200 text-slate-800 min-h-full text-xs overflow-x-auto"
-            >
-              {eg}
-          </pre>
+        )}
         </div>
-      )}
     </div>
   )
 }

--- a/packages/adaptor-docs/src/render/Function.tsx
+++ b/packages/adaptor-docs/src/render/Function.tsx
@@ -42,7 +42,7 @@ const RenderFunction = ({ fn, onInsert }: RenderFunctionProps) => {
   return (
     <details>
       <summary className="text-m text-secondary-700 mb-1 cursor-pointer marker:text-slate-600 marker:text-sm">
-        <span style={{ position: 'relative', top: '1px' }}>{getSignature(fn)}</span>
+        <span className="relative top-px">{getSignature(fn)}</span>
       </summary>
       <div className="block mb-4 pl-4">
         <p className="block text-sm">{fn.description}</p>


### PR DESCRIPTION
Simple PR to nest each line of documentation in a little collapser:

![image](https://user-images.githubusercontent.com/7052509/203370875-e5312c5f-991a-4571-b9b4-8584c02a8680.png)

Very simple implementation using HTML `<details>` (thanks @taylordowns2000!). One day we can add something a bit flashier but for now this is a huge improvement.

## Related issue

Closes #82

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
