### PR TITLE
describe-package: Don't describe beta

### DIFF
--- a/examples/adaptor-docs/tsup.config.js
+++ b/examples/adaptor-docs/tsup.config.js
@@ -1,48 +1,54 @@
 import { defineConfig } from 'tsup';
 import Koa from 'koa';
 import serve from 'koa-static';
-import websockify from 'koa-websocket'
+import websockify from 'koa-websocket';
 
 import copyStaticFiles from 'esbuild-copy-static-files';
 
 let app;
-let listeners = []
+let listeners = [];
 
 const onSuccess = () => {
   if (!app) {
     app = new websockify(new Koa());
-    app.use(serve('./dist'))
-    console.log('Server running at localhost:1234')
-    app.listen(1234)
-    
+    app.use(serve('./dist'));
+    console.log('Server running at localhost:1234');
+    app.listen(1234);
+
     app.ws.use((ctx) => {
-      listeners.push(ctx)
+      listeners.push(ctx);
     });
   } else {
-    console.log('triggering refresh')
+    console.log('triggering refresh');
     while (listeners.length) {
-      listeners.pop().websocket.send('refresh')
+      listeners.pop().websocket.send('refresh');
     }
   }
-}
+};
 
 export default defineConfig({
   entry: {
-    'app': 'src/index.tsx'
+    app: 'src/index.tsx',
   },
   format: 'esm',
   platform: 'browser',
   clean: true,
   bundle: true,
-  watch: ['.', '../../packages/adaptor-docs/dist'],
-  noExternal: ["@openfn/adaptor-docs", "react"],
-  esbuildPlugins: [copyStaticFiles({
-    src: './static/',
-    dest: './dist/'
-  })],
+  watch: [
+    '.',
+    '../../packages/adaptor-docs/dist',
+    '../../packages/describe-package/dist',
+  ],
+  noExternal: ['@openfn/adaptor-docs', 'react'],
+  esbuildPlugins: [
+    copyStaticFiles({
+      src: './static/',
+      dest: './dist/',
+    }),
+  ],
   esbuildOptions: (opts) => {
     opts.inject = ['src/shims.js'];
     return opts;
   },
-  onSuccess
-})
+  onSuccess,
+});

--- a/packages/describe-package/src/api.ts
+++ b/packages/describe-package/src/api.ts
@@ -44,6 +44,12 @@ export type ParameterDescription = {
   type: string; // this is a human-readble string I think. Should we also store a machine readable type?
 };
 
+/*
+ * describePackage will describe all the publicly exported functions of an adaptor
+ * This is expected to be the main (only?) enytrypoint for this package
+ * - Each function MUST have an @public jsdoc tag
+ * - The beta file is excluded
+ */
 export const describePackage = async (
   specifier: string,
   _options: Options
@@ -65,9 +71,12 @@ export const describePackage = async (
   const files = await fetchDTSListing(specifier);
   const functions: FunctionDescription[] = [];
   for await (const fileName of files) {
-    const f = await fetchFile(`${specifier}${fileName}`);
-    project.createFile(f, fileName);
-    functions.push(...describeProject(project, fileName));
+    // Exclude the beta file
+    if (!/beta\.d\.ts$/.test(fileName)) {
+      const f = await fetchFile(`${specifier}${fileName}`);
+      project.createFile(f, fileName);
+      functions.push(...describeProject(project, fileName));
+    }
   }
 
   return {


### PR DESCRIPTION
A simple fix to exclude beta from the documentation exported by `desrcribe-package`.

This is the dumb solution which is fine for now.

What we should REALLY be doing is parsing the index and tracing the actual exports. This would let us properly trace export aliases and present a more accurate picture of what the adaptor exports (not just what code happens to be lying around in the folder).

I've updated the internal documentation to represent what describe package now does:
* Only describe functions marked as @public in the jsdoc
* Ignore the beta.d.ts file

This closes #80

You can test it works by starting up `examples/adaptor-docs` and looking at the dev console. No more duplicate key errors.