### PR TITLE
Fix autoinstall with paths

### DIFF
--- a/packages/cli/src/execute/handler.ts
+++ b/packages/cli/src/execute/handler.ts
@@ -4,16 +4,25 @@ import loadState from './load-state';
 import execute from './execute';
 import compile from '../compile/compile';
 import { install } from '../repo/handler';
-import { SafeOpts } from '../commands';
+import { Opts, SafeOpts } from '../commands';
+
+export const getAutoinstallTargets = (
+  options: Pick<Opts, 'adaptors' | 'autoinstall'>
+) => {
+  if (options.autoinstall && options.adaptors) {
+    return options.adaptors?.filter((a) => !/=/.test(a));
+  }
+  return [];
+};
 
 const executeHandler = async (options: SafeOpts, logger: Logger) => {
   const start = new Date().getTime();
 
-  // auto install the language adaptor
-  if (options.autoinstall) {
+  const autoInstallTargets = getAutoinstallTargets(options);
+  if (autoInstallTargets.length) {
     const { repoDir } = options;
     logger.info('Auto-installing language adaptors');
-    await install({ packages: options.adaptors, repoDir }, logger);
+    await install({ packages: autoInstallTargets, repoDir }, logger);
   }
 
   const state = await loadState(options, logger);

--- a/packages/cli/src/repo/handler.ts
+++ b/packages/cli/src/repo/handler.ts
@@ -12,18 +12,18 @@ export const install = async (
   opts: InstallOpts,
   log: Logger = defaultLogger
 ) => {
-  log.timer('install');
   let { packages, adaptor, repoDir } = opts;
-  log.success('Installing packages...'); // not really success but I want it to default
   if (packages) {
+    log.timer('install');
+    log.success('Installing packages...'); // not really success but I want it to default
     log.debug('repoDir is set to:', repoDir);
     if (adaptor) {
       packages = expandAdaptors(packages, log);
     }
     await rtInstall(packages, repoDir, log);
+    const duration = log.timer('install');
+    log.success(`Installation complete in ${duration}`);
   }
-  const duration = log.timer('install');
-  log.success(`Installation complete in ${duration}`);
 };
 
 export const clean = async (options: SafeOpts, logger: Logger) => {

--- a/packages/cli/test/execute/autoinstall-targets.test.ts
+++ b/packages/cli/test/execute/autoinstall-targets.test.ts
@@ -1,0 +1,88 @@
+import test from 'ava';
+
+import { getAutoinstallTargets } from '../../src/execute/handler';
+
+test('return empty if autoinstall is false', (t) => {
+  const result = getAutoinstallTargets({
+    autoinstall: false,
+    adaptors: ['a', 'b'],
+  });
+  t.truthy(result);
+  t.is(result.length, 0);
+});
+
+test('return empty if an empty array is passed', (t) => {
+  const result = getAutoinstallTargets({
+    autoinstall: true,
+    adaptors: [],
+  });
+  t.truthy(result);
+  t.is(result.length, 0);
+});
+
+test('return 2 valid targets', (t) => {
+  const result = getAutoinstallTargets({
+    autoinstall: true,
+    adaptors: ['a', 'b'],
+  });
+  t.truthy(result);
+  t.is(result.length, 2);
+  t.deepEqual(result, ['a', 'b']);
+});
+
+test('return empty if a path is passed', (t) => {
+  const result = getAutoinstallTargets({
+    autoinstall: true,
+    adaptors: ['a=a/b/c'],
+  });
+  t.truthy(result);
+  t.is(result.length, 0);
+});
+
+test('return 1 valid target', (t) => {
+  const result = getAutoinstallTargets({
+    autoinstall: true,
+    adaptors: ['a=/some/path', 'b@1.2.3'],
+  });
+  t.truthy(result);
+  t.is(result.length, 1);
+  t.deepEqual(result, ['b@1.2.3']);
+});
+
+test('return language common', (t) => {
+  const result = getAutoinstallTargets({
+    autoinstall: true,
+    adaptors: ['@openfn/language-common'],
+  });
+  t.truthy(result);
+  t.is(result.length, 1);
+  t.deepEqual(result, ['@openfn/language-common']);
+});
+
+test('return language common with specifier', (t) => {
+  const result = getAutoinstallTargets({
+    autoinstall: true,
+    adaptors: ['@openfn/language-common@1.0.0'],
+  });
+  t.truthy(result);
+  t.is(result.length, 1);
+  t.deepEqual(result, ['@openfn/language-common@1.0.0']);
+});
+
+test('reject language common with path', (t) => {
+  const result = getAutoinstallTargets({
+    autoinstall: true,
+    adaptors: ['@openfn/language-common=/a/b/c'],
+  });
+  t.truthy(result);
+  t.is(result.length, 0);
+});
+
+test('reject language common with specifier and path', (t) => {
+  const result = getAutoinstallTargets({
+    autoinstall: true,
+    adaptors: ['@openfn/language-common@1.0.0=/tmp/repo/common'],
+  });
+  t.truthy(result);
+  t.is(result.length, 0);
+});


### PR DESCRIPTION
If you do:

`openfn ia -a common=path/to/common`

You'll get an exception because the CLI runs `npm install common=path/to/common`. This is silly. Ok, so it doesn't make sense to ask for an autoinstall if you're going to tell the CLI where to find a module, but nothing should explode.

This PR simply ignores any adaptor arguments with a path.

Fixes #77.

I spent some time this afternoon trying to set up some mocks with `testdouble`  so that I could mockout the install function and test the command a bit better. But I couldn't get it to work :( I'll spend more time on this later but for now it's too much sffort.