### PR TITLE
Tighten up output and support circular structures

### DIFF
--- a/.changeset/famous-chicken-marry.md
+++ b/.changeset/famous-chicken-marry.md
@@ -1,0 +1,7 @@
+---
+'@openfn/cli': patch
+---
+
+Support circular structures in JSON output
+Introduce strict output (by default) which only serializes data
+Never serialize configuration to output

--- a/.changeset/rude-shrimps-beg.md
+++ b/.changeset/rude-shrimps-beg.md
@@ -1,0 +1,5 @@
+---
+'@openfn/logger': patch
+---
+
+Allow null and undefined to be logged

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
     "@openfn/compiler": "workspace:^0.0.16",
     "@openfn/logger": "workspace:^0.0.6",
     "@openfn/runtime": "workspace:^0.0.11",
+    "fast-safe-stringify": "^2.1.1",
     "rimraf": "^3.0.2",
     "treeify": "^1.1.0",
     "yargs": "^17.5.1"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,9 +5,10 @@ import { repo as repoCommand, install as installCommand } from './repo/command';
 import executeCommand from './execute/command';
 import compileCommand from './compile/command';
 import testCommand from './test/command';
+import { Opts } from './commands';
 
 export const cmd = yargs(hideBin(process.argv))
-  .command(executeCommand as yargs.CommandModule<{}>)
+  .command(executeCommand)
   .command(compileCommand)
   .command(installCommand) // allow install to run from the top as well as repo
   .command(repoCommand)
@@ -19,4 +20,4 @@ export const cmd = yargs(hideBin(process.argv))
     array: true,
   })
   .alias('v', 'version')
-  .help();
+  .help() as yargs.Argv<Opts>;

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -24,6 +24,7 @@ export type Opts = {
   packages?: string[];
   statePath?: string;
   stateStdin?: string;
+  noStrictOutput?: boolean; // defaults to false
 };
 
 export type SafeOpts = Required<Omit<Opts, 'log'>> & {

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -12,19 +12,19 @@ export type Opts = {
   adaptor?: boolean;
   adaptors?: string[];
   autoinstall?: boolean;
-  immutable?: boolean;
-  jobPath?: string;
   expand: boolean; // for unit tests really
   force?: boolean;
+  immutable?: boolean;
+  jobPath?: string;
   log?: string[];
-  repoDir?: string;
   noCompile?: boolean;
+  strictOutput?: boolean; // defaults to true
   outputPath?: string;
   outputStdout?: boolean;
   packages?: string[];
+  repoDir?: string;
   statePath?: string;
   stateStdin?: string;
-  noStrictOutput?: boolean; // defaults to false
 };
 
 export type SafeOpts = Required<Omit<Opts, 'log'>> & {

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -12,7 +12,7 @@ export type Opts = {
   adaptor?: boolean;
   adaptors?: string[];
   autoinstall?: boolean;
-  expand: boolean; // for unit tests really
+  expand?: boolean; // for unit tests really
   force?: boolean;
   immutable?: boolean;
   jobPath?: string;

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -65,7 +65,7 @@ export const applyExecuteOptions = (yargs: yargs.Argv) =>
     .option('output-stdout', {
       alias: 'O',
       boolean: true,
-      description: 'Print output to stdout (intead of a file)',
+      description: 'Print output to stdout (instead of a file)',
     })
     .option('adaptors', {
       alias: ['a', 'adaptor'],

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -49,7 +49,7 @@ const executeCommand = {
         'Install the latest version of language-common to the repo'
       );
   },
-};
+} as yargs.CommandModule<Opts>;
 
 export const applyExecuteOptions = (yargs: yargs.Argv) =>
   yargs

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -31,6 +31,11 @@ const executeCommand = {
         boolean: true,
         description: 'Skip compilation',
       })
+      .option('no-strict-output', {
+        boolean: true,
+        description:
+          'Allow properties other than data to be returned in the output.',
+      })
       .example(
         'openfn foo/job.js',
         'Reads foo/job.js, looks for state and output in foo'

--- a/packages/cli/src/execute/handler.ts
+++ b/packages/cli/src/execute/handler.ts
@@ -20,13 +20,13 @@ const executeHandler = async (options: SafeOpts, logger: Logger) => {
   const code = await compile(options, logger);
   const result = await execute(code, state, options);
 
-  await handleOutput(options, result, logger);
+  await serializeOutput(options, result, logger);
 
   const duration = printDuration(new Date().getTime() - start);
   logger.success(`Done in ${duration}! ✨`);
 };
 
-export const handleOutput = async (
+export const serializeOutput = async (
   options: Pick<Opts, 'strictOutput' | 'outputStdout' | 'outputPath'>,
   result: any,
   logger: Logger
@@ -44,8 +44,12 @@ export const handleOutput = async (
       };
     }
   }
-  // Now stringify
-  output = JSON.stringify(output, null, 2);
+
+  if (output === undefined) {
+    output = '';
+  } else {
+    output = JSON.stringify(output, null, 2);
+  }
 
   if (options.outputStdout) {
     logger.success(`Result: `);

--- a/packages/cli/src/execute/handler.ts
+++ b/packages/cli/src/execute/handler.ts
@@ -1,10 +1,10 @@
-import { writeFile } from 'node:fs/promises';
 import { Logger, printDuration } from '../util/logger';
 import loadState from './load-state';
 import execute from './execute';
 import compile from '../compile/compile';
+import serializeOutput from './serialize-output';
 import { install } from '../repo/handler';
-import { Opts, SafeOpts } from '../commands';
+import { SafeOpts } from '../commands';
 
 const executeHandler = async (options: SafeOpts, logger: Logger) => {
   const start = new Date().getTime();
@@ -24,42 +24,6 @@ const executeHandler = async (options: SafeOpts, logger: Logger) => {
 
   const duration = printDuration(new Date().getTime() - start);
   logger.success(`Done in ${duration}! ✨`);
-};
-
-export const serializeOutput = async (
-  options: Pick<Opts, 'strictOutput' | 'outputStdout' | 'outputPath'>,
-  result: any,
-  logger: Logger
-) => {
-  let output = result;
-  if (output && (output.configuration || output.data)) {
-    // handle an object. Probably need a better test.
-    const { data, configuration, ...rest } = result;
-    if (options.strictOutput !== false) {
-      output = { data };
-    } else {
-      output = {
-        data,
-        ...rest,
-      };
-    }
-  }
-
-  if (output === undefined) {
-    output = '';
-  } else {
-    output = JSON.stringify(output, null, 2);
-  }
-
-  if (options.outputStdout) {
-    logger.success(`Result: `);
-    logger.success(output);
-  } else if (options.outputPath) {
-    logger.success(`Writing output to ${options.outputPath}`);
-    await writeFile(options.outputPath, output);
-  }
-
-  return output;
 };
 
 export default executeHandler;

--- a/packages/cli/src/execute/handler.ts
+++ b/packages/cli/src/execute/handler.ts
@@ -20,14 +20,14 @@ const executeHandler = async (options: SafeOpts, logger: Logger) => {
   const code = await compile(options, logger);
   const result = await execute(code, state, options);
 
-  await handleOutput(options, logger, result);
+  await handleOutput(options, result, logger);
 
   const duration = printDuration(new Date().getTime() - start);
   logger.success(`Done in ${duration}! ✨`);
 };
 
 export const handleOutput = async (
-  options: Pick<Opts, 'noStrictOutput' | 'outputStdout' | 'outputPath'>,
+  options: Pick<Opts, 'strictOutput' | 'outputStdout' | 'outputPath'>,
   result: any,
   logger: Logger
 ) => {
@@ -35,19 +35,17 @@ export const handleOutput = async (
   if (output && (output.configuration || output.data)) {
     // handle an object. Probably need a better test.
     const { data, configuration, ...rest } = result;
-    if (options.noStrictOutput) {
-      // if not in strict mode, we can write everything to the output
-      // except config?
+    if (options.strictOutput !== false) {
+      output = { data };
+    } else {
       output = {
         data,
         ...rest,
       };
-    } else {
-      output = { data };
     }
-    // Now stringify
-    output = JSON.stringify(output, null, 2);
   }
+  // Now stringify
+  output = JSON.stringify(output, null, 2);
 
   if (options.outputStdout) {
     logger.success(`Result: `);

--- a/packages/cli/src/execute/serialize-output.ts
+++ b/packages/cli/src/execute/serialize-output.ts
@@ -1,0 +1,41 @@
+import { writeFile } from 'node:fs/promises';
+import { Logger } from '../util/logger';
+import { Opts } from '../commands';
+
+const serializeOutput = async (
+  options: Pick<Opts, 'strictOutput' | 'outputStdout' | 'outputPath'>,
+  result: any,
+  logger: Logger
+) => {
+  let output = result;
+  if (output && (output.configuration || output.data)) {
+    // handle an object. Probably need a better test.
+    const { data, configuration, ...rest } = result;
+    if (options.strictOutput !== false) {
+      output = { data };
+    } else {
+      output = {
+        data,
+        ...rest,
+      };
+    }
+  }
+
+  if (output === undefined) {
+    output = '';
+  } else {
+    output = JSON.stringify(output, null, 2);
+  }
+
+  if (options.outputStdout) {
+    logger.success(`Result: `);
+    logger.success(output);
+  } else if (options.outputPath) {
+    logger.success(`Writing output to ${options.outputPath}`);
+    await writeFile(options.outputPath, output);
+  }
+
+  return output;
+};
+
+export default serializeOutput;

--- a/packages/cli/src/execute/serialize-output.ts
+++ b/packages/cli/src/execute/serialize-output.ts
@@ -24,7 +24,7 @@ const serializeOutput = async (
   if (output === undefined) {
     output = '';
   } else {
-    output = stringify(output, null, 2);
+    output = stringify(output, undefined, 2);
   }
 
   if (options.outputStdout) {

--- a/packages/cli/src/execute/serialize-output.ts
+++ b/packages/cli/src/execute/serialize-output.ts
@@ -1,7 +1,7 @@
 import { writeFile } from 'node:fs/promises';
+import stringify from 'fast-safe-stringify';
 import { Logger } from '../util/logger';
 import { Opts } from '../commands';
-
 const serializeOutput = async (
   options: Pick<Opts, 'strictOutput' | 'outputStdout' | 'outputPath'>,
   result: any,
@@ -24,7 +24,7 @@ const serializeOutput = async (
   if (output === undefined) {
     output = '';
   } else {
-    output = JSON.stringify(output, null, 2);
+    output = stringify(output, null, 2);
   }
 
   if (options.outputStdout) {

--- a/packages/cli/src/repo/handler.ts
+++ b/packages/cli/src/repo/handler.ts
@@ -1,4 +1,5 @@
 import { exec } from 'node:child_process';
+// @ts-ignore
 import treeify from 'treeify';
 import { install as rtInstall, loadRepoPkg } from '@openfn/runtime';
 import type { Opts, SafeOpts } from '../commands';

--- a/packages/cli/src/util/ensure-opts.ts
+++ b/packages/cli/src/util/ensure-opts.ts
@@ -82,10 +82,9 @@ export default function ensureOpts(
     outputStdout: Boolean(opts.outputStdout),
     packages: opts.packages,
     stateStdin: opts.stateStdin,
-    noStrictOutput: opts.noStrictOutput || false,
+    strictOutput: opts.strictOutput ?? true,
     immutable: opts.immutable || false,
   } as SafeOpts;
-
   const set = (key: keyof Opts, value: string) => {
     // @ts-ignore TODO
     newOpts[key] = opts.hasOwnProperty(key) ? opts[key] : value;

--- a/packages/cli/src/util/ensure-opts.ts
+++ b/packages/cli/src/util/ensure-opts.ts
@@ -82,6 +82,7 @@ export default function ensureOpts(
     outputStdout: Boolean(opts.outputStdout),
     packages: opts.packages,
     stateStdin: opts.stateStdin,
+    noStrictOutput: opts.noStrictOutput || false,
     immutable: opts.immutable || false,
   } as SafeOpts;
 

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -412,7 +412,8 @@ test.serial('list should return something', async (t) => {
   const [pwd, installed] = logger._history;
   t.is(logger._parse(pwd).message, 'Repo working directory is: a/b/c');
 
-  t.assert(logger._parse(installed).message.startsWith('Installed packages:'));
+  const message = logger._parse(installed).message as string;
+  t.assert(message.startsWith('Installed packages:'));
 });
 
 // This used to throw, see #70
@@ -423,7 +424,6 @@ test.serial('list does not throw if repo is not initialised', async (t) => {
 
   const opts = cmd.parse('repo list') as Opts;
   opts.repoDir = '/repo/';
-  opts.logger = logger;
 
   await commandParser('', opts, logger);
 

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -19,6 +19,8 @@ const JOB_EXPORT_42 = 'export default [() => 42];';
 const JOB_TIMES_2 = 'export default [(state) => state * 2];';
 const JOB_MOCK_ADAPTOR =
   'import { byTwo } from "times-two"; export default [byTwo];';
+const JOB_EXPORT_STATE =
+  "export default [() => ({ configuration: {}, data: {}, foo: 'bar' })];";
 
 type RunOptions = {
   jobPath?: string;
@@ -174,6 +176,50 @@ test.serial(
 
     const output = await fs.readFile('/tmp/my-output.json', 'utf8');
     t.assert(output === '42');
+  }
+);
+
+test.serial(
+  'output to file with strict state: openfn job.js --output-path=/tmp/my-output.json',
+  async (t) => {
+    const options = {
+      outputPath: '/tmp/my-output.json',
+    };
+
+    const result = await run(
+      'openfn job.js --output-path=/tmp/my-output.json',
+      JOB_EXPORT_STATE,
+      options
+    );
+    t.deepEqual(result, { data: {} });
+
+    const expectedFileContents = JSON.stringify({ data: {} }, null, 2);
+    const output = await fs.readFile('/tmp/my-output.json', 'utf8');
+    t.is(output, expectedFileContents);
+  }
+);
+
+test.serial(
+  'output to file with non-strict state: openfn job.js --output-path=/tmp/my-output.json',
+  async (t) => {
+    const options = {
+      outputPath: '/tmp/my-output.json',
+    };
+
+    const result = await run(
+      'openfn job.js --output-path=/tmp/my-output.json --no-strict-output',
+      JOB_EXPORT_STATE,
+      options
+    );
+    t.deepEqual(result, { data: {}, foo: 'bar' });
+
+    const expectedFileContents = JSON.stringify(
+      { data: {}, foo: 'bar' },
+      null,
+      2
+    );
+    const output = await fs.readFile('/tmp/my-output.json', 'utf8');
+    t.assert(output === expectedFileContents);
   }
 );
 

--- a/packages/cli/test/compile/compile.test.ts
+++ b/packages/cli/test/compile/compile.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import mock from 'mock-fs';
 import path from 'node:path';
-import createLogger, { createMockLogger } from '@openfn/logger';
+import { createMockLogger } from '@openfn/logger';
 import {
   stripVersionSpecifier,
   loadTransformOptions,

--- a/packages/cli/test/execute/handle-output.test.ts
+++ b/packages/cli/test/execute/handle-output.test.ts
@@ -1,0 +1,223 @@
+import test from 'ava';
+import mockfs from 'mock-fs';
+import { readFile } from 'node:fs/promises';
+
+import { handleOutput } from '../../src/execute/handler';
+import { createMockLogger } from '@openfn/logger';
+
+const logger = createMockLogger(undefined, { level: 'debug' });
+
+test.beforeEach(() => {
+  logger._reset();
+});
+
+const toString = (obj: object) => JSON.stringify(obj, null, 2);
+
+test('output true', async (t) => {
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+    },
+    true,
+    logger
+  );
+  t.true(result);
+});
+
+test('output false', async (t) => {
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+    },
+    false,
+    logger
+  );
+  t.false(result);
+});
+
+test('output a number', async (t) => {
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+    },
+    42,
+    logger
+  );
+  t.is(result, 42);
+});
+
+test('output null', async (t) => {
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+    },
+    null,
+    logger
+  );
+  t.is(result, null);
+});
+
+test('output undefined', async (t) => {
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+    },
+    undefined,
+    logger
+  );
+  t.is(result, undefined);
+});
+
+test('output a string', async (t) => {
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+    },
+    'ok',
+    logger
+  );
+  t.is(result, 'ok');
+});
+
+test('output a an array', async (t) => {
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+    },
+    ['ok'],
+    logger
+  );
+  t.deepEqual(result, ['ok']);
+});
+
+// TODO should return as string
+test('output an object', async (t) => {
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+    },
+    {},
+    logger
+  );
+  t.deepEqual(result, {});
+});
+
+test('strict-mode: only output data', async (t) => {
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+      noStrictOutput: false,
+    },
+    {
+      data: {},
+      configuration: {},
+      foo: 'bar',
+      _secret: true,
+    },
+    logger
+  );
+  t.is(result, toString({ data: {} }));
+});
+
+test('strict-mode by default', async (t) => {
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+    },
+    {
+      data: {},
+      configuration: {},
+      foo: 'bar',
+      _secret: true,
+    },
+    logger
+  );
+  t.is(result, toString({ data: {} }));
+});
+
+test('non-strict-mode: exclude configuration', async (t) => {
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+      noStrictOutput: true,
+    },
+    {
+      data: {},
+      configuration: {},
+    },
+    logger
+  );
+  t.is(result, toString({ data: {} }));
+});
+
+test('non-strict-mode: include other stuff', async (t) => {
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+      noStrictOutput: true,
+    },
+    {
+      data: {},
+      _secret: 'true',
+    },
+    logger
+  );
+  t.is(result, toString({ data: {}, _secret: 'true' }));
+});
+
+// TODO fails right now
+test.skip('handle circular data', async (t) => {
+  const a: any = { name: 'a' };
+  a.rel = a;
+
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+      noStrictOutput: false,
+    },
+    {
+      data: a,
+    },
+    logger
+  );
+  t.is(result, toString({ data: {} }));
+});
+
+test('ignore fuctions', async (t) => {
+  const a: any = { help: () => 'I need somebody' };
+
+  const result = await handleOutput(
+    {
+      outputStdout: true,
+      noStrictOutput: false,
+    },
+    {
+      data: a,
+    },
+    logger
+  );
+  t.is(result, toString({ data: {} }));
+});
+
+test('output to file', async (t) => {
+  mockfs({
+    'out.json': '',
+  });
+
+  const before = await readFile('out.json', 'utf8');
+  t.falsy(before);
+
+  await handleOutput(
+    {
+      outputPath: 'out.json',
+      noStrictOutput: false,
+    },
+    {
+      data: 1,
+    },
+    logger
+  );
+
+  const after = await readFile('out.json', 'utf8');
+  t.is(after, toString({ data: 1 }));
+});

--- a/packages/cli/test/execute/handle-output.test.ts
+++ b/packages/cli/test/execute/handle-output.test.ts
@@ -106,7 +106,7 @@ test('strict-mode: only output data', async (t) => {
   const result = await handleOutput(
     {
       outputStdout: true,
-      noStrictOutput: false,
+      strictOutput: true,
     },
     {
       data: {},
@@ -139,7 +139,7 @@ test('non-strict-mode: exclude configuration', async (t) => {
   const result = await handleOutput(
     {
       outputStdout: true,
-      noStrictOutput: true,
+      strictOutput: false,
     },
     {
       data: {},
@@ -154,7 +154,7 @@ test('non-strict-mode: include other stuff', async (t) => {
   const result = await handleOutput(
     {
       outputStdout: true,
-      noStrictOutput: true,
+      strictOutput: false,
     },
     {
       data: {},
@@ -173,7 +173,6 @@ test.skip('handle circular data', async (t) => {
   const result = await handleOutput(
     {
       outputStdout: true,
-      noStrictOutput: false,
     },
     {
       data: a,
@@ -189,7 +188,6 @@ test('ignore fuctions', async (t) => {
   const result = await handleOutput(
     {
       outputStdout: true,
-      noStrictOutput: false,
     },
     {
       data: a,
@@ -210,7 +208,6 @@ test('output to file', async (t) => {
   await handleOutput(
     {
       outputPath: 'out.json',
-      noStrictOutput: false,
     },
     {
       data: 1,

--- a/packages/cli/test/execute/serialize-output.test.ts
+++ b/packages/cli/test/execute/serialize-output.test.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import mockfs from 'mock-fs';
 import { readFile } from 'node:fs/promises';
 
-import { serializeOutput } from '../../src/execute/handler';
+import serializeOutput from '../../src/execute/serialize-output';
 import { createMockLogger } from '@openfn/logger';
 
 const logger = createMockLogger(undefined, { level: 'debug' });

--- a/packages/cli/test/execute/serialize-output.test.ts
+++ b/packages/cli/test/execute/serialize-output.test.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import mockfs from 'mock-fs';
 import { readFile } from 'node:fs/promises';
 
-import { handleOutput } from '../../src/execute/handler';
+import { serializeOutput } from '../../src/execute/handler';
 import { createMockLogger } from '@openfn/logger';
 
 const logger = createMockLogger(undefined, { level: 'debug' });
@@ -14,96 +14,95 @@ test.beforeEach(() => {
 const toString = (obj: object) => JSON.stringify(obj, null, 2);
 
 test('output true', async (t) => {
-  const result = await handleOutput(
+  const result = await serializeOutput(
     {
       outputStdout: true,
     },
     true,
     logger
   );
-  t.true(result);
+  t.is(result, 'true');
 });
 
 test('output false', async (t) => {
-  const result = await handleOutput(
+  const result = await serializeOutput(
     {
       outputStdout: true,
     },
     false,
     logger
   );
-  t.false(result);
+  t.is(result, 'false');
 });
 
 test('output a number', async (t) => {
-  const result = await handleOutput(
+  const result = await serializeOutput(
     {
       outputStdout: true,
     },
     42,
     logger
   );
-  t.is(result, 42);
+  t.is(result, '42');
 });
 
 test('output null', async (t) => {
-  const result = await handleOutput(
+  const result = await serializeOutput(
     {
       outputStdout: true,
     },
     null,
     logger
   );
-  t.is(result, null);
+  t.is(result, 'null');
 });
 
-test('output undefined', async (t) => {
-  const result = await handleOutput(
+test('output undefined as an empty string', async (t) => {
+  const result = await serializeOutput(
     {
       outputStdout: true,
     },
     undefined,
     logger
   );
-  t.is(result, undefined);
+  t.is(result, '');
 });
 
 test('output a string', async (t) => {
-  const result = await handleOutput(
+  const result = await serializeOutput(
     {
       outputStdout: true,
     },
     'ok',
     logger
   );
-  t.is(result, 'ok');
+  t.is(result, '"ok"');
 });
 
-test('output a an array', async (t) => {
-  const result = await handleOutput(
+test('output an array', async (t) => {
+  const result = await serializeOutput(
     {
       outputStdout: true,
     },
     ['ok'],
     logger
   );
-  t.deepEqual(result, ['ok']);
+  t.is(result, toString(['ok']));
 });
 
-// TODO should return as string
 test('output an object', async (t) => {
-  const result = await handleOutput(
+  const result = await serializeOutput(
     {
       outputStdout: true,
     },
     {},
     logger
   );
-  t.deepEqual(result, {});
+  t.is(result, '{}');
 });
 
 test('strict-mode: only output data', async (t) => {
-  const result = await handleOutput(
+  const result = await serializeOutput(
     {
       outputStdout: true,
       strictOutput: true,
@@ -120,7 +119,7 @@ test('strict-mode: only output data', async (t) => {
 });
 
 test('strict-mode by default', async (t) => {
-  const result = await handleOutput(
+  const result = await serializeOutput(
     {
       outputStdout: true,
     },
@@ -136,7 +135,7 @@ test('strict-mode by default', async (t) => {
 });
 
 test('non-strict-mode: exclude configuration', async (t) => {
-  const result = await handleOutput(
+  const result = await serializeOutput(
     {
       outputStdout: true,
       strictOutput: false,
@@ -151,7 +150,7 @@ test('non-strict-mode: exclude configuration', async (t) => {
 });
 
 test('non-strict-mode: include other stuff', async (t) => {
-  const result = await handleOutput(
+  const result = await serializeOutput(
     {
       outputStdout: true,
       strictOutput: false,
@@ -170,7 +169,7 @@ test.skip('handle circular data', async (t) => {
   const a: any = { name: 'a' };
   a.rel = a;
 
-  const result = await handleOutput(
+  const result = await serializeOutput(
     {
       outputStdout: true,
     },
@@ -185,7 +184,7 @@ test.skip('handle circular data', async (t) => {
 test('ignore fuctions', async (t) => {
   const a: any = { help: () => 'I need somebody' };
 
-  const result = await handleOutput(
+  const result = await serializeOutput(
     {
       outputStdout: true,
     },
@@ -205,7 +204,7 @@ test('output to file', async (t) => {
   const before = await readFile('out.json', 'utf8');
   t.falsy(before);
 
-  await handleOutput(
+  await serializeOutput(
     {
       outputPath: 'out.json',
     },

--- a/packages/cli/test/execute/serialize-output.test.ts
+++ b/packages/cli/test/execute/serialize-output.test.ts
@@ -164,10 +164,9 @@ test('non-strict-mode: include other stuff', async (t) => {
   t.is(result, toString({ data: {}, _secret: 'true' }));
 });
 
-// TODO fails right now
-test.skip('handle circular data', async (t) => {
+test('handle circular data', async (t) => {
   const a: any = { name: 'a' };
-  a.rel = a;
+  a.ref = a;
 
   const result = await serializeOutput(
     {
@@ -178,7 +177,35 @@ test.skip('handle circular data', async (t) => {
     },
     logger
   );
-  t.is(result, toString({ data: {} }));
+  t.is(result, toString({ data: { name: 'a', ref: '[Circular]' } }));
+});
+
+test('handle nested circular data', async (t) => {
+  const a: any = {
+    x: {
+      y: {},
+    },
+  };
+  a.x.y.z = a;
+
+  const result = await serializeOutput(
+    {
+      outputStdout: true,
+    },
+    {
+      data: a,
+    },
+    logger
+  );
+
+  const expected = {
+    x: {
+      y: {
+        z: '[Circular]',
+      },
+    },
+  };
+  t.is(result, toString({ data: expected }));
 });
 
 test('ignore fuctions', async (t) => {

--- a/packages/cli/test/util/ensure-opts.test.ts
+++ b/packages/cli/test/util/ensure-opts.test.ts
@@ -118,6 +118,34 @@ test('preserve outputStdout', (t) => {
   t.truthy(opts.outputStdout);
 });
 
+test('preserve strictOutput false', (t) => {
+  const initialOpts = {
+    strictOutput: false,
+  } as Opts;
+
+  const opts = ensureOpts('a', initialOpts);
+
+  t.false(opts.strictOutput);
+});
+
+test('preserve strictOutput true', (t) => {
+  const initialOpts = {
+    strictOutput: true,
+  } as Opts;
+
+  const opts = ensureOpts('a', initialOpts);
+
+  t.true(opts.strictOutput);
+});
+
+test('strictOutput true by default', (t) => {
+  const initialOpts = {} as Opts;
+
+  const opts = ensureOpts('a', initialOpts);
+
+  t.true(opts.strictOutput);
+});
+
 test('preserve force', (t) => {
   const initialOpts = {
     force: true,

--- a/packages/logger/src/sanitize.ts
+++ b/packages/logger/src/sanitize.ts
@@ -6,13 +6,13 @@ export const SECRET = '****';
 
 // Node itself does a good job of circular references and functions
 const sanitize = (
-  item: string | object,
+  item: any,
   _options: Pick<LogOptions, 'sanitizePaths'> = {}
 ) => {
   // TODO what if the object contains functions?
   if (typeof item !== 'string') {
     const obj = item as Record<string, unknown>;
-    if (obj.configuration) {
+    if (obj && obj.configuration) {
       // This looks sensitive, so let's sanitize it
       const configuration = {} as Record<string, unknown>;
       for (const k in obj.configuration) {

--- a/packages/logger/test/sanitize.test.ts
+++ b/packages/logger/test/sanitize.test.ts
@@ -8,6 +8,16 @@ test('simply return a string', (t) => {
   t.is(result, 'x');
 });
 
+test('simply return null', (t) => {
+  const result = sanitize(null, options);
+  t.is(result, null);
+});
+
+test('simply return undefined', (t) => {
+  const result = sanitize(undefined, options);
+  t.is(result, undefined);
+});
+
 test('simply return an object', (t) => {
   const result = sanitize({ a: 'x' }, options);
   t.deepEqual(result, { a: 'x' });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,7 @@ importers:
       '@types/node': ^17.0.45
       '@types/yargs': ^17.0.12
       ava: 5.1.0
+      fast-safe-stringify: ^2.1.1
       mock-fs: ^5.1.4
       rimraf: ^3.0.2
       treeify: ^1.1.0
@@ -167,6 +168,7 @@ importers:
       '@openfn/compiler': link:../compiler
       '@openfn/logger': link:../logger
       '@openfn/runtime': link:../runtime
+      fast-safe-stringify: 2.1.1
       rimraf: 3.0.2
       treeify: 1.1.0
       yargs: 17.5.1
@@ -4137,6 +4139,10 @@ packages:
       merge2: 1.4.1
       micromatch: 4.0.5
     dev: true
+
+  /fast-safe-stringify/2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+    dev: false
 
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}


### PR DESCRIPTION
Three fixes here related to what we write to `output.json`

1) Support circular structures thanks to `fast-safe-stringify` (fixes #106 which started all this)
2) Introduce a "strict mode" for state output, which only prints state.data to the output file
3) Don't serialize `configuration`

The second part in particular is worth some discussion.

## Strict output

By default the CLI will output in strict mode. This means we only print the `data` key of state. Anything else written to the state object will be ignored.

This avoids us serialising junk which is needed at runtime but shouldn't be returned at the end. Like request objects from the HTTP adaptor (which is the trigger for all this).

In non strict mode (`openfn job.js --no-strict-output`) we'll try and print the whole state object (except config, see below). We should be able to handle complex objects should anyone try to serialize a database connection or something.

## Config output

We now never serialize the `configuration` object in the output.

This means that in lightning, sensitive credential data is never printed out. We could take the approach of of sanitizing the output (scrubbing the values), but to what end? The configuration object is input-only and shouldn't IMO be shown in the output.

## Other ideas

Maybe we can ignore all keys starting with `_` ? Just at the top or nested? In strict mode or always?

## Issues

Closes #106