### PR TITLE
Jsdelivr

### DIFF
--- a/.changeset/light-cars-love.md
+++ b/.changeset/light-cars-love.md
@@ -1,0 +1,5 @@
+---
+'@openfn/describe-package': patch
+---
+
+Use jsdelivr rather than unpkg

--- a/packages/describe-package/src/fs/package-fs.ts
+++ b/packages/describe-package/src/fs/package-fs.ts
@@ -12,12 +12,6 @@ export class NotFound extends Error {
   }
 }
 
-interface PackageListing {
-  path: string;
-  type: 'directory' | 'file';
-  files?: PackageListing[];
-}
-
 interface JSDelivrListing {
   default: string;
   files: Array<{

--- a/packages/describe-package/src/fs/package-fs.ts
+++ b/packages/describe-package/src/fs/package-fs.ts
@@ -28,27 +28,10 @@ interface JSDelivrListing {
   }>;
 }
 
-export function* flattenFiles(
-  listing: PackageListing,
-  ignoreNodeModules = false,
-  path: string = ''
-): Generator<string> {
-  if (listing.type == 'directory') {
-    for (let i = 0; i < listing.files!.length; i++) {
-      const f = listing.files![i];
-      if (!ignoreNodeModules || !f.path.startsWith('/node_modules/')) {
-        yield* flattenFiles(f, ignoreNodeModules);
-      }
-    }
-  } else {
-    yield `${path}${listing.path}`;
-  }
-}
-
 export async function fetchFileListing(packageName: string) {
   // const cached = localStorage.getItem(packageName);
   // if (cached) {
-  //   return flattenFiles(JSON.parse(cached));
+  //   return JSON.parse(cached);
   // }
 
   const response = await fetch(

--- a/packages/describe-package/src/pack.ts
+++ b/packages/describe-package/src/pack.ts
@@ -19,7 +19,7 @@
  * ## Loading from Unpkg
  *
  * ```js
- * const pack = await Pack.fromUnpkg("@myorg/mypackage")
+ * const pack = await Pack.fetch("@myorg/mypackage")
  * ```
  *
  * This will create a new Pack instance and download it's `package.json` and
@@ -139,7 +139,7 @@ export class Pack {
     this.fsMap.set(urlJoin(this.packageBase, file), contents);
   }
 
-  static async fromUnpkg(specifier: string): Promise<Pack> {
+  static async fetch(specifier: string): Promise<Pack> {
     const pack = new Pack({
       path: specifier,
       packageJson: JSON.parse(await fetchFile(specifier + '/package.json')),

--- a/packages/describe-package/src/worker/worker.ts
+++ b/packages/describe-package/src/worker/worker.ts
@@ -30,7 +30,7 @@ async function loadModule(specifier: string) {
     throw new Error('Project not initialized, call `createProject` first.');
   }
 
-  const pack = await Pack.fromUnpkg(specifier);
+  const pack = await Pack.fetch(specifier);
 
   if (!pack.types)
     throw new Error(

--- a/packages/describe-package/test/fs/package-fs.test.ts
+++ b/packages/describe-package/test/fs/package-fs.test.ts
@@ -3,6 +3,7 @@ import test from 'ava';
 import {
   fetchDTSListing,
   fetchFile,
+  fetchFileListing,
   flattenFiles,
 } from '../../src/fs/package-fs';
 
@@ -65,7 +66,7 @@ test('fetchDTS lists .d.ts files for a given package', async (t) => {
   t.timeout(20000);
 
   const results: string[] = [];
-  for await (const f of fetchDTSListing('@typescript/vfs')) {
+  for await (const f of fetchDTSListing('@typescript/vfs@1.4.0')) {
     results.push(f);
   }
 
@@ -76,4 +77,12 @@ test('fetchFile retrieves a file for a given package', async (t) => {
   const result = await fetchFile('@typescript/vfs/dist/index.d.ts');
 
   t.truthy(result);
+});
+
+test('fetchFileListing returns a flat list of files', async (t) => {
+  const result = await fetchFileListing('@openfn/language-common@1.7.5');
+  t.true(result.includes('/ast.json'));
+  t.true(result.includes('/package.json'));
+  t.true(result.includes('/dist/index.js'));
+  t.true(result.includes('/types/Adaptor.d.ts'));
 });

--- a/packages/describe-package/test/fs/package-fs.test.ts
+++ b/packages/describe-package/test/fs/package-fs.test.ts
@@ -4,63 +4,7 @@ import {
   fetchDTSListing,
   fetchFile,
   fetchFileListing,
-  flattenFiles,
 } from '../../src/fs/package-fs';
-
-test('flattenFiles', async (t) => {
-  const listing = {
-    path: 'a',
-    type: 'directory',
-    files: [
-      {
-        path: 'node_modules',
-        type: 'directory',
-        files: [{ path: '/node_modules/x.js', type: 'file' }],
-      },
-      {
-        path: 'lib',
-        type: 'directory',
-        files: [{ path: '/lib/y.js', type: 'file' }],
-      },
-      { path: '/a.js', type: 'file' },
-    ],
-  };
-  const results: string[] = [];
-  for await (const f of flattenFiles(listing)) {
-    results.push(f);
-  }
-  t.is(results.length, 3);
-  t.assert(results.includes('/node_modules/x.js'));
-  t.assert(results.includes('/lib/y.js'));
-  t.assert(results.includes('/a.js'));
-});
-
-test('flattenFiles ignores node_modules', async (t) => {
-  const listing = {
-    path: 'a',
-    type: 'directory',
-    files: [
-      {
-        path: '/node_modules',
-        type: 'directory',
-        files: [{ path: '/node_modules/x.js', type: 'file' }],
-      },
-      {
-        path: 'lib',
-        type: 'directory',
-        files: [{ path: '/lib/y.js', type: 'file' }],
-      },
-      { path: '/a.js', type: 'file' },
-    ],
-  };
-  const results: string[] = [];
-  for await (const f of flattenFiles(listing, true)) {
-    results.push(f);
-  }
-  t.is(results.length, 2);
-  t.assert(results.includes('/lib/y.js'));
-  t.assert(results.includes('/a.js'));
-});
 
 test('fetchDTS lists .d.ts files for a given package', async (t) => {
   t.timeout(20000);

--- a/packages/describe-package/test/pack.test.ts
+++ b/packages/describe-package/test/pack.test.ts
@@ -2,28 +2,26 @@ import test from 'ava';
 
 import { Pack } from '../src/pack';
 
-test('fromUnpkg resolves the specifier after getting the package.json', async (t) => {
+test('fetch resolves the specifier after getting the package.json', async (t) => {
   t.timeout(20000);
 
-  const pack = await Pack.fromUnpkg('@openfn/language-common');
-  t.is(pack.path, '@openfn/language-common');
+  const pack = await Pack.fetch('@openfn/language-common@1.7.5');
+  t.is(pack.path, '@openfn/language-common@1.7.5');
   t.regex(pack.specifier, /^@openfn\/language-common@\d\.\d\.\d/);
 });
 
-test('fromUnpkg loads the file listing', async (t) => {
+test('fetch loads the file listing', async (t) => {
   t.timeout(20000);
 
-  const pack = await Pack.fromUnpkg('@openfn/language-common@2.0.0-rc1');
+  const pack = await Pack.fetch('@openfn/language-common@2.0.0-rc1');
   t.is(pack.path, '@openfn/language-common@2.0.0-rc1');
-  t.deepEqual(pack.fileListing, [
-    '/LICENSE',
-    '/dist/index.cjs',
-    '/dist/index.js',
-    '/dist/language-common.d.ts',
-    '/package.json',
-    '/LICENSE.LESSER',
-    '/README.md',
-  ]);
+  t.true(pack.fileListing.includes('/LICENSE'));
+  t.true(pack.fileListing.includes('/dist/index.cjs'));
+  t.true(pack.fileListing.includes('/dist/index.js'));
+  t.true(pack.fileListing.includes('/dist/language-common.d.ts'));
+  t.true(pack.fileListing.includes('/package.json'));
+  t.true(pack.fileListing.includes('/LICENSE.LESSER'));
+  t.true(pack.fileListing.includes('/README.md'));
 
   t.is(pack.fsMap.size, 0);
   await pack.getFiles();
@@ -36,8 +34,8 @@ test('fromUnpkg loads the file listing', async (t) => {
   t.truthy(pack.fsMap.get(pack.types!));
 });
 
-test("Unpkg throws an error when a package can't be found", async (t) => {
-  await t.throwsAsync(async () => Pack.fromUnpkg('@openfn/foobar'), {
+test("fetch throws an error when a package can't be found", async (t) => {
+  await t.throwsAsync(async () => Pack.fetch('@openfn/foobar'), {
     message: 'Got 404 from Unpkg for: @openfn/foobar/package.json',
   });
 });


### PR DESCRIPTION
Replace unpkg.com with jsdeliver.com

Notes & caveats:

* jsdeliver can return files in a flat format, which is nice, so we can delete some code
* jsdeliver MUST have a version number in the url. This is a probably a good thing but required changes

Closes #88

Performance notes:

This is hardly conclusive but here's low long devtools says it tales to load examples/adaptor-docs with primero on main (caching disabled):
```
1004ms
969ms
1006ms
972ms
1002ms
1001ms
936ms
```
I should add that the first load after building took about 20 seconds - Is this a blip, or is there a cache somewhere? If I switch to common it took 8 seconds, then came down to about a second. I think this is a case on unpkg kicking in.

And on this branch:

```
728ms
626ms
620ms
601ms
642ms
963ms
671ms
```

So it does seem to help.