### PR TITLE
Security tests

### DIFF
--- a/packages/runtime-manager/test/worker-pool.test.ts
+++ b/packages/runtime-manager/test/worker-pool.test.ts
@@ -1,0 +1,93 @@
+import test from 'ava';
+import workerpool from 'workerpool';
+
+//some tests of worker stuff
+let pool;
+
+test.beforeEach(() => {
+  pool = workerpool.pool({ maxWorkers: 1 });
+});
+
+test.afterEach(() => {
+  pool.terminate();
+});
+
+test.serial('run an expression inside a worker', async (t) => {
+  const fn = () => 42;
+
+  const result = await pool.exec(fn, []);
+
+  t.is(result, 42);
+});
+
+test.serial('worker should not have access to host globals', async (t) => {
+  const pool = workerpool.pool({ maxWorkers: 1 });
+  global.x = 22;
+
+  const fn = () => global.x;
+
+  const result = await pool.exec(fn, []);
+
+  t.is(result, undefined);
+  delete global.x;
+});
+
+test.serial('worker should not mutate host global scope', async (t) => {
+  t.is(global.x, undefined);
+
+  const fn = () => {
+    global.x = 9;
+  };
+
+  await pool.exec(fn, []);
+
+  t.is(global.x, undefined);
+});
+
+// fails! This is a problem
+test.serial.skip('workers should not affect each other', async (t) => {
+  t.is(global.x, undefined);
+
+  const fn1 = () => {
+    global.x = 9;
+  };
+
+  // Set a global inside the worker
+  await pool.exec(fn1, []);
+
+  // (should not affect us outside)
+  t.is(global.x, undefined);
+
+  const fn2 = () => global.x;
+
+  // Call into the same worker and check the scope is still there
+  const result = await pool.exec(fn2, []);
+
+  // Fails - result is 9
+  t.is(result, undefined);
+});
+
+test.serial(
+  'workers should not affect each other if global scope is frozen',
+  async (t) => {
+    t.is(global.x, undefined);
+
+    const fn1 = () => {
+      Object.freeze(global);
+      global.x = 9;
+    };
+
+    // Set a global inside the worker
+    await pool.exec(fn1, []);
+
+    // (should not affect us outside)
+    t.is(global.x, undefined);
+
+    const fn2 = () => global.x;
+
+    // Call into the same worker and check the scope is still there
+    const result = await pool.exec(fn2, []);
+
+    t.is(result, undefined);
+  }
+);

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -110,18 +110,16 @@ const wrapOperation = (
 const buildContext = (state: State, options: Options) => {
   const logger = options.jobLogger ?? console;
 
-  // TODO review this and decide what we explicitly want to exclude (see #104)
   const context = vm.createContext(
     {
       console: logger,
+      state, // TODO I don't really want to pass global state through
       clearInterval,
       clearTimeout,
-      JSON,
       parseFloat,
       parseInt,
       setInterval,
       setTimeout,
-      state, // TODO I don't really want to pass global state through
     },
     {
       codeGeneration: {

--- a/packages/runtime/test/security.test.ts
+++ b/packages/runtime/test/security.test.ts
@@ -1,0 +1,71 @@
+// a suite of tests with various security concerns in mind
+
+import test from 'ava';
+import run from '../src/runtime';
+
+// TODO use of globalthis is kinda interesting - I expect global to be available?
+test.serial('jobs should not have access to global scope', async (t) => {
+  const src = 'export default [() => globalThis.x]';
+  globalThis.x = 42;
+
+  const result = await run(src);
+  t.falsy(result);
+
+  delete globalThis.x;
+});
+
+test.serial('jobs should be able to read global state', async (t) => {
+  const src = 'export default [() => state.x]';
+
+  const result = await run(src, { x: 42 }); // typings are a bit tricky
+  t.is(result, 42);
+});
+
+test.serial('jobs should be able to mutate global state', async (t) => {
+  const src = 'export default [() => { state.x = 22; return state.x; }]';
+
+  const result = await run(src, { x: 42 }); // typings are a bit tricky
+  t.is(result, 22);
+});
+
+test.serial('jobs should each run in their own context', async (t) => {
+  const src1 = 'export default [() => { globalThis.x = 1; return 1;}]';
+  const src2 = 'export default [() => globalThis.x]';
+
+  await run(src1);
+
+  const r1 = await run(src1);
+  t.is(r1, 1);
+
+  const r2 = await run(src2);
+  t.is(r2, undefined);
+});
+
+test.serial('jobs should not have a process object', async (t) => {
+  const src = 'export default [() => process.pid]';
+
+  await t.throwsAsync(() => run(src), {
+    message: 'process is not defined',
+  });
+});
+
+test.serial(
+  'jobs should not be able to pass a string to setTimeout',
+  async (t) => {
+    const src = 'export default [() => setTimeout("hacking ur scriptz", 1)]';
+
+    await t.throwsAsync(() => run(src), {
+      instanceOf: TypeError,
+      message:
+        'The "callback" argument must be of type function. Received type string (\'hacking ur scriptz\')',
+    });
+  }
+);
+
+test.serial('jobs should be able to use sensible timeouts', async (t) => {
+  const src =
+    'export default [() => new Promise((resolve) => setTimeout(() => resolve(22), 1))]';
+
+  const result = await run(src);
+  t.is(result, 22);
+});


### PR DESCRIPTION
I've been adding some unit tests around security concerns - may as well merge them!

Some are around worker threads, others around the runtime sandbox.

There is some duplication here but a little redundancy is no bad thing.

There's also a tiny "fix" for #104 - having understood a bit better what createContext is doing I've removed a comment and made a tiny tweak. So I've targeted this against the release branch but I won't add a changeset.