### PR TITLE
Fix CLI in windows

### DIFF
--- a/.changeset/real-jokes-fail.md
+++ b/.changeset/real-jokes-fail.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Fix hang on windows

--- a/packages/cli/src/process/runner.ts
+++ b/packages/cli/src/process/runner.ts
@@ -4,7 +4,6 @@ type InitMessage = {
   init: true;
   basePath: string;
   opts: Opts;
-  //command?: string; // TODO execute | compile | validate etc
 };
 
 // When receiving a message as a child process, we pull out the args and run
@@ -15,3 +14,8 @@ process.on('message', ({ init, basePath, opts }: InitMessage) => {
     });
   }
 });
+
+// Tell the parent process we're awake and ready
+process.send!({
+  init: true
+})


### PR DESCRIPTION
When running in Windows, the CLI just freezes forever.

This is because the packing forked process doesn't receive its startup messages. Basically the start event is sent before the inner process is ready to listen to it. It's a timing thing.

I've just added another event from child to parent which fixes the issue.