### PR TITLE
describe-package: handle captions in examples better

### DIFF
--- a/.changeset/breezy-baboons-scream.md
+++ b/.changeset/breezy-baboons-scream.md
@@ -1,0 +1,5 @@
+---
+'@openfn/describe-package': patch
+---
+
+Handle captions in examples

--- a/.changeset/breezy-baboons-scream.md
+++ b/.changeset/breezy-baboons-scream.md
@@ -1,5 +1,0 @@
----
-'@openfn/describe-package': patch
----
-
-Handle captions in examples

--- a/packages/adaptor-docs/package.json
+++ b/packages/adaptor-docs/package.json
@@ -29,7 +29,7 @@
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",
   "dependencies": {
-    "@openfn/describe-package": "workspace:^0.0.11",
+    "@openfn/describe-package": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,10 +45,10 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@openfn/compiler": "workspace:^0.0.19",
-    "@openfn/describe-package": "workspace:^0.0.11",
-    "@openfn/logger": "workspace:^0.0.8",
-    "@openfn/runtime": "workspace:^0.0.13",
+    "@openfn/compiler": "workspace:*",
+    "@openfn/describe-package": "workspace:*",
+    "@openfn/logger": "workspace:*",
+    "@openfn/runtime": "workspace:*",
     "fast-safe-stringify": "^2.1.1",
     "rimraf": "^3.0.2",
     "treeify": "^1.1.0",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -39,8 +39,8 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@openfn/describe-package": "workspace:^0.0.11",
-    "@openfn/logger": "workspace:^0.0.8",
+    "@openfn/describe-package": "workspace:*",
+    "@openfn/logger": "workspace:*",
     "acorn": "^8.8.0",
     "ast-types": "^0.14.2",
     "recast": "^0.21.2",

--- a/packages/describe-package/CHANGELOG.md
+++ b/packages/describe-package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/describe-package
 
+## 0.0.12
+
+### Patch Changes
+
+- 220fb95: Handle captions in examples
+
 ## 0.0.11
 
 ### Patch Changes

--- a/packages/describe-package/package.json
+++ b/packages/describe-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/describe-package",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Utilities to inspect an npm package.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/describe-package/src/api.ts
+++ b/packages/describe-package/src/api.ts
@@ -34,8 +34,13 @@ export type FunctionDescription = {
   isOperation: boolean; // Is this an Operation?
   parameters: ParameterDescription[];
   description: string;
-  examples: string[];
+  examples: ExampleDescription[];
   parent?: string;
+};
+
+type ExampleDescription = {
+  code: string;
+  cpation?: string;
 };
 
 export type ParameterDescription = {

--- a/packages/describe-package/src/describe-project.ts
+++ b/packages/describe-package/src/describe-project.ts
@@ -38,7 +38,15 @@ const describeFunction = (
     parameters: symbol.parameters.map((p) => describeParameter(project, p)),
     magic: false,
     isOperation: false,
-    examples: symbol.examples,
+    examples: symbol.examples.map((eg: string) => {
+      if (eg.startsWith('<caption>')) {
+        let [caption, code] = eg.split('</caption>');
+        caption = caption.replace('<caption>', '');
+
+        return { caption, code };
+      }
+      return { code: eg };
+    }),
     parent,
   };
 };

--- a/packages/describe-package/src/describe-project.ts
+++ b/packages/describe-package/src/describe-project.ts
@@ -43,9 +43,9 @@ const describeFunction = (
         let [caption, code] = eg.split('</caption>');
         caption = caption.replace('<caption>', '');
 
-        return { caption, code };
+        return { caption: caption.trim(), code: code.trim() };
       }
-      return { code: eg };
+      return { code: eg.trim() };
     }),
     parent,
   };

--- a/packages/describe-package/test/describe-project.test.ts
+++ b/packages/describe-package/test/describe-project.test.ts
@@ -39,10 +39,18 @@ test('1 parameters in a 1-arity function', async (t) => {
   t.is(flavour.type, 'string');
 });
 
-test('Load the example', async (t) => {
+test('Load an example', async (t) => {
   const fn = get('traditional');
-  t.is(fn.examples[0], 'traditional()');
+  const [{ code }] = fn.examples;
+  t.is(code, 'traditional()');
   t.is(fn.parent, undefined);
+});
+
+test('Load an example with caption', async (t) => {
+  const fn = get('oneFlavour');
+  const [{ code, caption }] = fn.examples;
+  t.is(code, "oneFlavour('falafel')");
+  t.is(caption, 'cap');
 });
 
 test('Load common fn', async (t) => {

--- a/packages/describe-package/test/fixtures/stroopwafel.d.ts
+++ b/packages/describe-package/test/fixtures/stroopwafel.d.ts
@@ -10,7 +10,7 @@ export declare function traditional(): string;
  * Returns a flavoured stroopwafel
  * @public
  * @example
- * custom('falafel')
+ * <caption>cap</caption>oneFlavour('falafel')
  */
 export declare function oneFlavour(flavour: string): string;
 
@@ -18,7 +18,9 @@ export declare function oneFlavour(flavour: string): string;
  * Returns a many flavoured stroopwafel
  * @public
  * @example
- * custom(['strawberry', 'cream'])
+ * manyFlavours(['strawberry', 'cream'])
+ * @example
+ * manyFlavours(['garlic', 'chilli'])
  */
 export declare function manyFlavours(flavours: string[]): string;
 

--- a/packages/runtime-manager/package.json
+++ b/packages/runtime-manager/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@openfn/compiler": "workspace:^0.0.19",
     "@openfn/language-common": "2.0.0-rc3",
-    "@openfn/runtime": "workspace:^0.0.13",
+    "@openfn/logger": "workspace:*",
+    "@openfn/runtime": "workspace:*",
     "@types/koa": "^2.13.5",
     "@types/workerpool": "^6.1.0",
     "koa": "^2.13.4",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -40,7 +40,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@openfn/logger": "workspace:^0.0.8",
+    "@openfn/logger": "workspace:*",
     "semver": "^7.3.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
 
   packages/adaptor-docs:
     specifiers:
-      '@openfn/describe-package': workspace:^0.0.11
+      '@openfn/describe-package': workspace:*
       '@types/node': ^18.11.9
       '@types/react': ^18.0.25
       autoprefixer: ^10.4.13
@@ -124,11 +124,11 @@ importers:
 
   packages/cli:
     specifiers:
-      '@openfn/compiler': workspace:^0.0.19
-      '@openfn/describe-package': workspace:^0.0.11
+      '@openfn/compiler': workspace:*
+      '@openfn/describe-package': workspace:*
       '@openfn/language-common': 2.0.0-rc3
-      '@openfn/logger': workspace:^0.0.8
-      '@openfn/runtime': workspace:^0.0.13
+      '@openfn/logger': workspace:*
+      '@openfn/runtime': workspace:*
       '@types/mock-fs': ^4.13.1
       '@types/node': ^17.0.45
       '@types/yargs': ^17.0.12
@@ -165,8 +165,8 @@ importers:
 
   packages/compiler:
     specifiers:
-      '@openfn/describe-package': workspace:^0.0.11
-      '@openfn/logger': workspace:^0.0.8
+      '@openfn/describe-package': workspace:*
+      '@openfn/logger': workspace:*
       '@types/node': ^17.0.45
       '@types/yargs': ^17.0.12
       acorn: ^8.8.0
@@ -257,7 +257,7 @@ importers:
   packages/runtime:
     specifiers:
       '@openfn/language-common': 2.0.0-rc3
-      '@openfn/logger': workspace:^0.0.8
+      '@openfn/logger': workspace:*
       '@types/node': ^17.0.31
       ava: 5.1.0
       mock-fs: ^5.1.4
@@ -283,7 +283,8 @@ importers:
     specifiers:
       '@openfn/compiler': workspace:^0.0.19
       '@openfn/language-common': 2.0.0-rc3
-      '@openfn/runtime': workspace:^0.0.13
+      '@openfn/logger': workspace:*
+      '@openfn/runtime': workspace:*
       '@types/koa': ^2.13.5
       '@types/node': ^17.0.31
       '@types/workerpool': ^6.1.0
@@ -299,6 +300,7 @@ importers:
     dependencies:
       '@openfn/compiler': link:../compiler
       '@openfn/language-common': 2.0.0-rc3
+      '@openfn/logger': link:../logger
       '@openfn/runtime': link:../runtime
       '@types/koa': 2.13.5
       '@types/workerpool': 6.1.0


### PR DESCRIPTION
Some examples include a caption, which is like a label.

We don't handle that very elegantly - at least, not until now.

It's an awkward cross-package issue but this This fixes https://github.com/OpenFn/Lightning/issues/503

I'll test this against a corresponding fix in Lightning but when we're ready, I suggest we release `describe-package` here then merge down into main.

Update: I've updated workspace dependencies to `workspace:*`, otherwise things get a bit inconsistent if you just try to bump and release a single package.