### PR TITLE
CLI: Fix docs command

### DIFF
--- a/.changeset/smart-fans-laugh.md
+++ b/.changeset/smart-fans-laugh.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Fix an issue when running the docs command with no version number

--- a/packages/cli/src/docs/handler.ts
+++ b/packages/cli/src/docs/handler.ts
@@ -39,7 +39,7 @@ const docsHandler = async (
   let { name, version } = getNameAndVersion(adaptorName);
   if (!version) {
     logger.info('No version number provided, looking for latest...');
-    version = await getLatestVersion(version);
+    version = await getLatestVersion(name);
     logger.info('Found ', version);
     logger.success(`Showing docs for ${adaptorName} v${version}`);
   }

--- a/packages/runtime/src/modules/repo.ts
+++ b/packages/runtime/src/modules/repo.ts
@@ -118,7 +118,7 @@ export const getNameAndVersion = (specifier: string) => {
     name = specifier;
   }
 
-  return { name, version } as { name: string; version: string };
+  return { name, version } as { name: string; version?: string };
 };
 
 // If there's no version in the specifer, we'll use @latest


### PR DESCRIPTION
This PR fixes a silly issue in the `openfn docs` command, where if you don't pass a version number in, the automatic latest version lookup fails.

It also corrects a typing in `runtime`, for which I do not intend to submit a changeset.

## A note on testing.
So there are no unit tests on this, which is a large part of how this got shipped in a broken state.

Why are there no unit tests? Well, because to test this we shell out to `npm view`, and I don't particularly want to do that in a unit test. I need to either mock the command (which may not have worked anyway in this case because a bad argument was being passed to `getLatestVersion` and the TS is actually a bit wrong); or use an alternative to `npm view` (like calling out to `jsdelivr`) and maybe mock that.

I'm not really a big fan of heavily mocked environments and until now, I'd been quite pleased to avoid too much mocking.

I think actually the place to catch this would be an integration test, a la #75, but I'm not going to do that today.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
