### PR TITLE
Fix import undefined

### DIFF
--- a/.changeset/chilly-rabbits-speak.md
+++ b/.changeset/chilly-rabbits-speak.md
@@ -1,0 +1,5 @@
+---
+'@openfn/describe-package': patch
+---
+
+include caption fix in build

--- a/.changeset/chilly-rabbits-speak.md
+++ b/.changeset/chilly-rabbits-speak.md
@@ -1,5 +1,0 @@
----
-'@openfn/describe-package': patch
----
-
-include caption fix in build

--- a/.changeset/green-snails-jam.md
+++ b/.changeset/green-snails-jam.md
@@ -1,0 +1,5 @@
+---
+'@openfn/compiler': patch
+---
+
+Fix to prevent import undefined

--- a/examples/dts-inspector/CHANGELOG.md
+++ b/examples/dts-inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # dts-inspector
 
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [1a2d04a]
+  - @openfn/describe-package@0.0.13
+
 ## 1.0.9
 
 ### Patch Changes

--- a/examples/dts-inspector/package.json
+++ b/examples/dts-inspector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dts-inspector",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 0.0.22
+
+### Patch Changes
+
+- Updated dependencies [1a2d04a]
+  - @openfn/describe-package@0.0.13
+  - @openfn/compiler@0.0.20
+
 ## 0.0.21
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=16",

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/compiler
 
+## 0.0.20
+
+### Patch Changes
+
+- Updated dependencies [1a2d04a]
+  - @openfn/describe-package@0.0.13
+
 ## 0.0.19
 
 ### Patch Changes

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/compiler",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Compiler and language tooling for openfn jobs.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/compiler/src/transforms/add-imports.ts
+++ b/packages/compiler/src/transforms/add-imports.ts
@@ -59,7 +59,6 @@ const globals = [
   'Map',
   'Math',
   'module', // ditto
-  'NaN',
   'Number',
   'Object',
   'parseFloat',
@@ -108,7 +107,11 @@ export function findAllDanglingIdentifiers(ast: ASTNode) {
   const result: IdentifierList = {};
   visit(ast, {
     visitIdentifier: function (path) {
-      // If this is the top object of a member expression
+      // undefined and NaN are treated as a regular identifier
+      if (path.node.name === 'undefined' || path.node.name === 'NaN') {
+        return false;
+      }
+      // If this is the top object of a member expr
       if (n.MemberExpression.check(path.parentPath.node)) {
         // If this identifier is the subject of any part of an expression chain, it's not a dangler
         let target = path;

--- a/packages/compiler/test/transforms/add-imports.test.ts
+++ b/packages/compiler/test/transforms/add-imports.test.ts
@@ -191,10 +191,15 @@ test('findAllDanglingIdentifiers: import * as fn from "fn"; fn;', (t) => {
   t.assert(Object.keys(result).length == 0);
 });
 
-test.only('findAllDanglingIdentifiers: const x = undefined;', (t) => {
+test('findAllDanglingIdentifiers: const x = undefined;', (t) => {
   const ast = parse('const x = undefined;');
   const result = findAllDanglingIdentifiers(ast);
-  console.log(result);
+  t.assert(Object.keys(result).length == 0);
+});
+
+test('findAllDanglingIdentifiers: const x = true | false | null | NaN;', (t) => {
+  const ast = parse('const x = true | false | null | NaN;');
+  const result = findAllDanglingIdentifiers(ast);
   t.assert(Object.keys(result).length == 0);
 });
 

--- a/packages/compiler/test/transforms/add-imports.test.ts
+++ b/packages/compiler/test/transforms/add-imports.test.ts
@@ -191,6 +191,13 @@ test('findAllDanglingIdentifiers: import * as fn from "fn"; fn;', (t) => {
   t.assert(Object.keys(result).length == 0);
 });
 
+test.only('findAllDanglingIdentifiers: const x = undefined;', (t) => {
+  const ast = parse('const x = undefined;');
+  const result = findAllDanglingIdentifiers(ast);
+  console.log(result);
+  t.assert(Object.keys(result).length == 0);
+});
+
 test('findAllDanglingIdentifiers: nested scoping', (t) => {
   const ast = parse(`fn((a) => {
     const x = 1;

--- a/packages/describe-package/CHANGELOG.md
+++ b/packages/describe-package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/describe-package
 
+## 0.0.13
+
+### Patch Changes
+
+- 1a2d04a: include caption fix in build
+
 ## 0.0.12
 
 ### Patch Changes

--- a/packages/describe-package/package.json
+++ b/packages/describe-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/describe-package",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Utilities to inspect an npm package.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/runtime-manager/CHANGELOG.md
+++ b/packages/runtime-manager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # runtime-manager
 
+## 0.0.19
+
+### Patch Changes
+
+- @openfn/compiler@0.0.20
+
 ## 0.0.18
 
 ### Patch Changes

--- a/packages/runtime-manager/package.json
+++ b/packages/runtime-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime-manager",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "An example runtime manager service.",
   "main": "index.js",
   "type": "module",
@@ -15,7 +15,7 @@
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",
   "dependencies": {
-    "@openfn/compiler": "workspace:^0.0.19",
+    "@openfn/compiler": "workspace:^0.0.20",
     "@openfn/language-common": "2.0.0-rc3",
     "@openfn/logger": "workspace:*",
     "@openfn/runtime": "workspace:*",


### PR DESCRIPTION
Turns out that if you have `undefined` in your JS, we'll treat it as a global variable and try to import it from the adaptor.

Whoops.

This PR fixes that and covers a couple of similar cases.