### PR TITLE
Runtime timeouts

### DIFF
--- a/.changeset/breezy-spies-approve.md
+++ b/.changeset/breezy-spies-approve.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+Add timeout

--- a/.changeset/ninety-months-drop.md
+++ b/.changeset/ninety-months-drop.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Set job timeout through CLI

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -40,6 +40,7 @@ export type Opts = {
   packages?: string[];
   specifier?: string; // docgen
   repoDir?: string;
+  timeout?: number; // ms
   statePath?: string;
   stateStdin?: string;
 };

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -27,6 +27,10 @@ const executeCommand = {
         alias: 'S',
         description: 'Read state from stdin (instead of a file)',
       })
+      .option('timeout', {
+        alias: '-t',
+        description: 'Set the timeout duration in MS',
+      })
       .option('no-compile', {
         boolean: true,
         description: 'Skip compilation',

--- a/packages/cli/src/execute/execute.ts
+++ b/packages/cli/src/execute/execute.ts
@@ -10,6 +10,7 @@ export default (code: string, state: any, opts: SafeOpts): Promise<any> => {
   // Then again, maybe that doesn't make sense
   // Maybe we have to feed a job logger in?
   return run(code, state, {
+    timeout: opts.timeout,
     immutableState: opts.immutable,
     logger: createLogger(RUNTIME, opts),
     jobLogger: createLogger(JOB, opts),

--- a/packages/cli/src/util/ensure-opts.ts
+++ b/packages/cli/src/util/ensure-opts.ts
@@ -86,6 +86,7 @@ export default function ensureOpts(
     operation: opts.operation,
     packages: opts.packages,
     stateStdin: opts.stateStdin,
+    timeout: opts.timeout,
     specifier: opts.specifier,
     strictOutput: opts.strictOutput ?? true,
     immutable: opts.immutable || false,

--- a/packages/cli/test/util/ensure-opts.test.ts
+++ b/packages/cli/test/util/ensure-opts.test.ts
@@ -156,6 +156,16 @@ test('preserve force', (t) => {
   t.truthy(opts.force);
 });
 
+test('preserve timeout', (t) => {
+  const initialOpts = {
+    timeout: 999,
+  } as Opts;
+
+  const opts = ensureOpts('a', initialOpts);
+
+  t.is(opts.timeout, 999);
+});
+
 test('preserve noCompile', (t) => {
   const initialOpts = {
     noCompile: true,

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -3,6 +3,8 @@ import { createMockLogger, Logger, printDuration } from '@openfn/logger';
 import loadModule from './modules/module-loader';
 import type { LinkerOptions } from './modules/linker';
 
+const TIMEOUT = 1000;
+
 export declare interface State<D = object, C = object> {
   configuration: C;
   data: D;
@@ -17,6 +19,8 @@ export declare interface Operation<T = Promise<State> | State> {
 type Options = {
   logger?: Logger;
   jobLogger?: Logger;
+
+  timeout?: number;
 
   // Treat state as immutable (likely to break in legacy jobs)
   immutableState?: boolean;
@@ -41,31 +45,53 @@ const defaultLogger = createMockLogger();
 const defaultState = { data: {}, configuration: {} };
 
 // TODO what if an operation throws?
-export default async function run(
+export default function run(
   incomingJobs: string | Operation[],
   initialState: State = defaultState,
   opts: Options = {}
 ) {
-  const logger = opts.logger || defaultLogger;
-  logger.debug('Intialising pipeline');
-  // Setup a shared execution context
-  const context = buildContext(initialState, opts);
+  return new Promise(async (resolve, reject) => {
+    const timeout = opts.timeout || TIMEOUT;
+    const logger = opts.logger || defaultLogger;
+    logger.debug('Intialising pipeline');
+    logger.debug(`Timeout set to ${timeout}ms`);
 
-  const { operations, execute } = await prepareJob(incomingJobs, context, opts);
-  // Create the main reducer function
-  const reducer = (execute || defaultExecute)(
-    ...operations.map((op, idx) =>
-      wrapOperation(op, logger, `${idx + 1}`, opts.immutableState)
-    )
-  );
+    // Setup a shared execution context
+    const context = buildContext(initialState, opts);
 
-  // Run the pipeline
-  logger.debug(`Executing pipeline (${operations.length} operations)`);
-  const result = await reducer(initialState);
-  logger.debug('Pipeline complete!');
-  logger.debug(result);
-  // return the final state
-  return result;
+    const { operations, execute } = await prepareJob(
+      incomingJobs,
+      context,
+      opts
+    );
+    // Create the main reducer function
+    const reducer = (execute || defaultExecute)(
+      ...operations.map((op, idx) =>
+        wrapOperation(op, logger, `${idx + 1}`, opts.immutableState)
+      )
+    );
+
+    // Run the pipeline
+    logger.debug(`Executing pipeline (${operations.length} operations)`);
+
+    const tid = setTimeout(() => {
+      logger.error('Error: Timeout expired!');
+      reject(Error('timeout'));
+    }, timeout);
+
+    try {
+      const result = await reducer(initialState);
+      clearTimeout(tid);
+      logger.debug('Pipeline complete!');
+      logger.debug(result);
+      // return the final state
+      resolve(result);
+    } catch (e) {
+      logger.error('Error in runtime execution!');
+      logger.error(e);
+      reject(new Error('runtime exception'));
+    }
+  });
 }
 
 // TODO I'm in the market for the best solution here - immer? deep-clone?

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -3,7 +3,7 @@ import { createMockLogger, Logger, printDuration } from '@openfn/logger';
 import loadModule from './modules/module-loader';
 import type { LinkerOptions } from './modules/linker';
 
-const TIMEOUT = 1000;
+const TIMEOUT = 5000;
 
 export const ERR_TIMEOUT = 'timeout';
 // TODO maybe this is a job exception? Job fail?

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -5,6 +5,10 @@ import type { LinkerOptions } from './modules/linker';
 
 const TIMEOUT = 1000;
 
+export const ERR_TIMEOUT = 'timeout';
+// TODO maybe this is a job exception? Job fail?
+export const ERR_RUNTIME_EXCEPTION = 'runtime exception';
+
 export declare interface State<D = object, C = object> {
   configuration: C;
   data: D;
@@ -76,7 +80,7 @@ export default function run(
 
     const tid = setTimeout(() => {
       logger.error('Error: Timeout expired!');
-      reject(Error('timeout'));
+      reject(Error(ERR_TIMEOUT));
     }, timeout);
 
     try {
@@ -89,7 +93,7 @@ export default function run(
     } catch (e) {
       logger.error('Error in runtime execution!');
       logger.error(e);
-      reject(new Error('runtime exception'));
+      reject(new Error(ERR_RUNTIME_EXCEPTION));
     }
   });
 }

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -167,3 +167,28 @@ test('calls execute if exported from a job', async (t) => {
 
   t.is(logger._history.length, 1);
 });
+
+test('Throws after default timeout', async (t) => {
+  const logger = createMockLogger(undefined, { level: 'info' });
+
+  const job = `export default [() => new Promise(() => {})];`;
+
+  const state = createState();
+  await t.throwsAsync(async () => run(job, state, { jobLogger: logger }), {
+    message: 'timeout',
+  });
+});
+
+test('Throws after custom timeout', async (t) => {
+  const logger = createMockLogger(undefined, { level: 'info' });
+
+  const job = `export default [() => new Promise((resolve) => setTimeout(resolve, 100))];`;
+
+  const state = createState();
+  await t.throwsAsync(
+    async () => run(job, state, { jobLogger: logger, timeout: 10 }),
+    {
+      message: 'timeout',
+    }
+  );
+});


### PR DESCRIPTION
This PR enables the runtime to timeout after a number of milliseconds.

It's a pretty simple implementation. I've had to touch some error handling stuff - which isn't generally very good. This has prompted me to open #143 as a prelude to further work.

What's important here is that after the timeout the top promises will throw an exception, bringing the process to an end. There's some reasonable logging and a corresponding flag in the CLI to override the default value.

## Related issue

Fixes #68

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
