### PR TITLE
CLI: more docs fixes

### DIFF
--- a/.changeset/large-hats-help.md
+++ b/.changeset/large-hats-help.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Fix example display in docgen

--- a/.changeset/unlucky-rice-move.md
+++ b/.changeset/unlucky-rice-move.md
@@ -1,0 +1,5 @@
+---
+'@openfn/describe-package': patch
+---
+
+Fix typing

--- a/packages/cli/src/docs/command.ts
+++ b/packages/cli/src/docs/command.ts
@@ -2,7 +2,7 @@ import yargs, { Arguments } from 'yargs';
 import { Opts } from '../commands';
 
 export default {
-  command: 'docs [adaptor] [operation]',
+  command: 'docs <adaptor> [operation]',
   desc: 'Print help for an adaptor function. You can use short-hand for adaptor names (ie, common instead of @openfn/language-common)',
   handler: (argv: Arguments<Opts>) => {
     argv.command = 'docs';

--- a/packages/cli/src/docs/handler.ts
+++ b/packages/cli/src/docs/handler.ts
@@ -17,7 +17,18 @@ ${fn.description}
 
 ### Usage Examples
 
-${fn.examples.length ? fn.examples.map((eg) => eg).join('\n\n') : 'None'}
+${
+  fn.examples.length
+    ? fn.examples
+        .map(({ code, caption }) => {
+          if (caption) {
+            return `${caption}:\n${code}`;
+          }
+          return code;
+        })
+        .join('\n\n')
+    : 'None'
+}
 
 ### API Reference
 

--- a/packages/cli/src/docs/handler.ts
+++ b/packages/cli/src/docs/handler.ts
@@ -4,12 +4,15 @@ import docgen from '../docgen/handler';
 import { Opts } from '../commands';
 import { createNullLogger } from '../util/logger';
 import type { Logger } from '../util/logger';
-import type { FunctionDescription } from '@openfn/describe-package';
+import type {
+  FunctionDescription,
+  PackageDescription,
+} from '@openfn/describe-package';
 
 import { getNameAndVersion, getLatestVersion } from '@openfn/runtime';
 import expandAdaptors from '../util/expand-adaptors';
 
-const describe = (adaptorName: string, fn: FunctionDescription) => `## ${
+const describeFn = (adaptorName: string, fn: FunctionDescription) => `## ${
   fn.name
 }(${fn.parameters.map(({ name }) => name).join(',')})
 
@@ -36,6 +39,17 @@ https://docs.openfn.org/adaptors/packages/${adaptorName.replace(
   '@openfn/language-',
   ''
 )}-docs#${fn.name}
+`;
+
+const describeLib = (
+  adaptorName: string,
+  data: PackageDescription
+) => `## ${adaptorName} ${data.version}
+
+${data.functions
+  .map((fn) => `  ${fn.name}(${fn.parameters.map((p) => p.name).join(', ')})`)
+  .sort()
+  .join('\n')}
 `;
 
 const docsHandler = async (
@@ -71,12 +85,18 @@ const docsHandler = async (
     const source = await readFile(path, 'utf8');
     const data = JSON.parse(source);
 
-    const fn = data.functions.find(({ name }) => name === operation);
-    logger.debug('Operation schema:', fn);
-    logger.success(`Documentation for ${name}.${operation} v${version}:\n`);
+    let desc;
+    if (operation) {
+      const fn = data.functions.find(({ name }) => name === operation);
+      logger.debug('Operation schema:', fn);
+      logger.success(`Documentation for ${name}.${operation} v${version}:\n`);
 
-    // Generate a documentation string
-    const desc = describe(name, fn);
+      // Generate a documentation string
+      desc = describeFn(name, fn);
+    } else {
+      logger.debug('No operation provided, listing available operations');
+      desc = describeLib(name, data);
+    }
     // Log the description without any ceremony/meta stuff from the logger
     logger.print(desc);
 

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -456,39 +456,71 @@ test.serial('docs should print documention with full names', async (t) => {
   t.is(message, 'Done!');
 });
 
-test.serial('docs should print documention with shorthand names', async (t) => {
+test.serial('docs adaptor should print list operations', async (t) => {
   mock({
     '/repo/docs/@openfn/language-common@1.0.0.json': JSON.stringify({
       name: 'test',
+      version: '1.0.0',
       functions: [
         {
           name: 'fn',
-          parameters: [],
+          parameters: [{ name: 'a' }, { name: 'b' }],
           examples: [],
         },
       ],
     }),
   });
 
-  const opts = cmd.parse('docs common@1.0.0 fn') as Opts;
+  const opts = cmd.parse('docs common@1.0.0') as Opts;
   opts.repoDir = '/repo';
 
   await commandParser('', opts, logger);
-  const docs = logger._parse(logger._history[4]).message as string;
-  // match the signature
-  t.regex(docs, /\#\# fn\(\)/);
-  // Match usage examples
-  t.regex(docs, /\#\#\# Usage Examples/);
+  const docs = logger._parse(logger._history[3]).message as string;
   t.notRegex(docs, /\[object Object\]/);
-  t.regex(
-    docs,
-    /https:\/\/docs.openfn.org\/adaptors\/packages\/common-docs#fn/
-  );
+  t.notRegex(docs, /\#\#\# Usage Examples/);
+  t.regex(docs, /fn\(a, b\)/);
 
   const { message, level } = logger._parse(logger._last);
   t.is(level, 'success');
   t.is(message, 'Done!');
 });
+
+test.serial(
+  'docs adaptor + operation should print documention with shorthand names',
+  async (t) => {
+    mock({
+      '/repo/docs/@openfn/language-common@1.0.0.json': JSON.stringify({
+        name: 'test',
+        functions: [
+          {
+            name: 'fn',
+            parameters: [],
+            examples: [],
+          },
+        ],
+      }),
+    });
+
+    const opts = cmd.parse('docs common@1.0.0 fn') as Opts;
+    opts.repoDir = '/repo';
+
+    await commandParser('', opts, logger);
+    const docs = logger._parse(logger._history[4]).message as string;
+    // match the signature
+    t.regex(docs, /\#\# fn\(\)/);
+    // Match usage examples
+    t.regex(docs, /\#\#\# Usage Examples/);
+    t.notRegex(docs, /\[object Object\]/);
+    t.regex(
+      docs,
+      /https:\/\/docs.openfn.org\/adaptors\/packages\/common-docs#fn/
+    );
+
+    const { message, level } = logger._parse(logger._last);
+    t.is(level, 'success');
+    t.is(message, 'Done!');
+  }
+);
 
 // TODO - need to work out a way to test agaist stdout
 // should return to stdout

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -479,6 +479,7 @@ test.serial('docs should print documention with shorthand names', async (t) => {
   t.regex(docs, /\#\# fn\(\)/);
   // Match usage examples
   t.regex(docs, /\#\#\# Usage Examples/);
+  t.notRegex(docs, /\[object Object\]/);
   t.regex(
     docs,
     /https:\/\/docs.openfn.org\/adaptors\/packages\/common-docs#fn/

--- a/packages/describe-package/src/api.ts
+++ b/packages/describe-package/src/api.ts
@@ -40,7 +40,7 @@ export type FunctionDescription = {
 
 type ExampleDescription = {
   code: string;
-  cpation?: string;
+  caption?: string;
 };
 
 export type ParameterDescription = {


### PR DESCRIPTION
So `describe-package` changed how it handles examples in #127 and someone forgot to update the CLI to the new structure. So docs example would output [object Object]. 

This PR fixes this.

I've also sneaked in a fix for #133 because I was right in the zone.