### PR TITLE
Release: CLI  0.0.26  - Fix windows issues

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 0.0.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/compiler@0.0.23
+  - @openfn/runtime@0.0.16
+
 ## 0.0.25
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/compiler
 
+## 0.0.23
+
+### Patch Changes
+
+- Fix imports for windows
+
 ## 0.0.22
 
 ### Patch Changes

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/compiler",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Compiler and language tooling for openfn jobs.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -16,22 +16,22 @@ export const isPath = (pathOrCode: string) =>
 
 // Check if a path is a local file path (a relative specifier according to nodejs)
 export const isRelativeSpecifier = (specifier: string) =>
-  /^(\/|\.|~)/.test(specifier);
+  /^(\/|\.|~|\w\:\\)/.test(specifier);
 
 // Helper to load the exports of a given npm package
 // Can load from an unpkg specifier or a path to a local module
 export const preloadAdaptorExports = async (specifier: string) => {
   const project = new Project();
-
   let pkg;
   let types;
   // load the package from unpkg or the filesystem
   if (isRelativeSpecifier(specifier)) {
+    const prefix = process.platform == 'win32' ? 'file://' : '';
     // load locally
-    const pkgSrc = await readFile(`${specifier}/package.json`, 'utf8');
+    const pkgSrc = await readFile(`${prefix}${specifier}/package.json`, 'utf8');
     pkg = JSON.parse(pkgSrc);
     if (pkg.types) {
-      types = await readFile(`${specifier}/${pkg.types}`, 'utf8');
+      types = await readFile(`${prefix}${specifier}/${pkg.types}`, 'utf8');
     } else {
       // If there's no type information, we can safely return
       // TODO should we log a warning?

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -26,12 +26,11 @@ export const preloadAdaptorExports = async (specifier: string) => {
   let types;
   // load the package from unpkg or the filesystem
   if (isRelativeSpecifier(specifier)) {
-    const prefix = process.platform == 'win32' ? 'file://' : '';
     // load locally
-    const pkgSrc = await readFile(`${prefix}${specifier}/package.json`, 'utf8');
+    const pkgSrc = await readFile(`${specifier}/package.json`, 'utf8');
     pkg = JSON.parse(pkgSrc);
     if (pkg.types) {
-      types = await readFile(`${prefix}${specifier}/${pkg.types}`, 'utf8');
+      types = await readFile(`${specifier}/${pkg.types}`, 'utf8');
     } else {
       // If there's no type information, we can safely return
       // TODO should we log a warning?

--- a/packages/compiler/test/transforms/add-imports.test.ts
+++ b/packages/compiler/test/transforms/add-imports.test.ts
@@ -222,7 +222,7 @@ test('findAllDanglingIdentifiers: nested scoping', (t) => {
   t.falsy(result['y']);
 });
 
-test.only('add imports for a test module', async (t) => {
+test('add imports for a test module', async (t) => {
   const ast = b.program([
     b.expressionStatement(b.identifier('x')),
     b.expressionStatement(b.identifier('y')),

--- a/packages/compiler/test/transforms/add-imports.test.ts
+++ b/packages/compiler/test/transforms/add-imports.test.ts
@@ -222,7 +222,7 @@ test('findAllDanglingIdentifiers: nested scoping', (t) => {
   t.falsy(result['y']);
 });
 
-test('add imports for a test module', async (t) => {
+test.only('add imports for a test module', async (t) => {
   const ast = b.program([
     b.expressionStatement(b.identifier('x')),
     b.expressionStatement(b.identifier('y')),

--- a/packages/compiler/test/util/is-relative-specifier.test.ts
+++ b/packages/compiler/test/util/is-relative-specifier.test.ts
@@ -10,6 +10,7 @@ import { isRelativeSpecifier } from '../../src/util';
   '~/module',
   '.',
   '..',
+  'C:\\repo\\module', // windows absolute path
 ].forEach((path) => {
   test(`is a relative specifier: ${path}`, (t) => {
     t.truthy(isRelativeSpecifier(path));
@@ -23,6 +24,7 @@ import { isRelativeSpecifier } from '../../src/util';
   'namespace@module',
   'module@^3.2.1',
   '@namespace@module@=3.2.1',
+  'ab:\\repo\\module', // looks like a windows path, but is not!
 ].forEach((path) => {
   test(`is an absolute specifier: ${path}`, (t) => {
     t.falsy(isRelativeSpecifier(path));

--- a/packages/runtime-manager/CHANGELOG.md
+++ b/packages/runtime-manager/CHANGELOG.md
@@ -1,5 +1,13 @@
 # runtime-manager
 
+## 0.0.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/compiler@0.0.23
+  - @openfn/runtime@0.0.16
+
 ## 0.0.22
 
 ### Patch Changes

--- a/packages/runtime-manager/package.json
+++ b/packages/runtime-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime-manager",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "An example runtime manager service.",
   "main": "index.js",
   "type": "module",
@@ -15,7 +15,7 @@
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",
   "dependencies": {
-    "@openfn/compiler": "workspace:^0.0.22",
+    "@openfn/compiler": "workspace:^0.0.23",
     "@openfn/language-common": "2.0.0-rc3",
     "@openfn/logger": "workspace:*",
     "@openfn/runtime": "workspace:*",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/runtime
 
+## 0.0.16
+
+### Patch Changes
+
+- Fix imports for windows
+
 ## 0.0.15
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Job processing runtime.",
   "type": "module",
   "exports": {

--- a/packages/runtime/src/modules/linker.ts
+++ b/packages/runtime/src/modules/linker.ts
@@ -87,10 +87,11 @@ const linker: Linker = async (specifier, context, options = {}) => {
 // Loads a module as a general specifier or from a specific path
 const loadActualModule = async (specifier: string, options: LinkerOptions) => {
   const log = options.log || defaultLogger;
+  const prefix = process.platform == 'win32' ? 'file://' : '';
 
   // If the specifier is a path, just import it
   if (specifier.startsWith('/') && specifier.endsWith('.js')) {
-    return import(specifier);
+    return import(`${prefix}${specifier}`);
   }
 
   // Otherwise resolve the specifier to a path in the repo
@@ -116,7 +117,7 @@ const loadActualModule = async (specifier: string, options: LinkerOptions) => {
   if (path) {
     log.debug(`[linker] Loading module ${specifier} from ${path}`);
     try {
-      return import(path);
+      return import(`${prefix}${path}`);
     } catch (e) {
       log.debug(`[linker] Failed to load module ${specifier} from ${path}`);
       console.log(e);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,7 +202,7 @@ importers:
 
   packages/runtime-manager:
     specifiers:
-      '@openfn/compiler': workspace:^0.0.22
+      '@openfn/compiler': workspace:^0.0.23
       '@openfn/language-common': 2.0.0-rc3
       '@openfn/logger': workspace:*
       '@openfn/runtime': workspace:*


### PR DESCRIPTION
This PR:

* Fixes package imports for Windows
* Bumps verison numbers ready for release.

When `import`ing on Windows, it turns out we explicitly have to pass in `file://` as a prefix for local modules.

I don't think this was an issue before so maybe it's the node19 changes (ie node using node module resolution) which have instigated this.

## QA

To test this on Windows:

* Check out the pnpm
* `pnpm install`
* `pnpm -r build`
* `pnpm pack:local`
* `pack:local` will return an npm instal path - run it (basically `npm install -g dist/openfn-cli-0.0.26-local.tgz`)
* `openfn version` should report `0.0.16`
* Run a job `openfn job.js -ia http`