### PR TITLE
Ensure dist folder exists

### DIFF
--- a/build/ensure-dist.js
+++ b/build/ensure-dist.js
@@ -1,0 +1,4 @@
+const fs = require('node:fs');
+const path = require('path');
+
+fs.mkdirSync(path.resolve('dist'), { recursive: true });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean:local": "rimraf dist/**/*",
     "test": "pnpm -r --filter './packages/*' run test",
     "test:types": "pnpm -r --filter './packages/*' run test:types",
-    "pack": "pnpm -r run pack",
+    "pack": "node build/ensure-dist.js && pnpm -r run pack",
     "pack:local": "pnpm run pack && node ./build/pack-local.js",
     "export": "sh scripts/export.sh"
   },


### PR DESCRIPTION
Annoying little problem we just found in #154.

`pnpm pack` will FAIL if `--pack-destination` points to a missing directory. I think this is a `pnpm` issue because that seems very flaky to me.

Obviously we could just run `mkdir dist` before packing, but I'd like a cross-platform solution so ensure that builds work in Windows (very very useful for debugging windows issues). So I've written a tiny node script which does the same thing.

This isn't a very elegant solution @stuartc can you think of anything bettter?

## Repro steps

* Delete the `dist` folder in the repo root (if it exists)
* Run `pnpm -r pack`
* This should explode

On this branch it'll work. It should also work if `dist` already exists of course.

## Related issue

Fixes #154
