### PR TITLE
Describe-docs: Don't blow up if there isn't a common dependency

### DIFF
--- a/packages/describe-package/src/api.ts
+++ b/packages/describe-package/src/api.ts
@@ -67,27 +67,34 @@ export const describePackage = async (
     // (I don't expect this to be permanent)
 
     // First work out the correct version
-    const pkg = await fetchFile(`${specifier}/package.json`);
-    const commonVersion = JSON.parse(pkg).dependencies?.[
-      '@openfn/language-common'
-    ].replace('^', '');
+    const pkgStr = await fetchFile(`${specifier}/package.json`);
+    const pkg = JSON.parse(pkgStr);
 
-    // fetch it
-    const common = await fetchDTSListing(
-      `@openfn/language-common@${commonVersion}`
-    );
-    // Load it into the project
-    for await (const fileName of common) {
-      const f = await fetchFile(`@openfn/language-common${fileName}`);
-      // Flatten the paths or else there's trouble
-      // TODO need to better understand this at some stage
-      const relativeFileName = fileName.split('/').pop();
-      project.addTypeDefinition('@openfn/language-common', f, relativeFileName);
+    if (pkg.dependencies['@openfn/language-common']) {
+      const commonSpecifier = `@openfn/language-common@${pkg.dependencies[
+        '@openfn/language-common'
+      ].replace('^', '')}`;
+
+      // fetch that specific version
+      const common = await fetchDTSListing(commonSpecifier);
+      // Load it into the project
+      for await (const fileName of common) {
+        const f = await fetchFile(`${commonSpecifier}${fileName}`);
+        // Flatten the paths or else there's trouble
+        // TODO need to better understand this at some stage
+        const relativeFileName = fileName.split('/').pop();
+        project.addTypeDefinition(
+          '@openfn/language-common',
+          f,
+          relativeFileName
+        );
+      }
     }
   }
 
   // Now fetch the listings for the actual package
   const files = await fetchDTSListing(specifier);
+
   const functions: FunctionDescription[] = [];
   for await (const fileName of files) {
     // Exclude the beta file


### PR DESCRIPTION
When calling `describePackage` on a package without a dependency on `@openfn/language-common`, the function blows up. Which isn't very good, as old adaptors and non-adaptors fail to work.

This PR just relaxes that constraint a bit with some defensive code.

I also updated the fetch so that when looking up common's `d.ts`, it will use the specific version of common, not the latest. I seem to remember thinking about this a while ago and deciding it wasn't worth version-matching - but hey, I've just done it now, so I don't know what I was worried about before.

Closes #160 for now, although `beyonic@0.1.1` will still fail to load in Lightning. At least we can handle the case more gracefully now.

No unit tests because this package makes me sad. I need a week to re-write the whole thing properly. Even the example is out of date :(

I've tested against Lightning and it works fine there.