### PR TITLE
CLI: No default state

### DIFF
--- a/.changeset/red-cats-exercise.md
+++ b/.changeset/red-cats-exercise.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+CLI no longer attempts to load state.json by default

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -46,7 +46,7 @@ openfn path/to/job.js -ia adaptor-name
 
 You MUST specify which adaptor to use. Pass the `-i` flag to auto-install that adaptor (it's safe to do this redundantly).
 
-If output.json and state.json are not passed, the CLI will look for them next to the job.js file. You can pass a path to state by adding `-s path/to/state.json`, and output by passing `-o path/to/output.json`. You can use `-S` and `-O` to pass state through stdin and return the output through stdout.
+If output.json is not passed, the CLI will create an `output.json` next to the job file. You can pass a path to state by adding `-s path/to/state.json`, and output by passing `-o path/to/output.json`. You can use `-S` and `-O` to pass state through stdin and return the output through stdout.
 
 The CLI can auto-install language adaptors to its own privately maintained repo. Run `openfn repo list` to see where the repo is, and what's in it. Set the `OPENFN_REPO_DIR` env var to specify the repo folder. When autoinstalling, the CLI will check to see if a matching version is found in the repo.
 

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -63,10 +63,11 @@ const handlers = {
     printVersions(logger, opts),
 };
 
-export type SafeOpts = Required<Omit<Opts, 'log' | 'adaptor'>> & {
+export type SafeOpts = Required<Omit<Opts, 'log' | 'adaptor' | 'statePath'>> & {
   log: Record<string, LogLevel>;
   adaptor: string | boolean;
   monorepoPath?: string;
+  statePath?: string;
 };
 
 // Top level command parser

--- a/packages/cli/src/execute/execute.ts
+++ b/packages/cli/src/execute/execute.ts
@@ -3,7 +3,7 @@ import type { ModuleInfo, ModuleInfoMap } from '@openfn/runtime';
 import createLogger, { RUNTIME, JOB } from '../util/logger';
 import type { SafeOpts } from '../commands';
 
-export default (code: string, state: any, opts: SafeOpts): Promise<any> => {
+export default (code: string, state: any, opts: Omit<SafeOpts, 'jobPath'>): Promise<any> => {
   // TODO listen to runtime events and log them
   // events appeal because we don't have to pass two loggers into the runtime
   // we can just listen to runtime events and do the logging ourselves here

--- a/packages/cli/src/execute/load-state.ts
+++ b/packages/cli/src/execute/load-state.ts
@@ -18,18 +18,20 @@ export default async (opts: SafeOpts, log: Logger) => {
     }
   }
 
-  try {
-    const str = await fs.readFile(opts.statePath, 'utf8');
-    const json = JSON.parse(str);
-    log.success(`Loaded state from ${opts.statePath}`);
-    log.debug('state:', json);
-    return json;
-  } catch (e) {
-    log.warn(`Error loading state from ${opts.statePath}`);
-    log.warn(e);
+  if (opts.statePath) {
+    try {
+      const str = await fs.readFile(opts.statePath, 'utf8');
+      const json = JSON.parse(str);
+      log.success(`Loaded state from ${opts.statePath}`);
+      log.debug('state:', json);
+      return json;
+    } catch (e) {
+      log.warn(`Error loading state from ${opts.statePath}`);
+      log.warn(e);
+    }
   }
 
-  log.warn('Using default state { data: {}, configuration: {}');
+  log.info('No state provided - using default state { data: {}, configuration: {}');
   return {
     data: {},
     configuration: {},

--- a/packages/cli/src/execute/load-state.ts
+++ b/packages/cli/src/execute/load-state.ts
@@ -2,31 +2,34 @@ import fs from 'node:fs/promises';
 import type { Logger } from '@openfn/logger';
 import type { SafeOpts } from '../commands';
 
-export default async (opts: SafeOpts, log: Logger) => {
+export default async (
+  opts: Pick<SafeOpts, 'stateStdin' | 'statePath'>,
+  log: Logger) => {
+  const { stateStdin, statePath } = opts;
   log.debug('Load state...');
-  if (opts.stateStdin) {
+  if (stateStdin) {
     try {
-      const json = JSON.parse(opts.stateStdin);
+      const json = JSON.parse(stateStdin);
       log.success('Read state from stdin');
       log.debug('state:', json);
       return json;
     } catch (e) {
       log.error('Failed to load state from stdin');
-      log.error(opts.stateStdin);
+      log.error(stateStdin);
       log.error(e);
       process.exit(1);
     }
   }
 
-  if (opts.statePath) {
+  if (statePath) {
     try {
-      const str = await fs.readFile(opts.statePath, 'utf8');
+      const str = await fs.readFile(statePath, 'utf8');
       const json = JSON.parse(str);
-      log.success(`Loaded state from ${opts.statePath}`);
+      log.success(`Loaded state from ${statePath}`);
       log.debug('state:', json);
       return json;
     } catch (e) {
-      log.warn(`Error loading state from ${opts.statePath}`);
+      log.warn(`Error loading state from ${statePath}`);
       log.warn(e);
     }
   }

--- a/packages/cli/src/test/handler.ts
+++ b/packages/cli/src/test/handler.ts
@@ -4,7 +4,7 @@ import loadState from '../execute/load-state';
 import execute from '../execute/execute';
 import { CompilerOpts } from '../compile/compile';
 
-const sillyMessage = 'Calculating the answer to life, the universe, and eveything...';
+const sillyMessage = 'Calculating the answer to life, the universe, and everything...';
 
 const testHandler = async (options: CompilerOpts, logger: Logger) => {
   logger.log('Running test job...');

--- a/packages/cli/src/test/handler.ts
+++ b/packages/cli/src/test/handler.ts
@@ -13,7 +13,7 @@ const testHandler = async (options: CompilerOpts, logger: Logger) => {
   delete options.jobPath;
 
   if (!options.stateStdin) {
-    logger.debug('No state provided: use -S <number> to provide some state');
+    logger.warn('No state provided: try -S <number> to provide some state');
     options.stateStdin = '21';
   }
 

--- a/packages/cli/src/test/handler.ts
+++ b/packages/cli/src/test/handler.ts
@@ -13,7 +13,7 @@ const testHandler = async (options: CompilerOpts, logger: Logger) => {
   delete options.jobPath;
 
   if (!options.stateStdin) {
-    logger.warn('No state provided: try -S <number> to provide some state');
+    logger.debug('No state provided: try -S <number> to provide some state');
     options.stateStdin = '21';
   }
 

--- a/packages/cli/src/util/ensure-opts.ts
+++ b/packages/cli/src/util/ensure-opts.ts
@@ -112,7 +112,6 @@ export default function ensureOpts(
   } else {
     set('jobPath', `${baseDir}/job.js`);
   }
-  set('statePath', `${baseDir}/state.json`);
 
   if (!opts.outputStdout) {
     set(

--- a/packages/cli/src/util/ensure-opts.ts
+++ b/packages/cli/src/util/ensure-opts.ts
@@ -94,6 +94,7 @@ export default function ensureOpts(
     specifier: opts.specifier,
     stateStdin: opts.stateStdin,
     strictOutput: opts.strictOutput ?? true,
+    statePath: opts.statePath,
     timeout: opts.timeout,
   } as SafeOpts;
   const set = (key: keyof Opts, value: string) => {

--- a/packages/cli/test/util/ensure-opts.test.ts
+++ b/packages/cli/test/util/ensure-opts.test.ts
@@ -18,13 +18,12 @@ test('preserve the command name', (t) => {
   t.assert(opts.command === 'compile');
 });
 
-test('set job, state and output from a base path', (t) => {
+test('set job and state from a base path', (t) => {
   const initialOpts = {} as Opts;
 
   const opts = ensureOpts('a', initialOpts);
 
   t.assert(opts.jobPath === 'a/job.js');
-  t.assert(opts.statePath === 'a/state.json');
   t.assert(opts.outputPath === 'a/output.json');
 });
 
@@ -34,16 +33,14 @@ test("default base path to '.'", (t) => {
   const opts = ensureOpts(undefined, initialOpts);
 
   t.assert(opts.jobPath === './job.js');
-  t.assert(opts.statePath === './state.json');
   t.assert(opts.outputPath === './output.json');
 });
 
-test('should set state and output from a base path with an extension', (t) => {
+test('should output from a base path with an extension', (t) => {
   const initialOpts = {} as Opts;
 
   const opts = ensureOpts('a/x.js', initialOpts);
   t.assert(opts.jobPath === 'a/x.js');
-  t.assert(opts.statePath === 'a/state.json');
   t.assert(opts.outputPath === 'a/output.json');
 });
 
@@ -54,7 +51,6 @@ test('should not set outputPath if stdout is requested', (t) => {
 
   const opts = ensureOpts('a/x.js', initialOpts);
   t.assert(opts.jobPath === 'a/x.js');
-  t.assert(opts.statePath === 'a/state.json');
   t.falsy(opts.outputPath);
 });
 
@@ -79,7 +75,6 @@ test("should use the user's output path", (t) => {
   const opts = ensureOpts('a', initialOpts);
   t.assert(opts.jobPath === 'a/job.js');
   t.assert(opts.outputPath === outputPath);
-  t.assert(opts.statePath === 'a/state.json');
 });
 
 test('should not append @openfn to adaptors if already prefixed', (t) => {


### PR DESCRIPTION
This PR stops defaulting the state location to state.json.

If users want to load some state, they must now pass a path explicitly.

This has a few benefits:
* It's safer because we'll never accidentally suck in a state.json which prod credentials in it
* There are few errors about state not being defined if the user intentionally doesn't pass state

This doesn't affect lightning as state is always passed.

Docs and the new CLI tutorial will need to be updated. 

## Related issue

Closes #171 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
