### PR TITLE
Fix adaptor version paths

### DIFF
--- a/.changeset/nervous-fireants-check.md
+++ b/.changeset/nervous-fireants-check.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Support adaptor paths in version readout

--- a/.changeset/red-dolls-admire.md
+++ b/.changeset/red-dolls-admire.md
@@ -1,0 +1,5 @@
+---
+'@openfn/logger': patch
+---
+
+export extra typings

--- a/packages/cli/src/util/print-versions.ts
+++ b/packages/cli/src/util/print-versions.ts
@@ -25,7 +25,7 @@ const printVersions = async (
   logger: Logger,
   options: Partial<Pick<SafeOpts, 'adaptors' | 'logJson'>> = {}
   ) => {
-  const { adaptors } = options;
+  const { adaptors, logJson } = options;
   let adaptor = '';
   if (adaptors && adaptors.length) {
     adaptor = adaptors[0];
@@ -65,7 +65,7 @@ const printVersions = async (
   }
 
   let output: any;
-  if (options.logJson) {
+  if (logJson) {
     output = {
       versions: {
         'node.js': process.version.substring(1),
@@ -75,10 +75,7 @@ const printVersions = async (
       },
     };
     if (adaptorName) {
-      output.versions.adaptor = {
-        name: adaptorName,
-        version: adaptorVersion,
-      };
+      output.versions[adaptorName] = adaptorVersion;
     }
   } else {
     const adaptorVersionString = adaptorName

--- a/packages/cli/src/util/print-versions.ts
+++ b/packages/cli/src/util/print-versions.ts
@@ -5,7 +5,7 @@ import { Logger } from './logger';
 import { mainSymbols } from 'figures';
 import { SafeOpts } from '../commands';
 
-const NODE = 'nodejs';
+const NODE = 'node.js';
 const CLI = 'cli';
 const RUNTIME = 'runtime';
 const COMPILER = 'compiler';

--- a/packages/cli/test/util/print-versions.test.ts
+++ b/packages/cli/test/util/print-versions.test.ts
@@ -1,6 +1,10 @@
 import { createMockLogger } from '@openfn/logger';
 import test from 'ava';
+import mock from 'mock-fs';
+import path from 'node:path';
 import printVersions from '../../src/util/print-versions';
+
+const root = path.resolve('package.json')
 
 test('print versions for node, cli, runtime and compiler', async (t) => {
   const logger = createMockLogger('', { level: 'info' });
@@ -28,7 +32,7 @@ test('print versions for node, cli, runtime, compiler and adaptor', async (t) =>
   t.regex(message, /cli/);
   t.regex(message, /runtime/);
   t.regex(message, /compiler/);
-  t.regex(message, /adaptor http .+ latest/);
+  t.regex(message, /http .+ latest/);
 });
 
 test('print versions for node, cli, runtime, compiler and adaptor with version', async (t) => {
@@ -43,7 +47,7 @@ test('print versions for node, cli, runtime, compiler and adaptor with version',
   t.regex(message, /cli/);
   t.regex(message, /runtime/);
   t.regex(message, /compiler/);
-  t.regex(message, /adaptor http .+ 1234/);
+  t.regex(message, /http .+ 1234/);
 });
 
 test('print versions for node, cli, runtime, compiler and long-form adaptor', async (t) => {
@@ -53,7 +57,7 @@ test('print versions for node, cli, runtime, compiler and long-form adaptor', as
   const last = logger._parse(logger._last);
   const message = last.message as string;
 
-  t.regex(message, /adaptor http .+ latest/);
+  t.regex(message, /@openfn\/language-http .+ latest/);
 });
 
 test('print versions for node, cli, runtime, compiler and long-form adaptor with version', async (t) => {
@@ -63,5 +67,20 @@ test('print versions for node, cli, runtime, compiler and long-form adaptor with
   const last = logger._parse(logger._last);
   const message = last.message as string;
 
-  t.regex(message, /adaptor http .+ 1234/);
+  t.regex(message, /@openfn\/language-http .+ 1234/);
+});
+
+test('print version of adaptor with path', async (t) => {
+  mock({
+    '/repo/http/package.json': '{ "version": "1.0.0" }',
+    [root]: mock.load(root, {}) 
+  })
+
+  const logger = createMockLogger('', { level: 'info' });
+  await printVersions(logger, { adaptors: ['@openfn/language-http=/repo/http'] });
+
+  const last = logger._parse(logger._last);
+  const message = last.message as string;
+
+  t.regex(message,  /@openfn\/language-http(.+)1\.0\.0/);
 });

--- a/packages/cli/test/util/print-versions.test.ts
+++ b/packages/cli/test/util/print-versions.test.ts
@@ -85,13 +85,12 @@ test('print version of adaptor with path', async (t) => {
   t.regex(message,  /@openfn\/language-http(.+)1\.0\.0/);
 });
 
-test('json output', async (t) => {
+test.only('json output', async (t) => {
   const logger = createMockLogger('', { level: 'info', json: true });
-  await printVersions(logger, { adaptors: ['http'] });
+  await printVersions(logger, { adaptors: ['http'], logJson: true });
 
-  const last = logger._last as JSONLog;
+  const last = JSON.parse(logger._last) as JSONLog;
   t.is(last.level, 'info');
-  t.is(last.name, 'CLI');
 
   const [{ versions }] = last.message;
   t.truthy(versions['node.js']);

--- a/packages/cli/test/util/print-versions.test.ts
+++ b/packages/cli/test/util/print-versions.test.ts
@@ -84,3 +84,5 @@ test('print version of adaptor with path', async (t) => {
 
   t.regex(message,  /@openfn\/language-http(.+)1\.0\.0/);
 });
+
+// TODO quick test of json output

--- a/packages/cli/test/util/print-versions.test.ts
+++ b/packages/cli/test/util/print-versions.test.ts
@@ -1,4 +1,4 @@
-import { createMockLogger } from '@openfn/logger';
+import { createMockLogger, JSONLog } from '@openfn/logger';
 import test from 'ava';
 import mock from 'mock-fs';
 import path from 'node:path';
@@ -85,4 +85,18 @@ test('print version of adaptor with path', async (t) => {
   t.regex(message,  /@openfn\/language-http(.+)1\.0\.0/);
 });
 
-// TODO quick test of json output
+test('json output', async (t) => {
+  const logger = createMockLogger('', { level: 'info', json: true });
+  await printVersions(logger, { adaptors: ['http'] });
+
+  const last = logger._last as JSONLog;
+  t.is(last.level, 'info');
+  t.is(last.name, 'CLI');
+
+  const [{ versions }] = last.message;
+  t.truthy(versions['node.js']);
+  t.truthy(versions['cli']);
+  t.truthy(versions['runtime']);
+  t.truthy(versions['compiler']);
+  t.truthy(versions['http']);
+})

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -9,5 +9,5 @@ export const defaultLogger = createLogger();
 
 export default createLogger;
 
-export type { Logger } from './logger';
+export type { Logger, JSONLog, StringLog } from './logger';
 export type { LogOptions, LogLevel } from './options';


### PR DESCRIPTION
When running a job, we print out version details of a few choice modules, including the adaptor.

We deliberately kept this simple to avoid doing lots of heavy module resolution early in the process (and to avoid duplication of critical and complex functionality). 

But we missed something!

When a path is passed for an adaptor, we can't just echo this back to the user, like we do with `-a http@1.0.0`.

So in this PR, we now follow the path and try to load the version from the package.json we find there. If this is a problem, we just report `unknown`.

This will fix version number reporting in Lightning (quite important).

I've also lightly tweaked the presentation of this stuff to be a little nicer.

## Related issue

Fixes #173 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
