### PR TITLE
Fix version logs again

### DIFF
--- a/.changeset/witty-rules-admire.md
+++ b/.changeset/witty-rules-admire.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Fix adaptor version string in lightning

--- a/packages/cli/src/util/print-versions.ts
+++ b/packages/cli/src/util/print-versions.ts
@@ -31,17 +31,16 @@ const printVersions = async (
   if (adaptors && adaptors.length) {
     adaptor = adaptors[0];
   }
-  logger.debug('> ADAPTOR:', adaptor)
 
   let adaptorVersion;
   let adaptorName = '';
   if (adaptor) {
-    const { name, version } = getNameAndVersion(adaptor);
-    if (name.match('=')) {
-      const [namePart, pathPart] = name.split('=');
+    if (adaptor.match('=')) {
+      const [namePart, pathPart] = adaptor.split('=');
       adaptorVersion = loadVersionFromPath(pathPart);
-      adaptorName = namePart;
+      adaptorName = getNameAndVersion(namePart).name;
     } else {
+      const { name, version } = getNameAndVersion(adaptor);
       adaptorName = name;
       adaptorVersion = version || 'latest';
     }

--- a/packages/cli/src/util/print-versions.ts
+++ b/packages/cli/src/util/print-versions.ts
@@ -17,7 +17,6 @@ const loadVersionFromPath = (adaptorPath: string) => {
     const pkg = JSON.parse(readFileSync(path.resolve(adaptorPath, 'package.json'), 'utf8'));
     return pkg.version
   } catch(e) {
-    console.log(e)
     return 'unknown';
   }
 }

--- a/packages/cli/src/util/print-versions.ts
+++ b/packages/cli/src/util/print-versions.ts
@@ -54,7 +54,6 @@ const printVersions = async (
     COMPILER,
     adaptorName,
   ].map(s => s.length));
-  logger.debug('> LONGEST:', longest)
   
   // Prefix and pad version numbers
   const prefix = (str: string) =>

--- a/packages/cli/src/util/print-versions.ts
+++ b/packages/cli/src/util/print-versions.ts
@@ -17,6 +17,7 @@ const loadVersionFromPath = (adaptorPath: string) => {
     const pkg = JSON.parse(readFileSync(path.resolve(adaptorPath, 'package.json'), 'utf8'));
     return pkg.version
   } catch(e) {
+    console.log(e)
     return 'unknown';
   }
 }
@@ -30,28 +31,10 @@ const printVersions = async (
   if (adaptors && adaptors.length) {
     adaptor = adaptors[0];
   }
+  logger.debug('> ADAPTOR:', adaptor)
 
-  // Work out the longest label
-  const longest = Math.max(...[
-    NODE,
-    CLI,
-    RUNTIME,
-    COMPILER,
-    adaptor,
-  ].map(s => s.length));
-  
-  // Prefix and pad version numbers
-  const prefix = (str: string) =>
-    `         ${t} ${str.padEnd(longest + 4, ' ')}`;
-
-  const pkg = await import('../../package.json', { assert: { type: 'json' } });
-  const { version, dependencies } = pkg.default;
-  
-  const compilerVersion = dependencies['@openfn/compiler'];
-  const runtimeVersion = dependencies['@openfn/runtime'];
-  
   let adaptorVersion;
-  let adaptorName;
+  let adaptorName = '';
   if (adaptor) {
     const { name, version } = getNameAndVersion(adaptor);
     if (name.match('=')) {
@@ -63,6 +46,27 @@ const printVersions = async (
       adaptorVersion = version || 'latest';
     }
   }
+
+  // Work out the longest label
+  const longest = Math.max(...[
+    NODE,
+    CLI,
+    RUNTIME,
+    COMPILER,
+    adaptorName,
+  ].map(s => s.length));
+  logger.debug('> LONGEST:', longest)
+  
+  // Prefix and pad version numbers
+  const prefix = (str: string) =>
+    `         ${t} ${str.padEnd(longest + 4, ' ')}`;
+
+  const pkg = await import('../../package.json', { assert: { type: 'json' } });
+  const { version, dependencies } = pkg.default;
+  
+  const compilerVersion = dependencies['@openfn/compiler'];
+  const runtimeVersion = dependencies['@openfn/runtime'];
+  
 
   let output: any;
   if (logJson) {

--- a/packages/cli/test/util/print-versions.test.ts
+++ b/packages/cli/test/util/print-versions.test.ts
@@ -85,7 +85,7 @@ test('print version of adaptor with path', async (t) => {
   t.regex(message,  /@openfn\/language-http(.+)1\.0\.0/);
 });
 
-test.only('json output', async (t) => {
+test('json output', async (t) => {
   const logger = createMockLogger('', { level: 'info', json: true });
   await printVersions(logger, { adaptors: ['http'], logJson: true });
 

--- a/packages/cli/test/util/print-versions.test.ts
+++ b/packages/cli/test/util/print-versions.test.ts
@@ -85,6 +85,21 @@ test('print version of adaptor with path', async (t) => {
   t.regex(message,  /@openfn\/language-http(.+)1\.0\.0/);
 });
 
+test('print version of adaptor with path and @', async (t) => {
+  mock({
+    '/repo/node_modules/@openfn/http/package.json': '{ "version": "1.0.0" }',
+    [root]: mock.load(root, {}) 
+  })
+
+  const logger = createMockLogger('', { level: 'info' });
+  await printVersions(logger, { adaptors: ['@openfn/language-http=/repo/node_modules/@openfn/http'] });
+
+  const last = logger._parse(logger._last);
+  const message = last.message as string;
+
+  t.regex(message,  /@openfn\/language-http(.+)1\.0\.0/);
+});
+
 test('json output', async (t) => {
   const logger = createMockLogger('', { level: 'info', json: true });
   await printVersions(logger, { adaptors: ['http'], logJson: true });


### PR DESCRIPTION
The previous attempt to fix #173, in which adaptor versions are not printed in lightning, failed for two reasons:

1) We calculated the length of the adaptor name wrongly, resulting in messed up formatting
2) If the path happened to have an `@`  in it (ie, `node_modules/@openfn`), the path was mis-calculated and the version was reported as unknown.

Both issues should now be fixed.

Here's my local lightning with this fix in place:

![image](https://user-images.githubusercontent.com/7052509/217805645-c971c351-ae0c-4516-bb98-5f9ef9925314.png)

## Related issue

This actually fixes #173. Promise

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
