### PR TITLE
CLI: Metadata command

### DIFF
--- a/.changeset/two-zebras-work.md
+++ b/.changeset/two-zebras-work.md
@@ -1,0 +1,5 @@
+---
+'@openfn/logger': patch
+---
+
+print should log as json

--- a/integration-tests/cli/README.md
+++ b/integration-tests/cli/README.md
@@ -6,7 +6,7 @@ The test suite is designed to be run in CircleCI, but can run locally or in a lo
 
 ## Running Tests
 
-During developingment, you can run the unit tests against a local build (ie, `packages/cli/dist`):
+During development, you can run the unit tests against a local build (ie, `packages/cli/dist`):
 
 `pnpm test:dev`
 

--- a/integration-tests/cli/modules/test/index.js
+++ b/integration-tests/cli/modules/test/index.js
@@ -1,0 +1,7 @@
+export const metadata = async () => {
+  return {
+    name: 'test',
+    type: 'model',
+    children: [],
+  };
+};

--- a/integration-tests/cli/modules/test/package.json
+++ b/integration-tests/cli/modules/test/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@openfn/language-test",
+  "version": "0.0.1",
+  "type": "module",
+  "module": "index.js",
+  "private": true
+}

--- a/integration-tests/cli/package.json
+++ b/integration-tests/cli/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@types/node": "^18.7.18",
     "ava": "5.1.0",
+    "date-fns": "^2.29.3",
     "rimraf": "^3.0.2",
     "ts-node": "10.8.1",
     "tslib": "^2.4.0",

--- a/integration-tests/cli/src/run.ts
+++ b/integration-tests/cli/src/run.ts
@@ -3,23 +3,33 @@ import * as path from 'node:path';
 
 const isProd = process.env.NODE_ENV === 'production';
 
+const options = {
+  env: {
+    ...process.env,
+    OPENFN_REPO_DIR: path.resolve('repo'),
+  },
+};
+
+const mapOpenFnPath = (cmd) => {
+  if (!isProd) {
+    return cmd.replace(/^openfn/, 'pnpm -C ../../packages/cli openfn');
+  }
+  return cmd;
+};
+
 const run = async (
   cmd: string
 ): Promise<{ stdout: string; stderr?: string }> => {
-  if (!isProd) {
-    cmd = cmd.replace(/^openfn/, 'pnpm -C ../../packages/cli openfn');
-  }
   return new Promise((resolve) => {
-    const options = {
-      env: {
-        ...process.env,
-        OPENFN_REPO_DIR: path.resolve('repo'),
-      },
-    };
-    exec(cmd, options, (err, stdout, stderr) => {
+    exec(mapOpenFnPath(cmd), options, (err, stdout, stderr) => {
       resolve({ stdout, stderr });
     });
   });
 };
+
+export const clean = async () =>
+  new Promise<void>((resolve) => {
+    exec(mapOpenFnPath('openfn repo clean -f'), options, () => resolve());
+  });
 
 export default run;

--- a/integration-tests/cli/test/execute.test.ts
+++ b/integration-tests/cli/test/execute.test.ts
@@ -3,6 +3,7 @@ import { fstat, readFileSync, writeFileSync } from 'node:fs';
 import { rm, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import run from '../src/run';
+import { getJSON } from './util';
 
 const jobsPath = path.resolve('jobs');
 const tmpPath = path.resolve('tmp');
@@ -23,18 +24,10 @@ test.afterEach(async () => {
   } catch (e) {}
 });
 
-const getOutput = (pathToJson?: string) => {
-  if (!pathToJson) {
-    pathToJson = path.resolve('jobs', 'output.json');
-  }
-  const data = readFileSync(pathToJson, 'utf8');
-  return JSON.parse(data);
-};
-
 test.serial(`openfn ${jobsPath}/simple.js -ia common`, async (t) => {
   await run(t.title);
 
-  const out = getOutput();
+  const out = getJSON();
   t.is(out, 42);
 });
 
@@ -44,7 +37,7 @@ test.serial(
   async (t) => {
     await run(t.title);
 
-    const out = getOutput();
+    const out = getJSON();
     t.is(out, 42);
   }
 );
@@ -54,7 +47,7 @@ test.serial(
   async (t) => {
     await run(t.title);
 
-    const out = getOutput(`${tmpPath}/o.json`);
+    const out = getJSON(`${tmpPath}/o.json`);
     t.is(out, 42);
   }
 );
@@ -62,7 +55,7 @@ test.serial(
 test.serial(`openfn ${jobsPath}/simple.js -a common -O`, async (t) => {
   const { stdout } = await run(t.title);
 
-  await t.throws(() => getOutput());
+  await t.throws(() => getJSON());
   t.regex(stdout, /Result:/);
   t.regex(stdout, /42/);
 });
@@ -73,7 +66,7 @@ test.serial(
     await writeFileSync(`${tmpPath}/state.json`, '{ "data": 2 }');
     await run(t.title);
 
-    const out = getOutput();
+    const out = getJSON();
     t.is(out, 4);
   }
 );
@@ -83,7 +76,7 @@ test.serial(
   async (t) => {
     await run(t.title);
 
-    const out = getOutput();
+    const out = getJSON();
     t.is(out, 12);
   }
 );
@@ -93,7 +86,7 @@ test.serial(
   async (t) => {
     await run(t.title);
 
-    const out = getOutput();
+    const out = getJSON();
     t.truthy(out.data.value);
     t.regex(out.data.value, /chuck norris/i);
   }

--- a/integration-tests/cli/test/metadata.test.ts
+++ b/integration-tests/cli/test/metadata.test.ts
@@ -1,0 +1,28 @@
+import test from 'ava';
+import path from 'node:path';
+
+import run from '../src/run';
+import { getJSON } from './util';
+
+const state = '{ \\"configuration\\": { \\"url\\": \\"x\\" } }';
+const modulePath = path.resolve('modules/test/index.js'); // TODO need to build more leniency into this path
+test.serial(
+  `openfn metadata -S "${state}" -a test=${modulePath}`,
+  async (t) => {
+    const { stdout, stderr } = await run(t.title);
+
+    t.regex(stdout, /Generating metadata/);
+    t.regex(stdout, /Read state from stdin/);
+
+    const output = stdout.split('\n');
+    output.pop();
+    const lastLine = output.pop();
+    t.regex(lastLine, /(repo\/meta\/)*(\.json)/);
+
+    const metadata = getJSON(lastLine);
+    t.is(metadata.name, 'test');
+    t.is(metadata.type, 'model');
+  }
+);
+
+// TODO second load should come from cache

--- a/integration-tests/cli/test/metadata.test.ts
+++ b/integration-tests/cli/test/metadata.test.ts
@@ -1,25 +1,36 @@
 import test from 'ava';
 import path from 'node:path';
+import { exec } from 'node:child_process';
 import { differenceInMinutes } from 'date-fns';
-import run from '../src/run';
-import { getJSON } from './util';
+
+import run, { clean } from '../src/run';
+import { extractLogs, getJSON } from './util';
 
 const state = '{ \\"configuration\\": { \\"url\\": \\"x\\" } }';
 const modulePath = path.resolve('modules/test/index.js'); // TODO need to build more leniency into this path
+
+let lastCreated: Date;
+
+// For local dev, ensure the repo is clear
+test.before(async () => {
+  await clean();
+});
+
+// Generate metadata
 test.serial(
-  `openfn metadata -S "${state}" -a test=${modulePath}`,
+  `openfn metadata -S "${state}" -a test=${modulePath} --log-json --log info`,
   async (t) => {
     const { stdout, stderr } = await run(t.title);
 
     t.regex(stdout, /Generating metadata/);
-    t.regex(stdout, /Read state from stdin/);
+    t.regex(stdout, /Metadata function found. Generating metadata/);
+    t.notRegex(stdout, /Returning metadata from cache/);
 
-    const output = stdout.split('\n');
-    output.pop();
-    const lastLine = output.pop();
-    t.regex(lastLine, /(repo\/meta\/)*(\.json)/);
+    const logJson = extractLogs(stdout);
+    const [outputPath] = logJson.at(-1).message;
+    t.regex(outputPath, /(repo\/meta\/)*(\.json)/);
 
-    const metadata = getJSON(lastLine);
+    const metadata = getJSON(outputPath);
     t.is(metadata.name, 'test');
     t.is(metadata.type, 'model');
 
@@ -28,7 +39,51 @@ test.serial(
     // within seconds of the current date.
     // We'll use a minute to give us plenty of leeway
     t.assert(differenceInMinutes(new Date(metadata.created), new Date()) < 1);
+
+    // This affects the next test
+    lastCreated = metadata.created;
   }
 );
 
-// TODO second load should come from cache
+// return metadata from cache
+test.serial(
+  `openfn metadata -S "${state}" --adaptor test=${modulePath} --log-json --log info`,
+  async (t) => {
+    const { stdout, stderr } = await run(t.title);
+    t.regex(stdout, /Generating metadata/);
+    t.notRegex(stdout, /Metadata function found. Generating metadata/);
+    t.regex(stdout, /Returning metadata from cache/);
+
+    const logJson = extractLogs(stdout);
+    const [outputPath] = logJson.at(-1).message;
+
+    const metadata = getJSON(outputPath);
+    t.is(metadata.name, 'test');
+    t.is(metadata.type, 'model');
+
+    // timestamp should be the same as before
+    t.is(metadata.created, lastCreated);
+  }
+);
+
+// Force regeneration
+test.serial(
+  `openfn metadata -S "${state}" --a test=${modulePath} -f --log-json --log info`,
+  async (t) => {
+    const { stdout, stderr } = await run(t.title);
+
+    t.regex(stdout, /Generating metadata/);
+    t.regex(stdout, /Metadata function found. Generating metadata/);
+    t.notRegex(stdout, /Returning metadata from cache/);
+
+    const logJson = extractLogs(stdout);
+    const [outputPath] = logJson.at(-1).message;
+    const metadata = getJSON(outputPath);
+    t.is(metadata.name, 'test');
+    t.is(metadata.type, 'model');
+
+    // timestamp should have changed
+    t.not(metadata.created, lastCreated);
+    t.assert(differenceInMinutes(new Date(metadata.created), new Date()) < 1);
+  }
+);

--- a/integration-tests/cli/test/metadata.test.ts
+++ b/integration-tests/cli/test/metadata.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import path from 'node:path';
-
+import { differenceInMinutes } from 'date-fns';
 import run from '../src/run';
 import { getJSON } from './util';
 
@@ -22,6 +22,12 @@ test.serial(
     const metadata = getJSON(lastLine);
     t.is(metadata.name, 'test');
     t.is(metadata.type, 'model');
+
+    // Check the created timestamp
+    // As this is added at the very end, the created timestamp should be
+    // within seconds of the current date.
+    // We'll use a minute to give us plenty of leeway
+    t.assert(differenceInMinutes(new Date(metadata.created), new Date()) < 1);
   }
 );
 

--- a/integration-tests/cli/test/util.ts
+++ b/integration-tests/cli/test/util.ts
@@ -8,3 +8,9 @@ export const getJSON = (pathToJson?: string) => {
   const data = readFileSync(pathToJson, 'utf8');
   return JSON.parse(data);
 };
+
+export const extractLogs = (jsonLogString: string) =>
+  jsonLogString
+    .split(/\n/)
+    .filter((j) => j.startsWith('{'))
+    .map((j) => JSON.parse(j));

--- a/integration-tests/cli/test/util.ts
+++ b/integration-tests/cli/test/util.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export const getJSON = (pathToJson?: string) => {
+  if (!pathToJson) {
+    pathToJson = path.resolve('jobs', 'output.json');
+  }
+  const data = readFileSync(pathToJson, 'utf8');
+  return JSON.parse(data);
+};

--- a/integration-tests/cli/tsconfig.json
+++ b/integration-tests/cli/tsconfig.json
@@ -3,6 +3,7 @@
     "experimentalSpecifierResolution": "node"
   },
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "module": "es2020",
     "moduleResolution": "node",
     "allowJs": true,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,6 +7,7 @@ import compileCommand from './compile/command';
 import testCommand from './test/command';
 import docgenCommand from './docgen/command';
 import docsCommand from './docs/command';
+import metadataCommand from './metadata/command';
 import { Opts } from './commands';
 
 export const cmd = yargs(hideBin(process.argv))
@@ -16,6 +17,7 @@ export const cmd = yargs(hideBin(process.argv))
   .command(repoCommand)
   .command(testCommand)
   .command(docsCommand)
+  .command(metadataCommand)
   .command(docgenCommand)
   // Common options
   .option('log', {

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -5,6 +5,7 @@ import compile from './compile/handler';
 import test from './test/handler';
 import docgen from './docgen/handler';
 import docs from './docs/handler';
+import metadata from './metadata/handler';
 import { clean, install, pwd, list } from './repo/handler';
 import expandAdaptors from './util/expand-adaptors';
 import useAdaptorsRepo from './util/use-adaptors-repo';
@@ -55,6 +56,7 @@ const handlers = {
   test,
   docgen,
   docs,
+  metadata,
   ['repo-clean']: clean,
   ['repo-install']: install,
   ['repo-pwd']: pwd,

--- a/packages/cli/src/metadata/cache.ts
+++ b/packages/cli/src/metadata/cache.ts
@@ -1,0 +1,32 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { writeFile, mkdir } from 'node:fs/promises';
+
+const getPath = (repoDir: string, key: string) => `${repoDir}/meta/${key}.json`;
+
+// TODO should we sort keys so that equivalent objects generate the same key?
+const generateKey = (config: any) =>
+  createHash('sha256').update(JSON.stringify(config)).digest('hex');
+
+const get = (repoPath: string, key: string) => {
+  try {
+    const data = readFileSync(getPath(repoPath, key));
+    const json = JSON.parse(data);
+    return json;
+  } catch (e) {
+    return null;
+  }
+};
+
+// lock the cache to prevent another process generating
+// this is very similar to how docgen works
+const lock = async (repoPath: string, key: string) => {};
+
+const set = async (repoPath: string, key: string, data: any) => {
+  const fullPath = getPath(repoPath, key);
+  await mkdir(path.dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, JSON.stringify(data));
+};
+
+export default { get, set, generateKey, getPath };

--- a/packages/cli/src/metadata/command.ts
+++ b/packages/cli/src/metadata/command.ts
@@ -1,0 +1,39 @@
+import yargs, { Arguments } from 'yargs';
+import { Opts } from '../commands';
+
+export default {
+  command: 'metadata',
+  desc: 'Generate metadata for an adaptor config',
+  handler: (argv: Arguments<Opts>) => {
+    argv.command = 'metadata';
+  },
+  builder: (yargs: yargs.Argv) =>
+    yargs
+      .option('state-path', {
+        alias: 's',
+        description: 'Path to the state file',
+      })
+      .option('state-stdin', {
+        alias: 'S',
+        description: 'Read state from stdin (instead of a file)',
+      })
+      .option('adaptors', {
+        // TODO I have to map this to adaptors to get it to map properly
+        alias: ['a'],
+        array: true,
+        description:
+          'A language adaptor to use for the job. Short-form names are allowed. Can include an explicit path to a local adaptor build.',
+      })
+      // TODO how can I make these more re-usable?
+      // Maybea  big list of options in one file, and each command just imports the one it wants?
+      .option('use-adaptors-monorepo', {
+        alias: 'm',
+        boolean: true,
+        description:
+          'Load adaptors from the monorepo. The OPENFN_ADAPTORS_REPO env var must be set to a valid path',
+      })
+      .example(
+        'metadata -a salesforce -s tmp/state.json',
+        'Generate salesforce metadata from config in state.json'
+      ),
+} as yargs.CommandModule<{}>;

--- a/packages/cli/src/metadata/command.ts
+++ b/packages/cli/src/metadata/command.ts
@@ -17,6 +17,10 @@ export default {
         alias: 'S',
         description: 'Read state from stdin (instead of a file)',
       })
+      .option('force', {
+        alias: 'f',
+        description: 'Force generation (ignore the cache)',
+      })
       .option('adaptors', {
         // TODO I have to map this to adaptors to get it to map properly
         alias: ['a'],
@@ -24,8 +28,6 @@ export default {
         description:
           'A language adaptor to use for the job. Short-form names are allowed. Can include an explicit path to a local adaptor build.',
       })
-      // TODO how can I make these more re-usable?
-      // Maybea  big list of options in one file, and each command just imports the one it wants?
       .option('use-adaptors-monorepo', {
         alias: 'm',
         boolean: true,

--- a/packages/cli/src/metadata/handler.ts
+++ b/packages/cli/src/metadata/handler.ts
@@ -1,0 +1,62 @@
+import { Logger } from '../util/logger';
+import { SafeOpts } from '../commands';
+import loadState from '../execute/load-state';
+import cache from './cache';
+
+const metadataHandler = async (options: SafeOpts, logger: Logger) => {
+  logger.success('Generating metadata');
+  const state = await loadState(options, logger);
+
+  // Note that the config will be sanitised, so logging it may not be terrible helpful
+  const config = state.configuration;
+  logger.info('config:', config);
+
+  // validate the config object
+  // must exist
+  if (!config || Object.keys(config).length === 0) {
+    logger.error('ERROR: Invalid configuration passed');
+    process.exit(1);
+  }
+
+  const finish = () => {
+    logger.success('Done!');
+    logger.print(cache.getPath(repoDir, id));
+  };
+
+  // the adaptor path should now be totally set by the common cli stuff
+  const { repoDir, adaptors } = options;
+  const adaptor = adaptors[0]; // TODO adaptor argument is a bit dodgy, need to refactor opts
+  console.log(' ** ', adaptor);
+  // generate a hash for the config and check state
+  const id = cache.generateKey(config);
+  logger.debug('config hash: ', id);
+  const cached = await cache.get(repoDir, id);
+  if (cached) {
+    logger.success('Returning metadata from cache');
+    return finish();
+  }
+
+  try {
+    // TODO add better support if a path is passed into the adaptor (maybe use repo.getModuleEntryPoint )
+    let adaptorPath = adaptor.match('=') ? adaptor.split('=')[1] : adaptor;
+    // Import the adaptor
+    const mod = await import(adaptorPath);
+    // Does it export a metadata function?
+    if (mod.metadata) {
+      logger.info('Metadata function found. Generating metadata...');
+      const result = await mod.metadata(config);
+      await cache.set(repoDir, id, result);
+      finish();
+    } else {
+      logger.error('No metadata helper found');
+
+      process.exit(1); // TODO what's the correct error code?
+    }
+  } catch (e) {
+    logger.error('Exception while generating metadata');
+    logger.error(e);
+    process.exit(1);
+  }
+};
+
+export default metadataHandler;

--- a/packages/cli/src/util/use-adaptors-repo.ts
+++ b/packages/cli/src/util/use-adaptors-repo.ts
@@ -47,6 +47,7 @@ const useAdaptorsRepo = async (
     log.info(`Mapped adaptor ${a} to monorepo: ${p.split('=')[1]}`);
     return p;
   });
+  console.log(updatedAdaptors);
   return updatedAdaptors;
 };
 

--- a/packages/cli/src/util/use-adaptors-repo.ts
+++ b/packages/cli/src/util/use-adaptors-repo.ts
@@ -47,7 +47,6 @@ const useAdaptorsRepo = async (
     log.info(`Mapped adaptor ${a} to monorepo: ${p.split('=')[1]}`);
     return p;
   });
-  console.log(updatedAdaptors);
   return updatedAdaptors;
 };
 

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -171,7 +171,7 @@ export default function (name?: string, options: LogOptions = {}): Logger {
   const print = (...args: any[]) => {
     if (opts.level !== NONE) {
       if (opts.json) {
-        emitter.info({ message: args });
+        emitter.info(JSON.stringify({ message: args }));
       } else {
         emitter.info(...args);
       }

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -168,10 +168,13 @@ export default function (name?: string, options: LogOptions = {}): Logger {
 
   // print() will log without any metadata/overhead/santization
   // basically a proxy for console.log
-  // TODO should this use json?
   const print = (...args: any[]) => {
     if (opts.level !== NONE) {
-      emitter.info(...args);
+      if (opts.json) {
+        emitter.info({ message: args });
+      } else {
+        emitter.info(...args);
+      }
     }
   };
 

--- a/packages/logger/src/mock.ts
+++ b/packages/logger/src/mock.ts
@@ -52,8 +52,13 @@ const mockLogger = <T = StringLog>(
   // TODO should this use json?
   mock.print = (...out: any[]) => {
     if (opts.level !== 'none') {
-      // @ts-ignore
-      history.push(['print', ...out]);
+      if (opts.json) {
+        // @ts-ignore
+        history.push(['print', { message: out }]);
+      } else {
+        // @ts-ignore
+        history.push(['print', ...out]);
+      }
     }
   };
 

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import chalk from 'chalk';
-import { styleLevel, LogFns, StringLog, JSONLog } from '../src/logger';
+import { styleLevel, LogFns, StringLog } from '../src/logger';
 import { defaults as defaultOptions, LogLevel } from '../src/options';
 import { SECRET } from '../src/sanitize';
 
@@ -8,7 +8,6 @@ import { SECRET } from '../src/sanitize';
 // Which is basically thin wrapper around the logger which bypasses
 // console and provides an inspection API
 import createLogger from '../src/mock';
-import { assert } from 'console';
 
 const wait = (ms: number) => {
   return new Promise((resolve) => {
@@ -151,6 +150,16 @@ test('print() should not log if level is none', (t) => {
   logger.print('abc');
 
   t.is(logger._history.length, 0);
+});
+
+test('print() should log as json', (t) => {
+  const options = { json: true };
+  const logger = createLogger('x', options);
+  logger.print('abc');
+
+  const [level, message] = logger._last;
+  t.is(level, 'print');
+  t.deepEqual(message, { message: ['abc'] });
 });
 
 test('log() should behave like info', (t) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,12 @@ importers:
       tslib: 2.4.0
       typescript: 4.8.3
 
+  integration-tests/cli/repo:
+    specifiers:
+      '@openfn/language-http_4.2.6': npm:@openfn/language-http@^4.2.6
+    dependencies:
+      '@openfn/language-http_4.2.6': /@openfn/language-http/4.2.6
+
   packages/cli:
     specifiers:
       '@openfn/compiler': workspace:*
@@ -606,11 +612,26 @@ packages:
       lodash: 4.17.21
     transitivePeerDependencies:
       - debug
-    dev: true
 
   /@openfn/language-common/2.0.0-rc3:
     resolution: {integrity: sha512-7kwhBnCd1idyTB3MD9dXmUqROAhoaUIkz2AGDKuv9vn/cbZh7egEv9/PzKkRcDJYFV9qyyS+cVT3Xbgsg2ii5g==}
     bundledDependencies: []
+
+  /@openfn/language-http/4.2.6:
+    resolution: {integrity: sha512-aoDu9DzAx53aNU9t1l9ZlPmsfBrDTiJiJvlTEp27dbnaTiiCfMVLtncSnePNBRO5VAJp/XGnOfJC9b+vt1+rDA==}
+    dependencies:
+      '@openfn/language-common': 1.7.5
+      cheerio: 1.0.0-rc.12
+      cheerio-tableparser: 1.0.1
+      csv-parse: 4.16.3
+      fast-safe-stringify: 2.1.1
+      form-data: 3.0.1
+      lodash: 4.17.21
+      request: 2.88.2
+      tough-cookie: 4.1.2
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /@tailwindcss/forms/0.5.2_tailwindcss@3.1.8:
     resolution: {integrity: sha512-pSrFeJB6Bg1Mrg9CdQW3+hqZXAKsBrSG9MAfFLKy1pVA4Mb4W7C0k7mEhlmS2Dfo/otxrQOET7NJiJ9RrS563w==}
@@ -893,6 +914,15 @@ packages:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
+  /ajv/6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+    dev: false
+
   /ansi-colors/4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -1026,6 +1056,17 @@ packages:
     resolution: {integrity: sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==}
     engines: {node: '>=12'}
 
+  /asn1/0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
+
+  /assert-plus/1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+    dev: false
+
   /assign-symbols/1.0.0:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
     engines: {node: '>=0.10.0'}
@@ -1051,7 +1092,6 @@ packages:
 
   /asynckit/0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
 
   /atob/2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
@@ -1117,6 +1157,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /aws-sign2/0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+    dev: false
+
+  /aws4/1.12.0:
+    resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
+    dev: false
+
   /axios/1.1.3:
     resolution: {integrity: sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==}
     dependencies:
@@ -1125,7 +1173,6 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
-    dev: true
 
   /b4a/1.6.1:
     resolution: {integrity: sha512-AsKjNhz72yxteo/0EtQEiwkMUgk/tGmycXlbG4g3Ard2/ULtNLUykGOkeK0egmN27h0xMAhb76jYccW+XTBExA==}
@@ -1161,6 +1208,12 @@ packages:
   /batch/0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
     dev: true
+
+  /bcrypt-pbkdf/1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+    dependencies:
+      tweetnacl: 0.14.5
+    dev: false
 
   /bcryptjs/2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
@@ -1200,6 +1253,10 @@ packages:
 
   /blueimp-md5/2.19.0:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
+
+  /boolbase/1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: false
 
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -1327,6 +1384,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /caseless/0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
+    dev: false
+
   /cbor/8.1.0:
     resolution: {integrity: sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==}
     engines: {node: '>=12.19'}
@@ -1357,6 +1418,34 @@ packages:
   /chardet/0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
     dev: true
+
+  /cheerio-select/2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.1.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.0.1
+    dev: false
+
+  /cheerio-tableparser/1.0.1:
+    resolution: {integrity: sha512-SCSWdMoFvIue0jdFZqRNPXDCZ67vuirJEG3pfh3AAU2hwxe/qh1EQUkUNPWlZhd6DMjRlTfcpcPWbaowjwRnNQ==}
+    dev: false
+
+  /cheerio/1.0.0-rc.12:
+    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
+    engines: {node: '>= 6'}
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.0.1
+      htmlparser2: 8.0.1
+      parse5: 7.1.2
+      parse5-htmlparser2-tree-adapter: 7.0.0
+    dev: false
 
   /chokidar/2.1.8:
     resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
@@ -1521,7 +1610,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /commander/4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1592,6 +1680,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /core-util-is/1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+    dev: false
+
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
@@ -1632,6 +1724,21 @@ packages:
       which: 2.0.2
     dev: true
 
+  /css-select/5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.0.1
+      nth-check: 2.1.1
+    dev: false
+
+  /css-what/6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
+    dev: false
+
   /cssesc/3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1648,7 +1755,6 @@ packages:
 
   /csv-parse/4.16.3:
     resolution: {integrity: sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==}
-    dev: true
 
   /csv-stringify/5.6.5:
     resolution: {integrity: sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==}
@@ -1670,10 +1776,16 @@ packages:
     dependencies:
       array-find-index: 1.0.2
 
+  /dashdash/1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      assert-plus: 1.0.0
+    dev: false
+
   /date-fns/2.29.3:
     resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
     engines: {node: '>=0.11'}
-    dev: true
 
   /date-time/3.1.0:
     resolution: {integrity: sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==}
@@ -1793,7 +1905,6 @@ packages:
   /delayed-stream/1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /delegates/1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -1844,6 +1955,33 @@ packages:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
     dev: true
 
+  /dom-serializer/2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.4.0
+    dev: false
+
+  /domelementtype/2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
+
+  /domhandler/5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
+  /domutils/3.0.1:
+    resolution: {integrity: sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==}
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+    dev: false
+
   /duplexer/0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
     dev: true
@@ -1859,6 +1997,13 @@ packages:
 
   /eastasianwidth/0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  /ecc-jsbn/0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+    dev: false
 
   /ee-first/1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -1889,6 +2034,11 @@ packages:
     dependencies:
       ansi-colors: 4.1.3
     dev: true
+
+  /entities/4.4.0:
+    resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
+    engines: {node: '>=0.12'}
+    dev: false
 
   /error-ex/1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -2689,6 +2839,10 @@ packages:
       is-extendable: 1.0.1
     dev: true
 
+  /extend/3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: false
+
   /extendable-error/0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
     dev: true
@@ -2718,6 +2872,15 @@ packages:
       - supports-color
     dev: true
 
+  /extsprintf/1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+    dev: false
+
+  /fast-deep-equal/3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: false
+
   /fast-diff/1.2.0:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
 
@@ -2734,6 +2897,10 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
+
+  /fast-json-stable-stringify/2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    dev: false
 
   /fast-safe-stringify/2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
@@ -2833,12 +3000,33 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: true
 
   /for-in/1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /forever-agent/0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+    dev: false
+
+  /form-data/2.3.3:
+    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
+
+  /form-data/3.0.1:
+    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
 
   /form-data/4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
@@ -2847,7 +3035,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: true
 
   /fragment-cache/0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
@@ -2952,6 +3139,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /getpass/0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+    dependencies:
+      assert-plus: 1.0.0
+    dev: false
+
   /glob-parent/3.1.0:
     resolution: {integrity: sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==}
     dependencies:
@@ -3034,6 +3227,20 @@ packages:
       through2: 2.0.5
     dev: true
 
+  /har-schema/2.0.0:
+    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /har-validator/5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
+    dependencies:
+      ajv: 6.12.6
+      har-schema: 2.0.0
+    dev: false
+
   /hard-rejection/2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
@@ -3111,6 +3318,15 @@ packages:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
     dev: true
 
+  /htmlparser2/8.0.1:
+    resolution: {integrity: sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.0.1
+      entities: 4.4.0
+    dev: false
+
   /http-assert/1.5.0:
     resolution: {integrity: sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==}
     engines: {node: '>= 0.8'}
@@ -3164,6 +3380,15 @@ packages:
   /http-parser-js/0.5.8:
     resolution: {integrity: sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==}
     dev: true
+
+  /http-signature/1.2.0:
+    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
+    engines: {node: '>=0.8', npm: '>=1.3.7'}
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.17.0
+    dev: false
 
   /human-id/1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
@@ -3493,6 +3718,10 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
+  /is-typedarray/1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+    dev: false
+
   /is-unicode-supported/1.3.0:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
     engines: {node: '>=12'}
@@ -3533,6 +3762,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /isstream/0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
+    dev: false
+
   /joycon/3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -3553,9 +3786,25 @@ packages:
       argparse: 1.0.10
       esprima: 4.0.1
 
+  /jsbn/0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+    dev: false
+
   /json-parse-even-better-errors/2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: true
+
+  /json-schema-traverse/0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    dev: false
+
+  /json-schema/0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+    dev: false
+
+  /json-stringify-safe/5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+    dev: false
 
   /jsonfile/4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -3566,7 +3815,16 @@ packages:
   /jsonpath-plus/4.0.0:
     resolution: {integrity: sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==}
     engines: {node: '>=10.0'}
-    dev: true
+
+  /jsprim/1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+    dev: false
 
   /keygrip/1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
@@ -4076,6 +4334,16 @@ packages:
       path-key: 3.1.1
     dev: true
 
+  /nth-check/2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+    dependencies:
+      boolbase: 1.0.0
+    dev: false
+
+  /oauth-sign/0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+    dev: false
+
   /object-assign/4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -4278,6 +4546,19 @@ packages:
     resolution: {integrity: sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==}
     engines: {node: '>=12'}
 
+  /parse5-htmlparser2-tree-adapter/7.0.0:
+    resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.1.2
+    dev: false
+
+  /parse5/7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+    dependencies:
+      entities: 4.4.0
+    dev: false
+
   /parseurl/1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -4330,6 +4611,10 @@ packages:
       duplexify: 3.7.1
       through2: 2.0.5
     dev: true
+
+  /performance-now/2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+    dev: false
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -4516,7 +4801,6 @@ packages:
 
   /proxy-from-env/1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: true
 
   /proxy-middleware/0.15.0:
     resolution: {integrity: sha512-EGCG8SeoIRVMhsqHQUdDigB2i7qU7fCsWASwn54+nPutYO8n4q6EiwMzyfWlC+dzRFExP+kvcnDFdBDHoZBU7Q==}
@@ -4526,6 +4810,10 @@ packages:
   /pseudomap/1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
     dev: true
+
+  /psl/1.9.0:
+    resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
+    dev: false
 
   /pstree.remy/1.1.8:
     resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
@@ -4549,7 +4837,15 @@ packages:
   /punycode/2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
-    dev: true
+
+  /qs/6.5.3:
+    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
+    engines: {node: '>=0.6'}
+    dev: false
+
+  /querystringify/2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+    dev: false
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4717,6 +5013,33 @@ packages:
     engines: {node: '>=0.10'}
     dev: true
 
+  /request/2.88.2:
+    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
+    engines: {node: '>= 6'}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.12.0
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.3
+      safe-buffer: 5.2.1
+      tough-cookie: 2.5.0
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
+    dev: false
+
   /require-directory/2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -4724,6 +5047,10 @@ packages:
   /require-main-filename/2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
     dev: true
+
+  /requires-port/1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+    dev: false
 
   /resolve-cwd/3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -4805,7 +5132,6 @@ packages:
 
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-    dev: true
 
   /scheduler/0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
@@ -5081,6 +5407,22 @@ packages:
 
   /sprintf-js/1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  /sshpk/1.17.0:
+    resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+    dev: false
 
   /stack-utils/2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -5384,6 +5726,24 @@ packages:
       nopt: 1.0.10
     dev: true
 
+  /tough-cookie/2.5.0:
+    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
+    engines: {node: '>=0.8'}
+    dependencies:
+      psl: 1.9.0
+      punycode: 2.1.1
+    dev: false
+
+  /tough-cookie/4.1.2:
+    resolution: {integrity: sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      psl: 1.9.0
+      punycode: 2.1.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+    dev: false
+
   /tr46/0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: false
@@ -5643,6 +6003,16 @@ packages:
       yargs: 17.6.0
     dev: true
 
+  /tunnel-agent/0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
+  /tweetnacl/0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+    dev: false
+
   /type-fest/0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
@@ -5709,6 +6079,11 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
+  /universalify/0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+    dev: false
+
   /unix-crypt-td-js/1.1.4:
     resolution: {integrity: sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==}
     dev: true
@@ -5731,6 +6106,12 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /uri-js/4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    dependencies:
+      punycode: 2.1.1
+    dev: false
+
   /urix/0.1.0:
     resolution: {integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==}
     deprecated: Please see https://github.com/lydell/urix#deprecated
@@ -5739,6 +6120,13 @@ packages:
   /url-join/5.0.0:
     resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
+
+  /url-parse/1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
     dev: false
 
   /use/3.1.1:
@@ -5759,7 +6147,6 @@ packages:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
-    dev: true
 
   /v8-compile-cache-lib/3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -5774,6 +6161,15 @@ packages:
   /vary/1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  /verror/1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
+    dev: false
 
   /wcwidth/1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,7 @@ importers:
     specifiers:
       '@types/node': ^18.7.18
       ava: 5.1.0
+      date-fns: ^2.29.3
       rimraf: ^3.0.2
       ts-node: 10.8.1
       tslib: ^2.4.0
@@ -52,6 +53,7 @@ importers:
     dependencies:
       '@types/node': 18.7.18
       ava: 5.1.0
+      date-fns: 2.29.3
       rimraf: 3.0.2
       ts-node: 10.8.1_bidgzm5cq2du6gnjtweqqjrrn4
       tslib: 2.4.0


### PR DESCRIPTION
This PR adds a `metadata` command to the CLI, which generates metadata for a given adaptor.

## API

The basic API is:

```
openfn metadata -s path/to/config -a adaptor-name
```

Adaptors will be resolved just like normal, so you can pass the monorepo flag `-m` or an adaptor name to be loaded from the repo, or a path to a location on disk.

CAVEAT: at the time of wrtiting you have to pass a path to the index.js entry point. This is very fixable, I just want to avoid code re-use so I need to think a little bit about the solution.

Output is written to the CLI repo and the path is returned as the final argument. You can tail it to load the metadata and pipe it into other commands.

At the moment there's a simple cache in place. Config objects are hashed into a key and stored under this key in the repo.

A timestamp is added to the generated data.

## Integration Tests

There are an integration tests!

So useful here because it's hard to unit test some of this stuff. And the heavy lifting is in the adaptor anyway.