### PR TITLE
describe-package: recognise magic functions

### DIFF
--- a/examples/dts-inspector/CHANGELOG.md
+++ b/examples/dts-inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # dts-inspector
 
+## 1.0.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/describe-package@0.0.15
+
 ## 1.0.11
 
 ### Patch Changes

--- a/examples/dts-inspector/package.json
+++ b/examples/dts-inspector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dts-inspector",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 0.0.33
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/describe-package@0.0.15
+  - @openfn/compiler@0.0.27
+
 ## 0.0.32
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/compiler
 
+## 0.0.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/describe-package@0.0.15
+
 ## 0.0.26
 
 ### Patch Changes

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/compiler",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Compiler and language tooling for openfn jobs.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/describe-package/CHANGELOG.md
+++ b/packages/describe-package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/describe-package
 
+## 0.0.15
+
+### Patch Changes
+
+- Support magic flag for functions with @magic annotations
+
 ## 0.0.14
 
 ### Patch Changes

--- a/packages/describe-package/package.json
+++ b/packages/describe-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/describe-package",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Utilities to inspect an npm package.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/describe-package/src/describe-project.ts
+++ b/packages/describe-package/src/describe-project.ts
@@ -32,11 +32,12 @@ const describeFunction = (
     // @ts-ignore symbol.parent
     [parent] = symbol.symbol.parent.escapedName.match(/(language-\w+)/);
   }
+
   return {
     name: moduleName ? `${moduleName}.${symbol.name}` : symbol.name,
     description: symbol.comment,
     parameters: symbol.parameters.map((p) => describeParameter(project, p)),
-    magic: false,
+    magic: symbol.jsDocTags.some((tag) => tag.tagName.escapedText === 'magic'),
     isOperation: false,
     examples: symbol.examples.map((eg: string) => {
       if (eg.startsWith('<caption>')) {

--- a/packages/describe-package/test/describe-project.test.ts
+++ b/packages/describe-package/test/describe-project.test.ts
@@ -58,3 +58,9 @@ test('Load common fn', async (t) => {
   t.truthy(fn);
   t.is(fn.parent, 'language-common');
 });
+
+test('Recognise a magic function', async (t) => {
+  const fn = get('oneFlavour');
+  t.truthy(fn);
+  t.true(fn.magic);
+});

--- a/packages/describe-package/test/fixtures/stroopwafel.d.ts
+++ b/packages/describe-package/test/fixtures/stroopwafel.d.ts
@@ -9,6 +9,8 @@ export declare function traditional(): string;
 /**
  * Returns a flavoured stroopwafel
  * @public
+ * @param {string} flavour
+ * @magic flavour - $.children[*]
  * @example
  * <caption>cap</caption>oneFlavour('falafel')
  */

--- a/packages/runtime-manager/CHANGELOG.md
+++ b/packages/runtime-manager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # runtime-manager
 
+## 0.0.28
+
+### Patch Changes
+
+- @openfn/compiler@0.0.27
+
 ## 0.0.27
 
 ### Patch Changes

--- a/packages/runtime-manager/package.json
+++ b/packages/runtime-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime-manager",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "An example runtime manager service.",
   "main": "index.js",
   "type": "module",
@@ -15,7 +15,7 @@
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",
   "dependencies": {
-    "@openfn/compiler": "workspace:^0.0.26",
+    "@openfn/compiler": "workspace:^0.0.27",
     "@openfn/language-common": "2.0.0-rc3",
     "@openfn/logger": "workspace:*",
     "@openfn/runtime": "workspace:*",


### PR DESCRIPTION
To address https://github.com/OpenFn/Lightning/issues/657 - enable adaptor docs to indicate which functions support :sparkles: magic :sparkles: - we need to add a little more information to the package description returned by `describe-package`.

Phew, that's a mouthful.

Basically when `describe-package` generates a json object to describe a function, it includes a `magic: false` flag. Now that we have two published adaptors with magic annotations, we sometimes want to set `magic: true`.

This PR does that an unblocks Lightning#657.

Describe package really needs a couple of days of love on it - but luckily this is a trivial implementation and I think we can rush it in.

I have committed version bumps so we  can release directly from this branch.