### PR TITLE
Fix autoimports

### DIFF
--- a/.changeset/eight-bees-carry.md
+++ b/.changeset/eight-bees-carry.md
@@ -1,0 +1,5 @@
+---
+'@openfn/compiler': patch
+---
+
+Don't lookup exports from absolute modules

--- a/.changeset/fifty-bears-cheat.md
+++ b/.changeset/fifty-bears-cheat.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Optionally disable auto-import

--- a/.changeset/fluffy-games-march.md
+++ b/.changeset/fluffy-games-march.md
@@ -1,0 +1,5 @@
+---
+'@openfn/compiler': patch
+---
+
+Fix lookups of adaptor types

--- a/.changeset/little-shrimps-carry.md
+++ b/.changeset/little-shrimps-carry.md
@@ -1,0 +1,5 @@
+---
+'@openfn/compiler': patch
+---
+
+Allow add-imports transformer to ignore passed values

--- a/integration-tests/cli/src/run.ts
+++ b/integration-tests/cli/src/run.ts
@@ -20,8 +20,11 @@ const mapOpenFnPath = (cmd) => {
 const run = async (
   cmd: string
 ): Promise<{ stdout: string; stderr?: string }> => {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     exec(mapOpenFnPath(cmd), options, (err, stdout, stderr) => {
+      if (err) {
+        reject(err);
+      }
       resolve({ stdout, stderr });
     });
   });

--- a/integration-tests/cli/test/execute.test.ts
+++ b/integration-tests/cli/test/execute.test.ts
@@ -61,6 +61,22 @@ test.serial(`openfn ${jobsPath}/simple.js -a common -O`, async (t) => {
 });
 
 test.serial(
+  `openfn ${jobsPath}/simple.js -a common --ignore-imports`,
+  async (t) => {
+    const error = await t.throwsAsync(() => run(t.title));
+    t.regex(error.message, /(fn is not defined)/);
+  }
+);
+
+test.serial(
+  `openfn ${jobsPath}/simple.js -a common --ignore-imports=fn`,
+  async (t) => {
+    const error = await t.throwsAsync(() => run(t.title));
+    t.regex(error.message, /(fn is not defined)/);
+  }
+);
+
+test.serial(
   `openfn ${jobsPath}/simple.js -a @openfn/language-common -s ${tmpPath}/state.json`,
   async (t) => {
     await writeFileSync(`${tmpPath}/state.json`, '{ "data": 2 }');

--- a/packages/cli/src/compile/command.ts
+++ b/packages/cli/src/compile/command.ts
@@ -9,6 +9,7 @@ export type CompileOptions = Required<
     | 'adaptors'
     | 'command'
     | 'expandAdaptors'
+    | 'ignoreImports'
     | 'jobPath'
     | 'logJson'
     | 'log'
@@ -25,6 +26,7 @@ export type CompileOptions = Required<
 const options = [
   o.expandAdaptors, // order important
   o.adaptors,
+  o.ignoreImports,
   o.jobPath,
   o.logJson,
   override(o.outputStdout, {

--- a/packages/cli/src/compile/command.ts
+++ b/packages/cli/src/compile/command.ts
@@ -15,6 +15,7 @@ export type CompileOptions = Required<
     | 'log'
     | 'outputPath'
     | 'outputStdout'
+    | 'repoDir'
     | 'path'
     | 'useAdaptorsMonorepo'
   >
@@ -33,6 +34,7 @@ const options = [
     default: true,
   }),
   o.outputPath,
+  o.repoDir,
   o.useAdaptorsMonorepo,
 ];
 

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -81,7 +81,7 @@ export const loadTransformOptions = async (
     }
 
     options['add-imports'] = {
-      ignore: opts.ignoreImports,
+      ignore: opts.ignoreImports as string[],
       adaptor: {
         name: stripVersionSpecifier(specifier),
         exports,

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -62,20 +62,17 @@ export const loadTransformOptions = async (
 
   // If an adaptor is passed in, we need to look up its declared exports
   // and pass them along to the compiler
-  if (opts.adaptors?.length) {
+  if (opts.adaptors?.length && opts.ignoreImports != true) {
     let exports;
-    const [pattern] = opts.adaptors; // TODO add-imports only takes on adaptor, but the cli can take multiple
+    const [pattern] = opts.adaptors;
     const [specifier] = pattern.split('=');
 
     // Preload exports from a path, optionally logging errors in case of a failure
-    log.debug(`Attempting to preload typedefs for ${specifier}`);
+    log.debug(`Attempting to preload types for ${specifier}`);
     const path = await resolveSpecifierPath(pattern, opts.repoDir, log);
     if (path) {
       try {
-        exports = await preloadAdaptorExports(path);
-        if (exports) {
-          log.info(`Loaded typedefs for ${specifier}`);
-        }
+        exports = await preloadAdaptorExports(path, log);
       } catch (e) {
         log.error(`Failed to load adaptor typedefs from path ${path}`);
         log.error(e);
@@ -87,6 +84,7 @@ export const loadTransformOptions = async (
     }
 
     options['add-imports'] = {
+      ignore: opts.ignoreImports,
       adaptor: {
         name: stripVersionSpecifier(specifier),
         exports,
@@ -94,5 +92,6 @@ export const loadTransformOptions = async (
       },
     };
   }
+
   return options;
 };

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -8,8 +8,6 @@ import type { CompileOptions } from './command';
 export default async (opts: CompileOptions, log: Logger) => {
   log.debug('Loading job...');
   const compilerOptions: Options = await loadTransformOptions(opts, log);
-  compilerOptions.logger = createLogger(COMPILER, opts as any); // TODO log options are a bit flaky right now
-
   const job = compile(opts.jobSource || opts.jobPath, compilerOptions);
   if (opts.jobPath) {
     log.success(`Compiled job from ${opts.jobPath}`);
@@ -57,9 +55,8 @@ export const loadTransformOptions = async (
   log: Logger
 ) => {
   const options: Options = {
-    logger: log,
+    logger: log || createLogger(COMPILER, opts as any),
   };
-
   // If an adaptor is passed in, we need to look up its declared exports
   // and pass them along to the compiler
   if (opts.adaptors?.length && opts.ignoreImports != true) {

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -12,6 +12,7 @@ export type ExecuteOptions = Required<
     | 'compile'
     | 'expandAdaptors'
     | 'immutable'
+    | 'ignoreImports'
     | 'jobPath'
     | 'log'
     | 'logJson'
@@ -36,6 +37,7 @@ const options = [
   o.autoinstall,
   o.compile,
   o.immutable,
+  o.ignoreImports,
   o.jobPath,
   o.logJson,
   o.outputPath,

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -5,7 +5,7 @@ import { DEFAULT_REPO_DIR } from './util/ensure-opts';
 import type { CommandList } from './commands';
 
 // Central type definition for the main options
-// This is in flux as options are being refactoreds
+// This is in flux as options are being refactored
 export type Opts = {
   command?: CommandList;
   baseDir?: string;
@@ -18,6 +18,7 @@ export type Opts = {
   expandAdaptors?: boolean; // for unit tests really
   force?: boolean;
   immutable?: boolean;
+  ignoreImports?: boolean | string[];
   jobPath?: string;
   log?: string[];
   logJson?: boolean;
@@ -34,6 +35,11 @@ export type Opts = {
   strictOutput?: boolean; // defaults to true
   timeout?: number; // ms
   useAdaptorsMonorepo?: string | boolean;
+};
+
+// Defintion of what Yargs returns (before ensure is called)
+export type UnparsedOpts = Opts & {
+  ignoreImports?: boolean | string;
 };
 
 export type CLIOption = {
@@ -127,6 +133,21 @@ export const immutable: CLIOption = {
     description: 'Enforce immutabilty on state object',
     boolean: true,
     default: false,
+  },
+};
+
+export const ignoreImports: CLIOption = {
+  name: 'ignore-imports',
+  yargs: {
+    description:
+      "Don't auto-import references in compiled code. Can take a list of names to ignore.",
+  },
+  ensure: (opts) => {
+    if (typeof opts.ignoreImports === 'string') {
+      opts.ignoreImports = (opts.ignoreImports as string)
+        .split(',')
+        .map((s) => s.trim());
+    }
   },
 };
 

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -37,7 +37,7 @@ export type Opts = {
   useAdaptorsMonorepo?: string | boolean;
 };
 
-// Defintion of what Yargs returns (before ensure is called)
+// Definition of what Yargs returns (before ensure is called)
 export type UnparsedOpts = Opts & {
   ignoreImports?: boolean | string;
 };

--- a/packages/cli/test/compile/options.test.ts
+++ b/packages/cli/test/compile/options.test.ts
@@ -85,3 +85,15 @@ test('output path overrides stdout', (t) => {
   t.falsy(options.outputStdout);
   t.is(options.outputPath, 'out.json');
 });
+
+test('disable all imports', (t) => {
+  const options = parse('compile job.js --ignore-imports');
+  t.true(options.ignoreImports);
+});
+
+test('disable some imports', (t) => {
+  const options = parse('compile job.js --ignore-imports=jam,jar');
+  const [a, b] = options.ignoreImports as string[];
+  t.is(a, 'jam');
+  t.is(b, 'jar');
+});

--- a/packages/cli/test/execute/options.test.ts
+++ b/packages/cli/test/execute/options.test.ts
@@ -147,3 +147,15 @@ test('set timeout (long)', (t) => {
   const options = parse('execute job.js --timeout 1234');
   t.is(options.timeout, 1234);
 });
+
+test('disable all imports', (t) => {
+  const options = parse('execute job.js --ignore-imports');
+  t.true(options.ignoreImports);
+});
+
+test('disable some imports', (t) => {
+  const options = parse('execute job.js --ignore-imports=jam,jar');
+  const [a, b] = options.ignoreImports as string[];
+  t.is(a, 'jam');
+  t.is(b, 'jar');
+});

--- a/packages/cli/test/options/ensure/ignore-imports.test.ts
+++ b/packages/cli/test/options/ensure/ignore-imports.test.ts
@@ -1,0 +1,46 @@
+import test from 'ava';
+import { ignoreImports, Opts, UnparsedOpts } from '../../../src/options';
+
+test('do nothing if importImports is true (--ignore-imports)', (t) => {
+  const opts = {
+    ignoreImports: true,
+  } as Opts;
+  ignoreImports.ensure!(opts);
+
+  t.true(opts.ignoreImports);
+});
+
+test('convert a single value to an array', (t) => {
+  const opts = {
+    ignoreImports: 'a',
+  } as UnparsedOpts;
+  ignoreImports.ensure!(opts);
+
+  t.true(Array.isArray(opts.ignoreImports));
+  const [a] = opts.ignoreImports as string[];
+  t.is(a, 'a');
+});
+
+test('convert a single value to an array and trims', (t) => {
+  const opts = {
+    ignoreImports: '  a  ',
+  } as UnparsedOpts;
+  ignoreImports.ensure!(opts);
+
+  t.true(Array.isArray(opts.ignoreImports));
+  const [a] = opts.ignoreImports as string[];
+  t.is(a, 'a');
+});
+
+test('convert multiple values to an array', (t) => {
+  const opts = {
+    ignoreImports: 'a, b, c',
+  } as UnparsedOpts;
+  ignoreImports.ensure!(opts);
+
+  t.true(Array.isArray(opts.ignoreImports));
+  const [a, b, c] = opts.ignoreImports as string[];
+  t.is(a, 'a');
+  t.is(b, 'b');
+  t.is(c, 'c');
+});

--- a/packages/compiler/src/transforms/add-imports.ts
+++ b/packages/compiler/src/transforms/add-imports.ts
@@ -165,7 +165,7 @@ function visitor(path: NodePath, logger: Logger, options: AddImportsOptions) {
       const usedExports =
         exports && exports.length
           ? // If we have exports for this adaptor, import any dangling variables from the export list
-            exports.filter((e) => identifiers[e])
+            exports.filter((e) => !ignore[e] && identifiers[e])
           : // If we have no exports for this adaptor, import anything apart from a few choice globals
             Object.keys(identifiers).filter(
               (i) => !ignore[i] && !globalRE.test(i)

--- a/packages/compiler/src/transforms/add-imports.ts
+++ b/packages/compiler/src/transforms/add-imports.ts
@@ -92,6 +92,7 @@ const globals = [
 const globalRE = new RegExp(`^${globals.join('|')}$`);
 
 export type AddImportsOptions = {
+  ignore?: string[];
   // Adaptor MUST be pre-populated for this transformer to actually do anything
   adaptor: {
     name: string;
@@ -153,6 +154,12 @@ export function findAllDanglingIdentifiers(ast: ASTNode) {
 function visitor(path: NodePath, logger: Logger, options: AddImportsOptions) {
   if (options.adaptor) {
     const { name, exports, exportAll } = options.adaptor;
+    const ignore =
+      options.ignore?.reduce((obj, key) => {
+        obj[key] = true;
+        return obj;
+      }, {} as Record<string, true>) ?? {};
+
     if (name) {
       const identifiers = findAllDanglingIdentifiers(path.node);
       const usedExports =
@@ -160,7 +167,9 @@ function visitor(path: NodePath, logger: Logger, options: AddImportsOptions) {
           ? // If we have exports for this adaptor, import any dangling variables from the export list
             exports.filter((e) => identifiers[e])
           : // If we have no exports for this adaptor, import anything apart from a few choice globals
-            Object.keys(identifiers).filter((i) => !globalRE.test(i));
+            Object.keys(identifiers).filter(
+              (i) => !ignore[i] && !globalRE.test(i)
+            );
       if (usedExports.length) {
         // TODO maybe in trace output we can say WHY we're doing these things
         addUsedImports(path, usedExports, name);

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { Project, describeDts, fetchFile } from '@openfn/describe-package';
+import type { Logger } from '@openfn/logger';
 
 export const loadFile = (filePath: string) =>
   fs.readFileSync(path.resolve(filePath), 'utf8');
@@ -19,41 +20,43 @@ export const isRelativeSpecifier = (specifier: string) =>
   /^(\/|\.|~|\w\:\\)/.test(specifier);
 
 // Helper to load the exports of a given npm package
-// Can load from an unpkg specifier or a path to a local module
-export const preloadAdaptorExports = async (specifier: string) => {
+// At the moment this expects to be passed a path to a local module,
+// But we may relax this  later.
+export const preloadAdaptorExports = async (
+  pathToModule: string,
+  log?: Logger
+) => {
   const project = new Project();
   let pkg;
   let types;
   // load the package from unpkg or the filesystem
-  if (isRelativeSpecifier(specifier)) {
+  if (isRelativeSpecifier(pathToModule)) {
     // load locally
-    const pkgSrc = await readFile(`${specifier}/package.json`, 'utf8');
+    const pkgSrc = await readFile(`${pathToModule}/package.json`, 'utf8');
     pkg = JSON.parse(pkgSrc);
     if (pkg.types) {
-      types = await readFile(`${specifier}/${pkg.types}`, 'utf8');
-    } else {
-      // If there's no type information, we can safely return
-      // TODO should we log a warning?
-      return [];
+      types = await readFile(`${pathToModule}/${pkg.types}`, 'utf8');
     }
   } else {
-    // TODO this should never be used right now - the CLI should always pass in a path
-
-    // TODO - if modules_home is set, we should look there for definitions before calling out to unpkg
-    // load from unpkg
-    const pkgSrc = await fetchFile(`${specifier}/package.json`);
-    pkg = JSON.parse(pkgSrc);
-    types = await fetchFile(`${specifier}/${pkg.types}`);
+    // Do not load absolute modules
+    // We can later do this with fetchFile(`${specifier}/package.json`)
+    if (log) {
+      log.info(`Skipping adaptor export preload for ${pathToModule}`);
+    }
   }
 
-  // Setup the project so we can read the dts definitions
-  project.addToFS(types, pkg.types);
-  project.createFile(types, pkg.types);
+  if (types) {
+    // Setup the project so we can read the dts definitions
+    project.addToFS(types, pkg.types);
+    project.createFile(types, pkg.types);
 
-  // find the main dts
-  const functionDefs = describeDts(project, pkg.types, {
-    includePrivate: true,
-  });
-  // Return a flat array of names
-  return functionDefs.map(({ name }) => name);
+    // find the main dts
+    const functionDefs = describeDts(project, pkg.types, {
+      includePrivate: true,
+    });
+
+    // Return a flat array of names
+    return functionDefs.map(({ name }) => name);
+  }
+  return [];
 };

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -46,7 +46,7 @@ export const preloadAdaptorExports = async (
             project
           );
           if (common) {
-            common.forEach((name) => {
+            common.forEach(({ name }) => {
               functionDefs[name] = true;
             });
           }
@@ -56,7 +56,7 @@ export const preloadAdaptorExports = async (
       }
 
       const adaptor = await findExports(pathToModule, pkg.types, project);
-      adaptor.forEach((name) => {
+      adaptor.forEach(({ name }) => {
         functionDefs[name] = true;
       });
 

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -73,9 +73,6 @@ export const preloadAdaptorExports = async (
   return [];
 };
 
-// TODO this should all be done by describe-package really, but that's too focused around jsdelivr
-// what about dependencies on common? Will we see the exports? We just need the names...
-// No, we don't see the exports :(
 const findExports = async (
   moduleRoot: string,
   types: string,

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { Project, describeDts, fetchFile } from '@openfn/describe-package';
+import { Project, describeDts } from '@openfn/describe-package';
 import type { Logger } from '@openfn/logger';
 
 export const loadFile = (filePath: string) =>

--- a/packages/compiler/test/transform.test.ts
+++ b/packages/compiler/test/transform.test.ts
@@ -97,7 +97,7 @@ test('transform will stop if a visitor returns truthy', (t) => {
   t.assert(visitCount === 1);
 });
 
-test('ignore disabled visitors', (t) => {
+test('ignore visitors disabled in options', (t) => {
   const transformers = [{ id: TEST, types: ['Program'], visitor: noop }];
 
   const map = indexTransformers(transformers, { test: false });

--- a/packages/compiler/test/transforms/add-imports.test.ts
+++ b/packages/compiler/test/transforms/add-imports.test.ts
@@ -421,6 +421,32 @@ test("don't auto add imports for node globals", (t) => {
   t.assert(imports[0].imported.name === 'x');
 });
 
+test("Don't add imports for ignored identifiers", async (t) => {
+  const ast = b.program([
+    b.expressionStatement(b.identifier('x')),
+    b.expressionStatement(b.identifier('y')),
+  ]);
+
+  const options = {
+    'add-imports': {
+      ignore: ['x'],
+      adaptor: {
+        name: 'test-adaptor',
+        exports: [],
+      },
+    },
+  };
+
+  const transformed = transform(ast, [addImports], options) as n.Program;
+
+  const [first] = transformed.body;
+  t.assert(n.ImportDeclaration.check(first));
+  const imports = (first as n.ImportDeclaration)
+    .specifiers as n.ImportSpecifier[];
+  t.assert(imports.length === 1);
+  t.assert(imports[0].imported.name === 'y');
+});
+
 test('export everything from an adaptor', (t) => {
   const ast = b.program([b.expressionStatement(b.identifier('x'))]);
 

--- a/packages/compiler/test/util/preload-adaptor-exports.test.ts
+++ b/packages/compiler/test/util/preload-adaptor-exports.test.ts
@@ -3,31 +3,33 @@ import path from 'node:path';
 
 import { preloadAdaptorExports } from '../../src/util';
 
-const TEST_ADAPTOR = path.resolve('test/__modules__/adaptor');
+const TEST_ADAPTOR_PATH = path.resolve('test/__modules__/adaptor');
 
 test('load exports from a path', async (t) => {
-  const result = await preloadAdaptorExports(TEST_ADAPTOR);
+  const result = await preloadAdaptorExports(TEST_ADAPTOR_PATH);
 
   t.assert(result.length === 2);
   t.assert(result.includes('x'));
   t.assert(result.includes('y'));
 });
 
-// This test is currently failing because a lot of the functions in the 2.0 common
-// aren't marked as public
-// But I think this test is redundant now that we have the repo and autoinstall - I don't
-// think we should be fetching from unpkg at all.
-// Raised an issue #103 to think about this with a clearer head
-test.skip('load exports from unpkg', async (t) => {
-  const result = await preloadAdaptorExports(
-    '@openfn/language-common@2.0.0-rc3'
-  );
+test('return an empty array from a bad path', async (t) => {
+  const result = await preloadAdaptorExports('jam/jar');
 
-  t.assert(result.length > 0);
-  t.assert(result.includes('fn'));
-  t.assert(result.includes('combine'));
-  t.assert(result.includes('execute'));
-  t.assert(result.includes('each'));
+  t.true(Array.isArray(result));
+  t.assert(result.length === 0);
 });
 
-// TODO test error handling
+test('return an empty array from an absolute path', async (t) => {
+  const result = await preloadAdaptorExports('jam');
+
+  t.true(Array.isArray(result));
+  t.assert(result.length === 0);
+});
+
+test('return an empty array from a namespaced absolute path', async (t) => {
+  const result = await preloadAdaptorExports('@openfn/jam');
+
+  t.true(Array.isArray(result));
+  t.assert(result.length === 0);
+});


### PR DESCRIPTION
This PR aims to deal with autoimport issues that have cropped up recently.

There are three strategies here:

* Force the CLI to disable generation of auto imports completely with `--ignore-imports`. This is a nuclear option and will likely cause errors, unless the job code has explicit imports. I don't expect anyone to ever use this.

* Tell the compiler to ignore some imported names with `--ignore-imports=parseInt,i,performance`. If anyone ever has trouble compiling a job properly, this is a valid option to override the auto-import behaviour. This would have fixed Alexa's issue yesterday without needing to modify the job code.

* Fix the lookup for an adaptor's exports, which can be used as an input by the compiler to smartly only add imports to packages they belong to. Turns out this was broken has been for ages. I've implemented a fix here but really we need to get on and do #197

## Related issues

* #195
* #179
* #103
* #191
* 
## About autoimport

A bit of important context for autoimport.

Remember that jobs are not runnable javascript. We need to convert this:
```
fn(s => s)
```
Into this:
```
import { fn } from '@openfn/language-common'
export default [fn(s => s)]
```

The compiler generates this extra bit of import code. It must work out which names to import from the adaptor. 

It can do this the "dumb" way, by looking up any undeclared variables and attempting to import them from the adaptor (this is basically what happens in the wild right now).

Or it can do this the "smart" way, by looking up the adaptor's exports from its type definition, and matching those to any undeclared variables.

This is the autoimport problem.

# Common Dependencies

Here's a problem we've encountered before, over in `adaptor-docs`.

When looking up the type defs for an adaptor, the adaptor lists its own dependencies in d.ts. We can detect and consider those for auto-import.

But if the adaptor exports anything from another library (and many adaptors export direct from common), those proxied exports don't have a type definition in the adaptor. They're stored in the other library. So those exports are basically hidden.

I've solved this here, as I have in adaptor docs, by forcing the common definitions to be loaded from the repo. This seems to work but it's super flaky.

We're going to have to enhance `describe-package` to do this properly - detect any proxied type aliases in a d.ts, find the definition, and present it as a single interface to the caller. I've raised #197 to cover this.

I suppose another solution would be to generate a d.ts which inlines all the third-party exports (ie, doesn't treat them as externals). We can do this for language-common, but when it comes to eg `export { axios }`  I'm not sure it'll work so well.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
