### PR TITLE
Include timestamp in json logs

### DIFF
--- a/.changeset/late-vans-divide.md
+++ b/.changeset/late-vans-divide.md
@@ -1,0 +1,5 @@
+---
+'@openfn/logger': patch
+---
+
+include a timestamp on json logs

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -38,6 +38,7 @@ export type JSONLog = {
   message: Array<string | object | any>;
   level: LogFns;
   name?: string;
+  time: number;
 };
 
 export type StringLog = [LogFns | 'confirm' | 'print', ...any];
@@ -141,6 +142,7 @@ export default function (name?: string, options: LogOptions = {}): Logger {
       level,
       name,
       message: args.map((o) => sanitize(o, { stringify: false })),
+      time: Date.now(),
     };
 
     emitter[level](stringify(output));

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -126,11 +126,12 @@ test('should log objects as strings', (t) => {
     logger[fn]('abc');
 
     const result = JSON.parse(logger._last);
-    t.assert(Object.keys(result).length === 3);
+    t.assert(Object.keys(result).length === 4);
 
     t.assert(result.level === level);
     t.assert(result.name === 'x');
     t.assert(result.message[0] === 'abc');
+    t.true(!isNaN(result.time));
   });
 });
 

--- a/packages/logger/test/mock.test.ts
+++ b/packages/logger/test/mock.test.ts
@@ -183,8 +183,9 @@ test('log JSON', async (t) => {
   const logger = mockLogger<string>('a', { json: true });
   logger.success('z');
 
-  const { level, message, name } = JSON.parse(logger._last);
+  const { level, message, name, time } = JSON.parse(logger._last);
   t.is(name, 'a');
   t.is(level, 'success');
   t.is(message[0], 'z');
+  t.true(!isNaN(time));
 });


### PR DESCRIPTION
Simple feature which logs a timestamp as epoch-ms with Date.now().

Feels like a useful thing to track as a first-class property in the log object, and doesn't hurt anyone.

Timestamps are not included in stdout logs.

## Related issue

Fixes #181
