### PR TITLE
CLI: Better help text

### DIFF
--- a/.changeset/angry-kangaroos-lay.md
+++ b/.changeset/angry-kangaroos-lay.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Update help

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -36,6 +36,14 @@ Get help:
 openfn help
 ```
 
+## Migrating from devtools
+
+If you're coming to the CLI from the old openfn devtools, here are a couple of key points to be aware of:
+
+* The CLI has a shorter, sleeker syntax, so your command should be much shorter
+* The CLI will automatically install adaptors for you (with full version control)
+* By default, the CLI will only write state.data to output. This is to encourage better state management. Pass `--no-strict-output` to save the entire state object.
+
 ## Basic Usage
 
 You're probably here to run jobs (expressions), which the CLI makes easy:
@@ -46,13 +54,13 @@ openfn path/to/job.js -ia adaptor-name
 
 You MUST specify which adaptor to use. Pass the `-i` flag to auto-install that adaptor (it's safe to do this redundantly).
 
-If output.json is not passed, the CLI will create an `output.json` next to the job file. You can pass a path to state by adding `-s path/to/state.json`, and output by passing `-o path/to/output.json`. You can use `-S` and `-O` to pass state through stdin and return the output through stdout.
+When the job is finished, the CLI will write the `data` property of your state to disk. By default the CLI will create an `output.json` next to the job file. You can pass a path to output by passing `-o path/to/output.json` and state by adding `-s path/to/state.json`. You can use `-S` and `-O` to pass state through stdin and return the output through stdout. To write the entire state object (not just `data`), pass `--no-strict-output`.
 
-The CLI can auto-install language adaptors to its own privately maintained repo. Run `openfn repo list` to see where the repo is, and what's in it. Set the `OPENFN_REPO_DIR` env var to specify the repo folder. When autoinstalling, the CLI will check to see if a matching version is found in the repo.
+The CLI can auto-install language adaptors to its own privately maintained repo, just include the `-i` flag in the command and your adaptors will be forever fully managed. Run `openfn repo list` to see where the repo is, and what's in it. Set the `OPENFN_REPO_DIR` env var to specify the repo folder. When autoinstalling, the CLI will check to see if a matching version is found in the repo.
 
 You can specify adaptors with a shorthand (`http`) or use the full package name (`@openfn/language-http`). You can add a specific version like `http@2.0.0`. You can pass a path to a locally installed adaptor like `http=/repo/openfn/adaptors/my-http-build`.
 
-If you have the adaptors monorepo set up on your machine, you can also run from that. Pass the `-m` flag to load from the monorepo. Set the monorepo location by setting the OPENFN_ADAPTORS_REPO env var to a valid path. This runs from the built package, so remember to build an adaptor before running!
+If you have the adaptors monorepo set up on your machine, you can also run adaptors straight from source. Pass the `-m <path>` flag to load from the monorepo. You can also set the monorepo location by setting the `OPENFN_ADAPTORS_REPO` env var to a valid path. After that just include `-m` to load from the monorepo. Remember that adaptors will be loaded from the BUILT package in `dist`, so remember to build an adaptor before running!
 
 You can pass `--log info` to get more feedback about what's happening, or `--log debug` for more details than you could ever use.
 
@@ -119,9 +127,11 @@ The CLI uses openfn's own runtime to execute jobs in a safe environment.
 
 All jobs which work against `@openfn/core` will work in the new CLI and runtime environment (note: although this is a work in progress and we are actively looking for help to test this!).
 
+If you want to see how the compiler is changing your job, run `openfn compile path/to/job -a <adaptor>` to return the compiled code to stdout. Add `-o path/to/output.js` to save the result to disk.
+
 ## New Runtime notes
 
-The new openfunction runtime basically does one thing: load a Javascript Module, find the default export, and execute the functions it holds.
+The new OpenFn runtime will create a secure sandboxed environemtn which loads a Javascript Module, finds the default export, and execute the functions held within it.
 
 So long as your job has an array of functions as its default export, it will run in the new runtime.
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,7 +10,9 @@ import docsCommand from './docs/command';
 import metadataCommand from './metadata/command';
 import { Opts } from './options';
 
-export const cmd = yargs(hideBin(process.argv))
+const y = yargs(hideBin(process.argv));
+
+export const cmd = y
   .command(executeCommand as any)
   .command(compileCommand as any)
   .command(installCommand) // allow install to run from the top as well as repo
@@ -40,4 +42,5 @@ export const cmd = yargs(hideBin(process.argv))
       argv.command = 'version';
     },
   })
+  .wrap(y.terminalWidth())
   .help() as yargs.Argv<Opts>;

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -50,8 +50,11 @@ const options = [
 ];
 
 const executeCommand = {
-  command: 'execute [path]',
-  desc: `Run an openfn job. Get more help by running openfn <command> help`,
+  command: 'execute [path/to/job.js]',
+  desc: `Run an openfn job. Get more help by running openfn <command> help.
+  \nExecute will run a job/expression and write the output state to disk (to ./state.json unless otherwise specified)
+  \nBy default only state.data will be written to the output. Include --no-strict-output to write the entire state object.
+  \nRemember to include the adaptor name with -a. Auto install adaptors with the -i flag.`,
   aliases: ['$0'],
   handler: ensure('execute', options),
   builder: (yargs) =>
@@ -63,15 +66,19 @@ const executeCommand = {
       })
       .example(
         'openfn foo/job.js',
-        'Reads foo/job.js, looks for state and output in foo'
+        'Execute foo/job.js with no adaptor and write the final state to foo/job.json'
       )
       .example(
-        'openfn job.js -a common',
-        'Run job.js using @openfn/language-common'
+        'openfn job.js -ia common',
+        'Execute job.js using @openfn/language-commom , with autoinstall enabled)'
       )
       .example(
-        'openfn install -a common',
-        'Install the latest version of language-common to the repo'
+        'openfn job.js -a common --log info',
+        'Execute job.js with common adaptor and info-level logging'
+      )
+      .example(
+        'openfn compile job.js -a http',
+        'Compile job.js with the http adaptor and print the code to stdout'
       ),
 } as yargs.CommandModule<ExecuteOptions>;
 

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -50,7 +50,7 @@ const options = [
 ];
 
 const executeCommand = {
-  command: 'execute [path/to/job.js]',
+  command: 'execute [path]',
   desc: `Run an openfn job. Get more help by running openfn <command> help.
   \nExecute will run a job/expression and write the output state to disk (to ./state.json unless otherwise specified)
   \nBy default only state.data will be written to the output. Include --no-strict-output to write the entire state object.


### PR DESCRIPTION
I've added more help text to `yargs.help` and the readme. I'm hoping this will help alleviate the confusion of strict state and #194. In practice there's a lot of help text here so I don't know if it'll be very effective.

I've also fixed the terminal width so that args renders its output a bit more nicely.

Making state non-strict will make the problem go away. But if we want to encourage better consideration of how state is used, we need to keep this pain point. So I'm not sure. Better documentation has to to be key though.

Probably closes #194