### PR TITLE
CLI: Don't log credentials in metadata command

### DIFF
--- a/.changeset/new-experts-sin.md
+++ b/.changeset/new-experts-sin.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Tighten up credential logging in metadata service"

--- a/.changeset/new-experts-sin.md
+++ b/.changeset/new-experts-sin.md
@@ -1,5 +1,0 @@
----
-'@openfn/cli': patch
----
-
-Tighten up credential logging in metadata service"

--- a/integration-tests/cli/test/metadata.test.ts
+++ b/integration-tests/cli/test/metadata.test.ts
@@ -112,3 +112,18 @@ test.serial(
     lastCreated = metadata.created;
   }
 );
+
+test.serial('does not log credentials', async (t) => {
+  const sensitiveValue = '8888888';
+  const state = `{ \\"configuration\\": { \\"pin_number\\": \\"${sensitiveValue}\\" } }`;
+  const command = `openfn metadata -f -S "${state}" -a ${modulePath} --log-json --log debug`;
+  const { stdout } = await run(command);
+
+  const logJson = extractLogs(stdout);
+  // trim the command from the logs because it contains the sensitive value
+  const logString = JSON.stringify(logJson);
+
+  // Should log the state object at least once
+  t.regex(logString, /(pin_number)/i);
+  t.notRegex(logString, new RegExp(sensitiveValue), 'i');
+});

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/cli
 
+## 0.0.36
+
+### Patch Changes
+
+- b66217c: Tighten up credential logging in metadata service"
+
 ## 0.0.35
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/cli/src/metadata/handler.ts
+++ b/packages/cli/src/metadata/handler.ts
@@ -55,9 +55,9 @@ const metadataHandler = async (options: SafeOpts, logger: Logger) => {
   logger.success(`Generating metadata`);
 
   // Note that the config will be sanitised, so logging it may not be terrible helpful
-  const config = state.configuration;
-  logger.info('config:', config);
+  logger.info('config:', state);
 
+  const config = state.configuration;
   if (!config || Object.keys(config).length === 0) {
     logger.error('ERROR: Invalid configuration passed');
     process.exit(1);


### PR DESCRIPTION
This PR ensures that when the CLI metadata command logs stuff out, it sanitises state output to remove potentially sensitive information.

The logger is smart enough to recognise a state object with credentials and scrub the values of `configuration`. But we were passing in `state.configuration` to the logger, which is just an object, so it wasn't cleaned.

I thought about adding some kind of force-sanitising API to the logger but I'm not sure that's the right answer, at least not yet.

Integration test added to keep us honest in the future.

Closes #203