### PR TITLE
Better metadata caching

### DIFF
--- a/packages/cli/src/metadata/cache.ts
+++ b/packages/cli/src/metadata/cache.ts
@@ -5,9 +5,28 @@ import { writeFile, mkdir } from 'node:fs/promises';
 
 const getPath = (repoDir: string, key: string) => `${repoDir}/meta/${key}.json`;
 
-// TODO should we sort keys so that equivalent objects generate the same key?
-const generateKey = (config: any) =>
-  createHash('sha256').update(JSON.stringify(config)).digest('hex');
+// Sort keys on a json object so that the same object with different key order returns the same cache id
+// At this stage we're not sorting values (apart from objects)
+const sortKeys = (obj: Record<string, any>) => {
+  const newObj = {} as Record<string, any>;
+  Object.keys(obj)
+    .sort()
+    .forEach((k: string) => {
+      const v = obj[k];
+      if (!v || typeof v == 'string' || !isNaN(v) || Array.isArray(v)) {
+        newObj[k] = v;
+      } else {
+        newObj[k] = sortKeys(v);
+      }
+    });
+  return newObj;
+};
+
+const generateKey = (config: any, adaptor: string) => {
+  const sorted = sortKeys(config);
+  const key = `${JSON.stringify(sorted)}-${adaptor}}`;
+  return createHash('sha256').update(key).digest('hex');
+};
 
 const get = (repoPath: string, key: string) => {
   try {
@@ -29,4 +48,4 @@ const set = async (repoPath: string, key: string, data: any) => {
   await writeFile(fullPath, JSON.stringify(data));
 };
 
-export default { get, set, generateKey, getPath };
+export default { get, set, generateKey, getPath, sortKeys };

--- a/packages/cli/src/metadata/handler.ts
+++ b/packages/cli/src/metadata/handler.ts
@@ -2,7 +2,7 @@ import { Logger } from '../util/logger';
 import { SafeOpts } from '../commands';
 import loadState from '../execute/load-state';
 import cache from './cache';
-import { getModuleEntryPoint } from '@openfn/runtime';
+import { getModuleEntryPoint, getNameAndVersion } from '@openfn/runtime';
 
 // Add extra, uh, metadata to the, uh, metadata object
 const decorateMetadata = (metadata: any) => {
@@ -68,7 +68,7 @@ const metadataHandler = async (options: SafeOpts, logger: Logger) => {
     logger.print(cache.getPath(repoDir, id));
   };
 
-  const id = cache.generateKey(config);
+  const id = cache.generateKey(config, adaptor);
   if (!options.force) {
     // generate a hash for the config and check state
     logger.debug('config hash: ', id);

--- a/packages/cli/test/metadata/generate-key.test.ts
+++ b/packages/cli/test/metadata/generate-key.test.ts
@@ -1,0 +1,117 @@
+import test from 'ava';
+import cache from '../../src/metadata/cache';
+
+const eg = {
+  adaptor: 'common@1.0.0',
+  config: {
+    password: 'password123',
+    user: 'admin',
+  },
+};
+
+let defaultKey = '';
+
+test.before(() => {
+  defaultKey = cache.generateKey(eg.config, eg.adaptor);
+});
+
+test('generate a hash for default config', (t) => {
+  const hash = cache.generateKey(eg.config, eg.adaptor);
+  t.is(hash, defaultKey);
+});
+
+test('generate a hash for bad input', (t) => {
+  // @ts-ignore
+  const hash = cache.generateKey({}, undefined, undefined);
+  t.false(hash === defaultKey);
+  t.notRegex(hash, /undefined/);
+  t.is(hash.length, defaultKey.length);
+});
+
+test('generate a different hash for different config', (t) => {
+  const hash = cache.generateKey(
+    {
+      user: 'x',
+      password: 'y',
+    },
+    eg.adaptor
+  );
+  t.false(hash === defaultKey);
+  t.notRegex(hash, /user/);
+  t.notRegex(hash, /password/);
+  t.is(hash.length, defaultKey.length);
+});
+
+test('generate a different hash for different adaptor', (t) => {
+  const hash = cache.generateKey(eg.config, 'http');
+  t.false(hash === defaultKey);
+  t.notRegex(hash, /user/);
+  t.notRegex(hash, /password/);
+  t.is(hash.length, defaultKey.length);
+});
+
+test('generate a different hash for different adaptor version', (t) => {
+  const hash = cache.generateKey(eg.config, 'common@99');
+  t.false(hash === defaultKey);
+  t.notRegex(hash, /user/);
+  t.notRegex(hash, /password/);
+  t.is(hash.length, defaultKey.length);
+});
+
+test('generate a different hash for an adaptor with a path', (t) => {
+  const hash = cache.generateKey(eg.config, 'common=a/b/c');
+  t.false(hash === defaultKey);
+  t.notRegex(hash, /user/);
+  t.notRegex(hash, /password/);
+  t.is(hash.length, defaultKey.length);
+});
+
+test('generate the same for keys in a different order', (t) => {
+  const config = {
+    user: 'admin',
+    password: 'password123',
+  };
+  const hash = cache.generateKey(config, eg.adaptor);
+  t.is(hash, defaultKey);
+});
+
+test('generate the same for deep keys in a different order', (t) => {
+  const config = {
+    x: {
+      y: {
+        a: 'a',
+        b: 'b',
+        c: 'c',
+      },
+    },
+  };
+  const hash1 = cache.generateKey(config, eg.adaptor);
+
+  const config2 = {
+    x: {
+      y: {
+        b: 'b',
+        a: 'a',
+        c: 'c',
+      },
+    },
+  };
+  const hash2 = cache.generateKey(config2, eg.adaptor);
+
+  t.is(hash1, hash2);
+});
+
+// We don't sort arrays within the config
+test('generate a different hash for different array order', (t) => {
+  const config1 = {
+    arr: ['a', 'b'],
+  };
+  const config2 = {
+    arr: ['b', 'a'],
+  };
+
+  const hash1 = cache.generateKey(config1, eg.adaptor);
+  const hash2 = cache.generateKey(config2, eg.adaptor);
+
+  t.false(hash1 === hash2);
+});

--- a/packages/cli/test/metadata/sort-keys.test.ts
+++ b/packages/cli/test/metadata/sort-keys.test.ts
@@ -1,0 +1,102 @@
+import test from 'ava';
+import cache from '../../src/metadata/cache';
+
+test('sort keys', (t) => {
+  const sorted = cache.sortKeys({
+    z: 'x',
+    a: 'x',
+    A: 'x',
+  });
+
+  t.is(
+    JSON.stringify(sorted),
+    JSON.stringify({
+      A: 'x',
+      a: 'x',
+      z: 'x',
+    })
+  );
+});
+
+test('sort keys deeply', (t) => {
+  const sorted = cache.sortKeys({
+    y: {
+      z: 'x',
+      a: 'x',
+      A: 'x',
+    },
+    x: {
+      z: 'x',
+      a: 'x',
+      A: 'x',
+    },
+  });
+
+  t.is(
+    JSON.stringify(sorted),
+    JSON.stringify({
+      x: {
+        A: 'x',
+        a: 'x',
+        z: 'x',
+      },
+      y: {
+        A: 'x',
+        a: 'x',
+        z: 'x',
+      },
+    })
+  );
+});
+
+test("Don't sort arrays", (t) => {
+  const sorted = cache.sortKeys({
+    a: [9, 2, 3],
+  });
+  t.is(
+    JSON.stringify(sorted),
+    JSON.stringify({
+      a: [9, 2, 3],
+    })
+  );
+});
+
+test('handle numeric values', (t) => {
+  const sorted = cache.sortKeys({
+    a: 1,
+    b: -1,
+    c: Infinity,
+    d: NaN,
+    e: 0,
+    f: 0.5,
+  });
+  t.is(
+    JSON.stringify(sorted),
+    JSON.stringify({
+      a: 1,
+      b: -1,
+      c: Infinity,
+      d: NaN,
+      e: 0,
+      f: 0.5,
+    })
+  );
+});
+
+test('handle falsy values', (t) => {
+  const sorted = cache.sortKeys({
+    a: undefined,
+    b: null,
+    c: false,
+    d: 0,
+  });
+  t.is(
+    JSON.stringify(sorted),
+    JSON.stringify({
+      a: undefined,
+      b: null,
+      c: false,
+      d: 0,
+    })
+  );
+});


### PR DESCRIPTION
The CLI's metadata command does not take adaptor info into account when loading from the cache.

So if you pass the same config with a new adaptor, the CLI will wrongly return the cached result.

This PR fixes that and closes #215

It also sorts the keys of objects before caching, so `{ user: 'u', pass: 'p' }` and `{ pass: 'p', user: 'u' }` return the same cache key.