### PR TITLE
Restore runtime tests

### DIFF
--- a/packages/runtime/test/__repo__/node_modules/cjs_1.0.0/index.cjs
+++ b/packages/runtime/test/__repo__/node_modules/cjs_1.0.0/index.cjs
@@ -1,0 +1,1 @@
+module.exports =  42;

--- a/packages/runtime/test/__repo__/node_modules/cjs_1.0.0/package.json
+++ b/packages/runtime/test/__repo__/node_modules/cjs_1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cjs",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.cjs",
+  "private": true
+}

--- a/packages/runtime/test/__repo__/node_modules/ultimate-answer_1.0.0/index.js
+++ b/packages/runtime/test/__repo__/node_modules/ultimate-answer_1.0.0/index.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/runtime/test/__repo__/node_modules/ultimate-answer_1.0.0/package.json
+++ b/packages/runtime/test/__repo__/node_modules/ultimate-answer_1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ultimate-answer",
+  "version": "2.0.0",
+  "type": "module",
+  "module": "index.js",
+  "private": true
+}

--- a/packages/runtime/test/__repo__/node_modules/ultimate-answer_2.0.0/index.js
+++ b/packages/runtime/test/__repo__/node_modules/ultimate-answer_2.0.0/index.js
@@ -1,0 +1,1 @@
+export default 43;

--- a/packages/runtime/test/__repo__/node_modules/ultimate-answer_2.0.0/package.json
+++ b/packages/runtime/test/__repo__/node_modules/ultimate-answer_2.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ultimate-answer",
+  "version": "0.0.1",
+  "type": "module",
+  "module": "index.js",
+  "private": true
+}

--- a/packages/runtime/test/modules/linker.test.ts
+++ b/packages/runtime/test/modules/linker.test.ts
@@ -93,7 +93,7 @@ test('loads a cjs module from the repo', async (t) => {
   t.assert(m.namespace.default === 42);
 });
 
-test.only('loads a module from a path', async (t) => {
+test('loads a module from a path', async (t) => {
   const m = await linker('ultimate-answer', context, {
     modules: {
       ['ultimate-answer']: {


### PR DESCRIPTION
Somehow some of our test fixtures  got deleted. I didn't realise because of a  naughty `.only`.

This restores them to their former glory.