### PR TITLE
Error Handling overhaul

### DIFF
--- a/.changeset/chatty-readers-run.md
+++ b/.changeset/chatty-readers-run.md
@@ -1,0 +1,5 @@
+---
+'@openfn/logger': patch
+---
+
+Don't stringify error objects

--- a/.changeset/silly-rings-study.md
+++ b/.changeset/silly-rings-study.md
@@ -1,0 +1,5 @@
+---
+'@openfn/logger': patch
+---
+
+mock break() shoulnd't print anything

--- a/.changeset/smooth-toes-care.md
+++ b/.changeset/smooth-toes-care.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+Throw when a workflow is invalid

--- a/.changeset/strange-teachers-laugh.md
+++ b/.changeset/strange-teachers-laugh.md
@@ -1,0 +1,6 @@
+---
+'@openfn/cli': patch
+'@openfn/runtime': patch
+---
+
+Better error handling and reporting

--- a/integration-tests/cli/src/run.ts
+++ b/integration-tests/cli/src/run.ts
@@ -19,13 +19,10 @@ const mapOpenFnPath = (cmd) => {
 
 const run = async (
   cmd: string
-): Promise<{ stdout: string; stderr?: string }> => {
+): Promise<{ stdout: string; stderr?: string; err?: any }> => {
   return new Promise((resolve, reject) => {
     exec(mapOpenFnPath(cmd), options, (err, stdout, stderr) => {
-      if (err) {
-        reject(err);
-      }
-      resolve({ stdout, stderr });
+      resolve({ err, stdout, stderr });
     });
   });
 };

--- a/integration-tests/cli/test/errors.test.ts
+++ b/integration-tests/cli/test/errors.test.ts
@@ -1,0 +1,114 @@
+import test from 'ava';
+import path from 'node:path';
+import run from '../src/run';
+import { extractLogs } from '../src/util';
+
+const jobsPath = path.resolve('test/fixtures');
+
+// These are all errors that will stop the CLI from even running
+
+const assertLog = (t: any, logs: any[], re: RegExp) =>
+  t.assert(logs.find(({ message }) => re.test(message[0])));
+
+test.serial('job not found', async (t) => {
+  const { stdout, stderr, err } = await run('openfn blah.js --log-json');
+  t.is(err.code, 1);
+  const stdlogs = extractLogs(stdout);
+  const errlogs = extractLogs(stderr);
+
+  assertLog(t, errlogs, /job not found/i);
+  assertLog(t, stdlogs, /failed to load the job from blah.js/i);
+  assertLog(t, errlogs, /critical error: aborting command/i);
+});
+
+test.serial('workflow not found', async (t) => {
+  const { stdout, stderr, err } = await run('openfn blah.json --log-json');
+  t.is(err.code, 1);
+  const stdlogs = extractLogs(stdout);
+  const errlogs = extractLogs(stderr);
+
+  assertLog(t, errlogs, /workflow not found/i);
+  assertLog(t, stdlogs, /failed to load a workflow from blah.json/i);
+  assertLog(t, errlogs, /critical error: aborting command/i);
+});
+
+test.serial('job contains invalid js', async (t) => {
+  const { stdout, stderr, err } = await run(
+    `openfn ${jobsPath}/invalid.js --log-json`
+  );
+  t.is(err.code, 1);
+  const stdlogs = extractLogs(stdout);
+  const errlogs = extractLogs(stderr);
+
+  assertLog(t, errlogs, /failed to compile job/i);
+  assertLog(t, errlogs, /unexpected token \(2:10\)/i);
+  assertLog(t, stdlogs, /check the syntax of the job expression/i);
+  assertLog(t, errlogs, /critical error: aborting command/i);
+});
+
+// TODO this should really mention which job threw the error
+test.serial('workflow references a job with invalid js', async (t) => {
+  const { stdout, stderr, err } = await run(
+    `openfn ${jobsPath}/invalid-syntax.json --log-json`
+  );
+  t.is(err.code, 1);
+  const stdlogs = extractLogs(stdout);
+  const errlogs = extractLogs(stderr);
+
+  assertLog(t, errlogs, /failed to compile job/i);
+  assertLog(t, errlogs, /unexpected token \(2:10\)/i);
+  assertLog(t, stdlogs, /check the syntax of the job expression/i);
+  assertLog(t, errlogs, /critical error: aborting command/i);
+});
+
+test.serial("can't find an expression referenced in a workflow", async (t) => {
+  const { stdout, stderr, err } = await run(
+    `openfn ${jobsPath}/invalid-exp-path.json --log-json`
+  );
+  t.is(err.code, 1);
+  const stdlogs = extractLogs(stdout);
+  const errlogs = extractLogs(stderr);
+
+  assertLog(t, errlogs, /File not found for job 1: does-not-exist.js/i);
+  assertLog(
+    t,
+    stdlogs,
+    /This workflow references a file which cannot be found at does-not-exist.js/i
+  );
+  assertLog(t, errlogs, /critical error: aborting command/i);
+});
+
+test.serial("can't find config referenced in a workflow", async (t) => {
+  const { stdout, stderr, err } = await run(
+    `openfn ${jobsPath}/invalid-config-path.json --log-json`
+  );
+  t.is(err.code, 1);
+  const stdlogs = extractLogs(stdout);
+  const errlogs = extractLogs(stderr);
+
+  assertLog(t, errlogs, /File not found for job 1: does-not-exist.js/i);
+  assertLog(
+    t,
+    stdlogs,
+    /This workflow references a file which cannot be found at does-not-exist.js/i
+  );
+  assertLog(t, errlogs, /critical error: aborting command/i);
+});
+
+// test.serial.only('circular workflow', async (t) => {
+//   const { stdout, stderr, err } = await run(
+//     `openfn ${jobsPath}/circular.json --log-json`
+//   );
+//   t.is(err.code, 1);
+//   const stdlogs = extractLogs(stdout);
+//   const errlogs = extractLogs(stderr);
+//   console.log(stdlogs);
+//   console.log(errlogs);
+//   assertLog(t, errlogs, /File not found for job 1: does-not-exist.js/i);
+//   assertLog(
+//     t,
+//     stdlogs,
+//     /This workflow references a file which cannot be found at does-not-exist.js/i
+//   );
+//   assertLog(t, errlogs, /critical error: aborting command/i);
+// });

--- a/integration-tests/cli/test/execute-job.test.ts
+++ b/integration-tests/cli/test/execute-job.test.ts
@@ -63,16 +63,16 @@ test.serial(`openfn ${jobsPath}/simple.js -a common -O`, async (t) => {
 test.serial(
   `openfn ${jobsPath}/simple.js -a common --ignore-imports`,
   async (t) => {
-    const error = await t.throwsAsync(() => run(t.title));
-    t.regex(error.message, /(fn is not defined)/);
+    const { err } = await run(t.title);
+    t.regex(err.message, /(fn is not defined)/);
   }
 );
 
 test.serial(
   `openfn ${jobsPath}/simple.js -a common --ignore-imports=fn`,
   async (t) => {
-    const error = await t.throwsAsync(() => run(t.title));
-    t.regex(error.message, /(fn is not defined)/);
+    const { err } = await run(t.title);
+    t.regex(err.message, /(fn is not defined)/);
   }
 );
 

--- a/integration-tests/cli/test/execute-workflow.test.ts
+++ b/integration-tests/cli/test/execute-workflow.test.ts
@@ -141,3 +141,31 @@ test.serial(`openfn ${jobsPath}/wf-strict.json --no-strict`, async (t) => {
     ],
   });
 });
+
+test.serial(
+  `openfn ${jobsPath}/wf-errors.json -i -S "{ \\"data\\": { \\"number\\": 2 } }"`,
+  async (t) => {
+    await run(t.title);
+
+    const out = getJSON();
+    t.deepEqual(out, {
+      data: {
+        number: 3,
+      },
+    });
+  }
+);
+
+test.serial(
+  `openfn ${jobsPath}/wf-errors.json -S "{ \\"data\\": { \\"number\\": 32 } }"`,
+  async (t) => {
+    await run(t.title);
+
+    const out = getJSON();
+    t.deepEqual(out, {
+      data: {
+        number: 32,
+      },
+    });
+  }
+);

--- a/integration-tests/cli/test/fixtures/circular.json
+++ b/integration-tests/cli/test/fixtures/circular.json
@@ -1,0 +1,14 @@
+{
+  "jobs": [
+    {
+      "id": "a",
+      "expression": "x",
+      "next": { "b": true }
+    },
+    {
+      "id": "b",
+      "expression": "x",
+      "next": { "a": true }
+    }
+  ]
+}

--- a/integration-tests/cli/test/fixtures/invalid-config-path.json
+++ b/integration-tests/cli/test/fixtures/invalid-config-path.json
@@ -1,0 +1,7 @@
+{
+  "jobs": [
+    {
+      "configuration": "does-not-exist.json"
+    }
+  ]
+}

--- a/integration-tests/cli/test/fixtures/invalid-exp-path.json
+++ b/integration-tests/cli/test/fixtures/invalid-exp-path.json
@@ -1,0 +1,7 @@
+{
+  "jobs": [
+    {
+      "expression": "does-not-exist.js"
+    }
+  ]
+}

--- a/integration-tests/cli/test/fixtures/invalid-start.json
+++ b/integration-tests/cli/test/fixtures/invalid-start.json
@@ -1,0 +1,9 @@
+{
+  "start": "nope",
+  "jobs": [
+    {
+      "id": "x",
+      "expression": "fn((state) => state)"
+    }
+  ]
+}

--- a/integration-tests/cli/test/fixtures/invalid-syntax.json
+++ b/integration-tests/cli/test/fixtures/invalid-syntax.json
@@ -1,0 +1,7 @@
+{
+  "jobs": [
+    {
+      "expression": "invalid.js"
+    }
+  ]
+}

--- a/integration-tests/cli/test/fixtures/invalid.js
+++ b/integration-tests/cli/test/fixtures/invalid.js
@@ -1,0 +1,2 @@
+// Subtle ish syntax error
+fn((s) => })

--- a/integration-tests/cli/test/fixtures/multiple-inputs.json
+++ b/integration-tests/cli/test/fixtures/multiple-inputs.json
@@ -1,0 +1,18 @@
+{
+  "jobs": [
+    {
+      "id": "a",
+      "expression": "x",
+      "next": { "b": true, "c": true }
+    },
+    {
+      "id": "b",
+      "expression": "x",
+      "next": { "c": true }
+    },
+    {
+      "id": "c",
+      "expression": "x"
+    }
+  ]
+}

--- a/integration-tests/cli/test/fixtures/wf-errors.json
+++ b/integration-tests/cli/test/fixtures/wf-errors.json
@@ -1,0 +1,24 @@
+{
+  "start": "start",
+  "jobs": [
+    {
+      "id": "start",
+      "adaptor": "common",
+      "expression": "fn((state) => { if (state.data.number > 10) { throw new Error('abort') }; return state; });",
+      "next": {
+        "increment": { "condition": "!state.errors" },
+        "do nothing": { "condition": "state.errors" }
+      }
+    },
+    {
+      "id": "increment",
+      "adaptor": "common",
+      "expression": "fn((state) => { state.data.number += 1; return state; });"
+    },
+    {
+      "id": "do nothing",
+      "adaptor": "common",
+      "expression": "fn((state) => state);"
+    }
+  ]
+}

--- a/integration-tests/cli/test/metadata.test.ts
+++ b/integration-tests/cli/test/metadata.test.ts
@@ -20,7 +20,7 @@ test.before(async () => {
 test.serial(
   `openfn metadata -S "${state}" -a test=${modulePath} --log-json --log info`,
   async (t) => {
-    const { stdout, stderr } = await run(t.title);
+    const { stdout } = await run(t.title);
 
     t.regex(stdout, /Generating metadata/);
     t.regex(stdout, /Metadata function found. Generating metadata/);
@@ -49,7 +49,7 @@ test.serial(
 test.serial(
   `openfn metadata -S "${state}" --adaptor test=${modulePath} --log-json --log info`,
   async (t) => {
-    const { stdout, stderr } = await run(t.title);
+    const { stdout } = await run(t.title);
     t.regex(stdout, /Generating metadata/);
     t.notRegex(stdout, /Metadata function found. Generating metadata/);
     t.regex(stdout, /Returning metadata from cache/);
@@ -70,7 +70,7 @@ test.serial(
 test.serial(
   `openfn metadata -S "${state}" --a test=${modulePath} -f --log-json --log info`,
   async (t) => {
-    const { stdout, stderr } = await run(t.title);
+    const { stdout } = await run(t.title);
 
     t.regex(stdout, /Generating metadata/);
     t.regex(stdout, /Metadata function found. Generating metadata/);

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -111,9 +111,14 @@ const parse = async (basePath: string, options: Opts, log?: Logger) => {
     if (!process.exitCode) {
       process.exitCode = e.exitCode || 1;
     }
-    logger.break();
-    logger.error('Command failed!');
-    logger.error(e);
+    if (e.handled) {
+      // If throwing an epected error from util/abort, we do nothing
+    } else {
+      // This is unexpected error and we should try to log something
+      logger.break();
+      logger.error('Command failed!');
+      logger.error(e);
+    }
   }
 };
 

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -1,6 +1,7 @@
 import compile, { preloadAdaptorExports, Options } from '@openfn/compiler';
 import { getModulePath, ExecutionPlan } from '@openfn/runtime';
 import createLogger, { COMPILER, Logger } from '../util/logger';
+import abort from '../util/abort';
 import type { CompileOptions } from './command';
 
 // Load and compile a job from a file, then return the result
@@ -11,8 +12,7 @@ export default async (opts: CompileOptions, log: Logger) => {
   if (opts.workflow) {
     job = compileWorkflow(opts.workflow, opts, log);
   } else {
-    const compilerOptions: Options = await loadTransformOptions(opts, log);
-    job = compile((opts.job || opts.jobPath) as string, compilerOptions);
+    job = await compileJob((opts.job || opts.jobPath) as string, opts, log);
   }
 
   if (opts.jobPath) {
@@ -21,6 +21,25 @@ export default async (opts: CompileOptions, log: Logger) => {
     log.success('Compilation complete');
   }
   return job;
+};
+
+const compileJob = async (
+  job: string,
+  opts: CompileOptions,
+  log: Logger,
+  jobName?: string
+) => {
+  try {
+    const compilerOptions: Options = await loadTransformOptions(opts, log);
+    return compile(job, compilerOptions);
+  } catch (e: any) {
+    abort(
+      log,
+      `Failed to compile job ${jobName ?? ''}`.trim(),
+      e,
+      'Check the syntax of the job expression:\n\n' + job
+    );
+  }
 };
 
 // Find every expression in the job and run the compiler on it
@@ -36,10 +55,13 @@ const compileWorkflow = async (
     if (job.adaptor) {
       jobOpts.adaptors = [job.adaptor];
     }
-    const compilerOptions: Options = await loadTransformOptions(jobOpts, log);
-
     if (job.expression) {
-      job.expression = compile(job.expression as string, compilerOptions);
+      job.expression = await compileJob(
+        job.expression as string,
+        opts,
+        log,
+        job.id
+      );
     }
   }
   return workflow;

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -58,7 +58,7 @@ const compileWorkflow = async (
     if (job.expression) {
       job.expression = await compileJob(
         job.expression as string,
-        opts,
+        jobOpts,
         log,
         job.id
       );

--- a/packages/cli/src/execute/execute.ts
+++ b/packages/cli/src/execute/execute.ts
@@ -1,35 +1,38 @@
 import run, { getNameAndVersion } from '@openfn/runtime';
 import type { ModuleInfo, ModuleInfoMap, ExecutionPlan } from '@openfn/runtime';
-import createLogger, { RUNTIME, JOB } from '../util/logger';
+import createLogger, { RUNTIME, JOB, Logger } from '../util/logger';
+import abort from '../util/abort';
 import { ExecuteOptions } from './command';
 
 type ExtendedModuleInfo = ModuleInfo & {
   name: string;
 };
 
-// TODO job and workflow are both on the options object, can we just take opts?
-export default (
+export default async (
   input: string | ExecutionPlan,
   state: any,
-  opts: Omit<ExecuteOptions, 'jobPath'>
+  opts: Omit<ExecuteOptions, 'jobPath'>,
+  logger: Logger
 ): Promise<any> => {
-  // TODO listen to runtime events and log them
-  // events appeal because we don't have to pass two loggers into the runtime
-  // we can just listen to runtime events and do the logging ourselves here
-  // Then again, maybe that doesn't make sense
-  // Maybe we have to feed a job logger in?
-  return run(input, state, {
-    strict: opts.strict,
-    start: opts.start,
-    timeout: opts.timeout,
-    immutableState: opts.immutable,
-    logger: createLogger(RUNTIME, opts as any), // TODO log types are flaky right now
-    jobLogger: createLogger(JOB, opts as any), // ditto
-    linker: {
-      repo: opts.repoDir,
-      modules: parseAdaptors(opts),
-    },
-  });
+  try {
+    const result = await run(input, state, {
+      strict: opts.strict,
+      start: opts.start,
+      timeout: opts.timeout,
+      immutableState: opts.immutable,
+      logger: createLogger(RUNTIME, opts as any), // TODO log types are flaky right now
+      jobLogger: createLogger(JOB, opts as any), // ditto
+      linker: {
+        repo: opts.repoDir,
+        modules: parseAdaptors(opts),
+      },
+    });
+    return result;
+  } catch (e: any) {
+    // The runtime will throw if it's give something it can't execute
+    // TODO Right now we assume this is a validation error (compilation errors should be caught already)
+    abort(logger, 'Invalid workflow', e);
+  }
 };
 
 // TODO we should throw if the adaptor strings are invalid for any reason

--- a/packages/cli/src/execute/handler.ts
+++ b/packages/cli/src/execute/handler.ts
@@ -45,21 +45,21 @@ const executeHandler = async (options: ExecuteOptions, logger: Logger) => {
   }
 
   try {
-    const result = await execute(input!, state, options);
+    const result = await execute(input!, state, options, logger);
     await serializeOutput(options, result, logger);
     const duration = printDuration(new Date().getTime() - start);
     if (result.errors) {
       logger.warn(
         `Errors reported in ${Object.keys(result.errors).length} jobs`
       );
-    } else {
     }
     logger.success(`Finished in ${duration}${result.errors ? '' : ' ✨'}`);
     return result;
-  } catch (err) {
-    logger.error('Unexpected error in execution');
-    logger.error(err);
-
+  } catch (err: any) {
+    if (!err.handled) {
+      logger.error('Unexpected error in execution');
+      logger.error(err);
+    }
     const duration = printDuration(new Date().getTime() - start);
     logger.always(`Workflow failed in ${duration}.`);
     process.exitCode = 1;

--- a/packages/cli/src/execute/handler.ts
+++ b/packages/cli/src/execute/handler.ts
@@ -46,18 +46,22 @@ const executeHandler = async (options: ExecuteOptions, logger: Logger) => {
 
   try {
     const result = await execute(input!, state, options);
-    // TODO if result.errors, report some kind of error feedback
     await serializeOutput(options, result, logger);
     const duration = printDuration(new Date().getTime() - start);
-    logger.success(`Done in ${duration}! ✨`); // TODO different emoji if error
+    if (result.errors) {
+      logger.warn(
+        `Errors reported in ${Object.keys(result.errors).length} jobs`
+      );
+    } else {
+    }
+    logger.success(`Finished in ${duration}${result.errors ? '' : ' ✨'}`);
     return result;
-  } catch (error) {
-    // TODO this now should only be an unexpected error
-    // The runtime should handle most errors itself
-    // logger.error(error);
+  } catch (err) {
+    logger.error('Unexpected error in execution');
+    logger.error(err);
 
     const duration = printDuration(new Date().getTime() - start);
-    logger.error(`Took ${duration}.`);
+    logger.always(`Workflow failed in ${duration}.`);
     process.exitCode = 1;
   }
 };

--- a/packages/cli/src/execute/handler.ts
+++ b/packages/cli/src/execute/handler.ts
@@ -46,12 +46,15 @@ const executeHandler = async (options: ExecuteOptions, logger: Logger) => {
 
   try {
     const result = await execute(input!, state, options);
+    // TODO if result.errors, report some kind of error feedback
     await serializeOutput(options, result, logger);
     const duration = printDuration(new Date().getTime() - start);
-    logger.success(`Done in ${duration}! ✨`);
+    logger.success(`Done in ${duration}! ✨`); // TODO different emoji if error
     return result;
   } catch (error) {
-    logger.error(error);
+    // TODO this now should only be an unexpected error
+    // The runtime should handle most errors itself
+    // logger.error(error);
 
     const duration = printDuration(new Date().getTime() - start);
     logger.error(`Took ${duration}.`);

--- a/packages/cli/src/execute/serialize-output.ts
+++ b/packages/cli/src/execute/serialize-output.ts
@@ -11,6 +11,9 @@ const serializeOutput = async (
   if (output && (output.configuration || output.data)) {
     if (options.strict) {
       output = { data: output.data };
+      if (result.errors) {
+        output.errors = result.errors;
+      }
     } else {
       const { configuration, ...rest } = result;
       output = rest;

--- a/packages/cli/src/execute/serialize-output.ts
+++ b/packages/cli/src/execute/serialize-output.ts
@@ -28,10 +28,11 @@ const serializeOutput = async (
 
   if (options.outputStdout) {
     logger.success(`Result: `);
-    logger.success(output);
+    logger.always(output);
   } else if (options.outputPath) {
-    logger.success(`Writing output to ${options.outputPath}`);
+    logger.debug(`Writing output to ${options.outputPath}`);
     await writeFile(options.outputPath, output);
+    logger.success(`State written to ${options.outputPath}`);
   }
 
   return output;

--- a/packages/cli/src/util/abort.ts
+++ b/packages/cli/src/util/abort.ts
@@ -1,0 +1,28 @@
+import { Logger } from '@openfn/logger';
+
+class AbortError extends Error {
+  constructor(reason: string) {
+    super(reason);
+  }
+  handled = true;
+}
+
+// This is always the CLI logger, can I trap it?
+export default (
+  logger: Logger,
+  reason: string,
+  error?: Error,
+  help?: string
+) => {
+  const e = new AbortError(reason);
+  logger.error(reason);
+  if (error) {
+    logger.error(error.message);
+  }
+  if (help) {
+    logger.always(help);
+  }
+  logger.break();
+  logger.error('Critical error: aborting command');
+  throw e;
+};

--- a/packages/cli/src/util/load-input.ts
+++ b/packages/cli/src/util/load-input.ts
@@ -14,7 +14,6 @@ export default async (
   opts: Pick<Opts, 'jobPath' | 'workflowPath' | 'workflow' | 'job'>,
   log: Logger
 ) => {
-  log.debug('Loading input...');
   const { job, workflow, jobPath, workflowPath } = opts;
   if (workflow || workflowPath) {
     return loadWorkflow(opts as LoadWorkflowOpts, log);

--- a/packages/cli/src/util/load-input.ts
+++ b/packages/cli/src/util/load-input.ts
@@ -28,7 +28,7 @@ export default async (
       log.debug(`Loading job from ${jobPath}`);
       opts.job = await fs.readFile(jobPath, 'utf8');
       return opts.job;
-    } catch (e) {
+    } catch (e: any) {
       abort(
         log,
         'Job not found',
@@ -59,7 +59,7 @@ const loadWorkflow = async (opts: LoadWorkflowOpts, log: Logger) => {
   const parseWorkflow = (contents: string) => {
     try {
       return JSON.parse(contents);
-    } catch (e) {
+    } catch (e: any) {
       abort(
         log,
         'Invalid JSON in workflow',
@@ -98,7 +98,6 @@ const loadWorkflow = async (opts: LoadWorkflowOpts, log: Logger) => {
     if (workflowPath) {
       let workflowRaw = await readWorkflow();
       wf = parseWorkflow(workflowRaw!);
-
       if (!rootDir) {
         // TODO this may not be neccessary, but keeping just in case
         rootDir = path.dirname(workflowPath);
@@ -114,20 +113,22 @@ const loadWorkflow = async (opts: LoadWorkflowOpts, log: Logger) => {
     let idx = 0;
     for (const job of wf.jobs) {
       idx += 1;
-      const expression = job.expression?.trim();
-      const configuration = job.configuration?.trim();
-      if (typeof expression === 'string' && isPath(expression)) {
+      const expressionStr =
+        typeof job.expression === 'string' && job.expression?.trim();
+      const configurationStr =
+        typeof job.configuration === 'string' && job.configuration?.trim();
+      if (expressionStr && isPath(expressionStr)) {
         job.expression = await fetchWorkflowFile(
           job.id || `${idx}`,
           rootDir,
-          expression
+          expressionStr
         );
       }
-      if (typeof configuration === 'string' && isPath(configuration)) {
+      if (configurationStr && isPath(configurationStr)) {
         const configString = await fetchWorkflowFile(
           job.id || `${idx}`,
           rootDir,
-          configuration
+          configurationStr
         );
         job.configuration = JSON.parse(configString!);
       }

--- a/packages/logger/src/mock.ts
+++ b/packages/logger/src/mock.ts
@@ -54,6 +54,8 @@ const mockLogger = <T = StringLog>(
   // Type shenanegans while we append the mock APIs
   const mock = m as MockLogger<T>;
 
+  mock.break = () => {}; // do nothing
+
   // TODO should this use json?
   mock.print = (...out: any[]) => {
     if (opts.level !== 'none') {

--- a/packages/logger/src/sanitize.ts
+++ b/packages/logger/src/sanitize.ts
@@ -15,7 +15,7 @@ const sanitize = (item: any, options: SanitizeOptions = {}) => {
     options.stringify === false ? o : stringify(o);
 
   if (item instanceof Error) {
-    return item.toString();
+    return item;
   }
 
   if (

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -377,3 +377,11 @@ test('ignore functions on logged objects', async (t) => {
   const { message } = logger._parse(logger._last);
   t.is(message, '{"a":1}');
 });
+
+test('log an error object', (t) => {
+  const logger = createLogger();
+  logger.error(new Error('err'));
+
+  const { message } = logger._parse(logger._last);
+  t.assert(message instanceof Error);
+});

--- a/packages/logger/test/sanitize.test.ts
+++ b/packages/logger/test/sanitize.test.ts
@@ -22,23 +22,23 @@ test('simply return undefined', (t) => {
   t.deepEqual(result, undefined);
 });
 
-test('stringify an error', (t) => {
+test("don't stringify errors", (t) => {
   const e = new Error('test');
   const result = sanitize(e);
-  t.regex(result, /test/);
+  t.assert(result instanceof Error);
 });
 
-test('stringify ReferenceError', (t) => {
+test("Don't stringify ReferenceError", (t) => {
   const e = new ReferenceError('test');
   const result = sanitize(e);
-  t.regex(result, /ReferenceError/);
+  t.assert(result instanceof ReferenceError);
 });
 
-test('stringify a custom error', (t) => {
+test("Don't stringify a custom error", (t) => {
   class CustomError extends Error {}
   const e = new CustomError('test');
   const result = sanitize(e);
-  t.regex(result, /test/);
+  t.assert(result instanceof Error);
 });
 
 test('stringify an object', (t) => {

--- a/packages/runtime/src/execute/compile-plan.ts
+++ b/packages/runtime/src/execute/compile-plan.ts
@@ -98,7 +98,9 @@ export default (plan: ExecutionPlan) => {
   }
 
   if (errs.length) {
-    throw errs;
+    const e = new Error('compilation error');
+    e.message = errs.map(({ message }) => message).join('\n\n');
+    throw e;
   }
 
   return newPlan as CompiledExecutionPlan;

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -2,12 +2,7 @@ import { printDuration, Logger } from '@openfn/logger';
 import stringify from 'fast-safe-stringify';
 import loadModule from '../modules/module-loader';
 import { Operation, JobModule, State } from '../types';
-import {
-  Options,
-  ERR_TIMEOUT,
-  ERR_RUNTIME_EXCEPTION,
-  TIMEOUT,
-} from '../runtime';
+import { Options, ERR_TIMEOUT, TIMEOUT } from '../runtime';
 import buildContext, { Context } from './context';
 import defaultExecute from '../util/execute';
 import clone from '../util/clone';

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -35,29 +35,26 @@ export default (
     );
 
     // Run the pipeline
-    logger.debug(`Executing expression (${operations.length} operations)`);
-
-    const tid = setTimeout(() => {
-      logger.error(`Error: Timeout (${timeout}ms) expired!`);
-      logger.error('  Set a different timeout by passing "-t 10000" ms)');
-      reject(Error(ERR_TIMEOUT));
-    }, timeout);
-
     try {
+      logger.debug(`Executing expression (${operations.length} operations)`);
+
+      const tid = setTimeout(() => {
+        logger.error(`Error: Timeout (${timeout}ms) expired!`);
+        logger.error('  Set a different timeout by passing "-t 10000" ms)');
+        reject(Error(ERR_TIMEOUT));
+      }, timeout);
+
+      // Note that any errors will be trapped by the containing Job
       const result = await reducer(initialState);
+
       clearTimeout(tid);
       logger.debug('Expression complete!');
       logger.debug(result);
+
       // return the final state
       resolve(prepareFinalState(opts, result));
     } catch (e: any) {
-      // Note: e will be some kind of serialized error object and not an instance of Error
-      // See https://github.com/OpenFn/kit/issues/143
-      logger.error('Error in runtime execution!');
-      if (e.toString) {
-        logger.error(e.toString());
-      }
-      reject(new Error(ERR_RUNTIME_EXCEPTION));
+      reject(e);
     }
   });
 

--- a/packages/runtime/src/execute/plan.ts
+++ b/packages/runtime/src/execute/plan.ts
@@ -96,25 +96,15 @@ const executeJob = async (
         ctx.logger,
         ctx.opts
       );
+      const duration = ctx.logger.timer('job');
+      ctx.logger.success(`Completed job ${jobId} in ${duration}`);
     } catch (e: any) {
-      // Can I tell the difference between:
-      // a) a deliberate throw in user code (ie, throw Error())
-      // b) an unexpected error in user code (ie state.data.undefined = 10)
-      // c) an error coming from an adaptor (or third party) (ie, HTTP 500)
-      // Report the error and carry on
-
-      let type = 'RuntimeException';
-      if (e.code) {
-        // if the error has a code, it's come from a library (adaptor)
-        type = 'AdaptorException';
-      }
-
-      ctx.report(state, jobId, type, e);
+      const duration = ctx.logger.timer('job');
+      ctx.logger.error(`Failed job ${jobId} after ${duration}`);
+      ctx.report(state, jobId, e);
     }
   }
 
-  const duration = ctx.logger.timer('job');
-  ctx.logger.success(`Completed job "${jobId}" in ${duration}`);
   if (job.next) {
     for (const nextJobId in job.next) {
       const edge = job.next[nextJobId];

--- a/packages/runtime/src/execute/plan.ts
+++ b/packages/runtime/src/execute/plan.ts
@@ -31,16 +31,8 @@ const executePlan = async (
     validatePlan(plan);
     compiledPlan = compilePlan(plan);
   } catch (e: any) {
-    return {
-      error: {
-        code: 1, // TODO what error code is an invalid plan?
-        // TODO compilation may throw several errors, for now we'll just
-        // concatenate them into one big message
-        message: Array.isArray(e)
-          ? e.map((e: any) => e.message).join('\n')
-          : e.message,
-      },
-    };
+    // If the plan is invalid, abort before trying to execute
+    throw e;
   }
 
   let queue: string[] = [opts.start || compiledPlan.start];

--- a/packages/runtime/src/execute/plan.ts
+++ b/packages/runtime/src/execute/plan.ts
@@ -77,7 +77,7 @@ const executeJob = async (
   const job = ctx.plan.jobs[jobId];
 
   ctx.logger.timer('job');
-  ctx.logger.info('Starting job', jobId);
+  ctx.logger.always('Starting job', jobId);
 
   const state = assembleState(
     initialState,

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -9,8 +9,6 @@ export const TIMEOUT = 5 * 60 * 1000; // 5 minutes
 
 // TODO move error strings into one file
 export const ERR_TIMEOUT = 'timeout';
-// TODO maybe this is a job exception? Job fail?
-export const ERR_RUNTIME_EXCEPTION = 'runtime exception';
 
 export type Options = {
   start?: JobNodeID;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,4 +1,5 @@
 // TMP just thinking through things
+// I dont think this is useufl? We can just use error.name of the error object
 export type ErrorTypes =
   | 'AdaptorNotFound' // probably a CLI validation thing
   | 'PackageNotFound' // Linker failed to load a dependency
@@ -7,12 +8,13 @@ export type ErrorTypes =
   | 'RuntimeException'; // Caused by an exception in a job. JobException? What about "expected" errors from adaptors?
 
 export type ErrorReport = {
-  type: ErrorTypes; // some kind of name like AdaptorNotFound. Need a
+  name: string; // The name/type of error, ie Error, TypeError
   message: string; // simple human readable message
   jobId: JobNodeID; // ID of the associated job
-  error: string; // Serialisation of the actual error object
+  error: Error; // the original underlying error object
 
-  stacktrace?: string; // not sure this is useful?
+  code?: string; // The error code, if any (found on node errors)
+  stack?: string; // not sure this is useful?
   data?: any; // General store for related error information
 };
 

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,8 +1,34 @@
+// TMP just thinking through things
+export type ErrorTypes =
+  | 'AdaptorNotFound' // probably a CLI validation thing
+  | 'PackageNotFound' // Linker failed to load a dependency
+  | 'ExpressionTimeout' // An expression (job) failed to return before the timeout
+  | 'AdaptorException' //  Bubbled out of adaptor code
+  | 'RuntimeException'; // Caused by an exception in a job. JobException? What about "expected" errors from adaptors?
+
+export type ErrorReport = {
+  type: ErrorTypes; // some kind of name like AdaptorNotFound. Need a
+  message: string; // simple human readable message
+  jobId: JobNodeID; // ID of the associated job
+  error: string; // Serialisation of the actual error object
+
+  stacktrace?: string; // not sure this is useful?
+  data?: any; // General store for related error information
+};
+
 export declare interface State<D = object, C = object> {
   configuration?: C;
   data?: D;
   references?: Array<any>;
   index?: number;
+
+  // New error capture object
+  // Synonyms: exceptions, problems, issues, err, failures
+  errors?: Record<JobNodeID, ErrorReport>;
+
+  // Legacy error property from old platform
+  // Adaptors may use this?
+  error?: any[];
 
   // Note that other properties written to state may be lost between jobs
   [other: string]: any;

--- a/packages/runtime/src/util/assemble-state.ts
+++ b/packages/runtime/src/util/assemble-state.ts
@@ -9,6 +9,9 @@ const assembleState = (
   if (initialState.references) {
     obj.references = initialState.references;
   }
+  if (initialState.errors) {
+    obj.errors = initialState.errors;
+  }
   Object.assign(obj, {
     configuration: Object.assign(
       {},

--- a/packages/runtime/src/util/log-error.ts
+++ b/packages/runtime/src/util/log-error.ts
@@ -1,0 +1,48 @@
+import { Logger } from '@openfn/logger';
+import { ErrorTypes, JobNodeID, State } from '../types';
+
+export type ErrorReporter = (
+  state: State,
+  jobId: JobNodeID,
+  type: ErrorTypes,
+  error: Error
+) => void;
+
+const createErrorReporter = (logger: Logger): ErrorReporter => {
+  // Util to save an error to state
+  // Is this worth it?
+  // Maybe later it can help with source mapping
+  return (state, jobId, type, error) => {
+    const report = {
+      jobId,
+      type,
+      message: error.message,
+      error: error, // Should include the code
+    };
+
+    const { stack } = error;
+    if (stack?.match(/at vm:module/)) {
+      // TODO if this is a vm:module error, try to pull something useful (like the line in question)
+      // stack trace is useless but source line is useful
+    } else {
+      report.stack = stack;
+    }
+
+    logger.error(`Error in job "${jobId}"`);
+    logger.error(`${error.code || type}: ${report.message}`);
+    logger.debug(`Error written to state.errors.${jobId}`);
+    logger.info(error); // tODO the logger doesn't handle this very well
+    // console.log(error);
+    // console.log(error.code);
+
+    if (!state.errors) {
+      state.errors = {};
+    }
+
+    // Can a job raise multiple errors? I think it'll abort
+    // after the first
+    state.errors[jobId] = report;
+  };
+};
+
+export default createErrorReporter;

--- a/packages/runtime/src/util/log-error.ts
+++ b/packages/runtime/src/util/log-error.ts
@@ -1,47 +1,39 @@
 import { Logger } from '@openfn/logger';
-import { ErrorTypes, JobNodeID, State } from '../types';
+import { JobNodeID, State } from '../types';
 
 export type ErrorReporter = (
   state: State,
   jobId: JobNodeID,
-  type: ErrorTypes,
   error: Error
 ) => void;
 
 const createErrorReporter = (logger: Logger): ErrorReporter => {
-  // Util to save an error to state
-  // Is this worth it?
-  // Maybe later it can help with source mapping
-  return (state, jobId, type, error) => {
+  return (state, jobId, error) => {
     const report = {
+      name: error.name,
       jobId,
-      type,
       message: error.message,
-      error: error, // Should include the code
+      error: error,
     };
 
-    const { stack } = error;
-    if (stack?.match(/at vm:module/)) {
-      // TODO if this is a vm:module error, try to pull something useful (like the line in question)
-      // stack trace is useless but source line is useful
-    } else {
-      report.stack = stack;
+    if (error.code) {
+      // An error coming from node will have a useful code and stack trace
+      report.code = error.code as string;
+      report.stack = error.stack as string;
     }
 
-    logger.error(`Error in job "${jobId}"`);
-    logger.error(`${error.code || type}: ${report.message}`);
+    logger.debug(`Error thrown by job ${jobId}`);
+    logger.error(`${error.code || error.name || type}: ${report.message}`);
     logger.debug(`Error written to state.errors.${jobId}`);
-    logger.info(error); // tODO the logger doesn't handle this very well
-    // console.log(error);
-    // console.log(error.code);
+    logger.debug(error); // TODO the logger doesn't handle this very well
 
     if (!state.errors) {
       state.errors = {};
     }
 
-    // Can a job raise multiple errors? I think it'll abort
-    // after the first
     state.errors[jobId] = report;
+
+    return report;
   };
 };
 

--- a/packages/runtime/test/execute/compile-plan.test.ts
+++ b/packages/runtime/test/execute/compile-plan.test.ts
@@ -187,15 +187,12 @@ test('throw for a syntax error on a job edge', (t) => {
 
   try {
     compilePlan(plan);
-  } catch (errors: any) {
-    t.true(Array.isArray(errors));
-    t.is(errors.length, 1);
-    const err = errors[0];
+  } catch (err: any) {
     t.regex(err.message, /failed to compile(.*)a->b/i);
   }
 });
 
-test('throw for a multiple errors', (t) => {
+test('throw for multiple errors', (t) => {
   const plan = {
     jobs: [
       {
@@ -215,8 +212,10 @@ test('throw for a multiple errors', (t) => {
 
   try {
     compilePlan(plan);
-  } catch (errors: any) {
-    t.true(Array.isArray(errors));
-    t.is(errors.length, 2);
+  } catch (e) {
+    // the message will have have one error per line
+    const { message } = e;
+    const lines = message.split('\n\n');
+    t.is(lines.length, 2);
   }
 });

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -14,7 +14,7 @@ const executePlan = (
   logger = mockLogger
 ): any => execute(plan, state, options, logger);
 
-test('report an error for a circular job', async (t) => {
+test('throw for a circular job', async (t) => {
   const plan: ExecutionPlan = {
     start: 'job1',
     jobs: [
@@ -30,12 +30,11 @@ test('report an error for a circular job', async (t) => {
       },
     ],
   };
-  const result = await executePlan(plan);
-  t.assert(result.hasOwnProperty('error'));
-  t.regex(result.error.message, /circular dependency/i);
+  const e = await t.throwsAsync(() => executePlan(plan));
+  t.regex(e!.message, /circular dependency/i);
 });
 
-test('report an error for a job with multiple inputs', async (t) => {
+test('throw for a job with multiple inputs', async (t) => {
   // TODO maybe this isn't a good test - job1 and job2 both input to job3, but job2 never gets called
   const plan: ExecutionPlan = {
     start: 'job1',
@@ -57,12 +56,11 @@ test('report an error for a job with multiple inputs', async (t) => {
       },
     ],
   };
-  const result = await executePlan(plan);
-  t.assert(result.hasOwnProperty('error'));
-  t.regex(result.error.message, /multiple dependencies/i);
+  const e = await t.throwsAsync(() => executePlan(plan));
+  t.regex(e!.message, /multiple dependencies/i);
 });
 
-test('report an error for a plan which references an undefined job', async (t) => {
+test('throw for a plan which references an undefined job', async (t) => {
   const plan: ExecutionPlan = {
     start: 'job1',
     jobs: [
@@ -73,12 +71,11 @@ test('report an error for a plan which references an undefined job', async (t) =
       },
     ],
   };
-  const result = await executePlan(plan);
-  t.assert(result.hasOwnProperty('error'));
-  t.regex(result.error.message, /cannot find job/i);
+  const e = await t.throwsAsync(() => executePlan(plan));
+  t.regex(e!.message, /cannot find job/i);
 });
 
-test('report an error for an illegal edge condition', async (t) => {
+test('throw for an illegal edge condition', async (t) => {
   const plan: ExecutionPlan = {
     jobs: [
       {
@@ -93,12 +90,11 @@ test('report an error for an illegal edge condition', async (t) => {
       { id: 'b' },
     ],
   };
-  const result = await executePlan(plan);
-  t.assert(result.hasOwnProperty('error'));
-  t.regex(result.error.message, /failed to compile edge condition a->b/i);
+  const e = await t.throwsAsync(() => executePlan(plan));
+  t.regex(e!.message, /failed to compile edge condition a->b/i);
 });
 
-test('report an error for an edge condition', async (t) => {
+test('throw for an edge condition', async (t) => {
   const plan: ExecutionPlan = {
     jobs: [
       {
@@ -112,9 +108,8 @@ test('report an error for an edge condition', async (t) => {
       { id: 'b' },
     ],
   };
-  const result = await executePlan(plan);
-  t.assert(result.hasOwnProperty('error'));
-  t.regex(result.error.message, /failed to compile edge condition/i);
+  const e = await t.throwsAsync(() => executePlan(plan));
+  t.regex(e!.message, /failed to compile edge condition/i);
 });
 
 test('execute a one-job execution plan with inline state', async (t) => {

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -550,13 +550,12 @@ test('log appopriately on error', async (t) => {
   };
 
   const logger = createMockLogger(undefined, { level: 'debug' });
-  const result = await executePlan(plan, {}, {}, logger);
-  t.log(result);
+
+  await executePlan(plan, {}, {}, logger);
 
   const err = logger._find('error', /failed job/i);
-  t.log(err);
   t.truthy(err);
-  t.regex(err.message, /Failed job job1 after \d+ms/i);
+  t.regex(err!.message as string, /Failed job job1 after \d+ms/i);
 
   t.truthy(logger._find('debug', /error thrown by job job1/i));
   t.truthy(logger._find('error', /Error: e/));


### PR DESCRIPTION
This PR resolves many issues around error handling.

Note that this is based on the improved logging stuff.

![image](https://user-images.githubusercontent.com/7052509/235197028-53b65a87-4273-4158-aca0-88d1df0d7fd5.png)

* The runtime will throw if it considers a workflow to be invalid (circular references, bad references, bad JS etc). This could be improved but I think it's good enough for now.
* Otherwise should a runtime error occur, the runtime won't throw. Instead it'll log, write the error to state, and evaluate the next edges and any outstanding jobs. This closes #229
* I am writing errors to state as `state.errors`. This is subtle, but doesn't clash with `error` property which is being used now. Closes #207
* When a job errors, write a nice clear error to the console #228
* Fixed an issue where the logger was stringifying errors and losing the stack trace. `console.log(error)` now behaves better than it  did.

All of this means we can close out #143, which is really just a bunch of notes. See the notes for comments on stack traces.

There's a bit of a a distinction between "an input error which means we won't even try to run your thing" versus "we ran your thing but it threw a runtime error". Generally the first case results in `process.exit(1)` and the others result in writing an error to state.

Check out integration-tests/cli/test/errors.test.ts for a bunch of examples of the new  error handling. These tests are designed to be fairly readable (once you get the hang of it anyway). 

We could do more here - I could go on for days - but I think this a really good pass. Let's put it out there, gather feedback, and iterate later.

## Final state

When errors occur, I am dumping as much information as possible to `state.errors`. It currently looks like this:

```
{
  "data": {},
  "errors": {
    "a": {
      "name": "Error",
      "jobId": "a",
      "message": "i threw this",
      "error": {}
    },
    "b": {
      "name": "TypeError",
      "jobId": "b",
      "message": "Cannot set properties of undefined (setting 'jam')",
      "error": {}
    },
    "c": {
      "name": "TypeError",
      "jobId": "c",
      "message": "Invalid URL",
      "error": {
        "input": "xyz.blah.com/whatever",
        "code": "ERR_INVALID_URL"
      },
      "code": "ERR_INVALID_URL",
      "stack": "TypeError [ERR_INVALID_URL]: Invalid URL\n    at new NodeError (node:internal/errors:393:5)\n    at URL.onParseError (node:internal/url:565:9)\n    at new URL (node:internal/url:645:5)\n    at dispatchHttpRequest (/d/repo/openfn/cli-repo/node_modules/axios/dist/node/axios.cjs:2122:20)\n    at new Promise (<anonymous>)\n    at httpAdapter (/d/repo/openfn/cli-repo/node_modules/axios/dist/node/axios.cjs:2058:10)\n    at Axios.dispatchRequest (/d/repo/openfn/cli-repo/node_modules/axios/dist/node/axios.cjs:3151:10)\n    at async file:///d/repo/openfn/kit/packages/runtime/dist/index.js:388:20\n    at async file:///d/repo/openfn/kit/packages/runtime/dist/index.js:374:20"
    }
  }
}
```
As you can kind of see here, the verobosity and usefulness of the error information changes with the type of error.

## Notes

* Stack traces are difficult. When they come out of the job directly, they aren't helpful, because the stack is the vm and then the runtime. When they come out of an adaptor, they'll include the adaptor stack and that can be useful for debugging. At the moment the stack trace gets written to the error in state if it doesn't come out of the VM.
* At the moment, if you write to state and then throw, the write remains valid and is passed downstream. We don't do anything like reverting back to the last good state for downstream jobs. I don't have a strong opinion on this yet - I don't think we have any sense that jobs are transactional, so it seems fine to me.
