### PR TITLE
Release CLI 0.0.39

### DIFF
--- a/.changeset/chatty-readers-run.md
+++ b/.changeset/chatty-readers-run.md
@@ -1,5 +1,0 @@
----
-'@openfn/logger': patch
----
-
-Don't stringify error objects

--- a/.changeset/empty-boats-happen.md
+++ b/.changeset/empty-boats-happen.md
@@ -1,5 +1,0 @@
----
-'@openfn/runtime': patch
----
-
-Support strict mode

--- a/.changeset/fast-pears-return.md
+++ b/.changeset/fast-pears-return.md
@@ -1,5 +1,0 @@
----
-'@openfn/cli': patch
----
-
-Tweak log output

--- a/.changeset/great-bugs-move.md
+++ b/.changeset/great-bugs-move.md
@@ -1,5 +1,0 @@
----
-'@openfn/cli': patch
----
-
-Run in non-strict mode by default

--- a/.changeset/heavy-carpets-compare.md
+++ b/.changeset/heavy-carpets-compare.md
@@ -1,5 +1,0 @@
----
-'@openfn/cli': patch
----
-
-Rename strict-output -> strict

--- a/.changeset/proud-schools-cheat.md
+++ b/.changeset/proud-schools-cheat.md
@@ -1,5 +1,0 @@
----
-'@openfn/logger': patch
----
-
-Add an 'always' log level

--- a/.changeset/silly-rings-study.md
+++ b/.changeset/silly-rings-study.md
@@ -1,5 +1,0 @@
----
-'@openfn/logger': patch
----
-
-mock break() shoulnd't print anything

--- a/.changeset/smooth-toes-care.md
+++ b/.changeset/smooth-toes-care.md
@@ -1,5 +1,0 @@
----
-'@openfn/runtime': patch
----
-
-Throw when a workflow is invalid

--- a/.changeset/strange-teachers-laugh.md
+++ b/.changeset/strange-teachers-laugh.md
@@ -1,6 +1,0 @@
----
-'@openfn/cli': patch
-'@openfn/runtime': patch
----
-
-Better error handling and reporting

--- a/.changeset/thick-eggs-doubt.md
+++ b/.changeset/thick-eggs-doubt.md
@@ -1,5 +1,0 @@
----
-'@openfn/runtime': patch
----
-
-Better state handling in workflows

--- a/.changeset/tiny-cheetahs-tie.md
+++ b/.changeset/tiny-cheetahs-tie.md
@@ -1,6 +1,0 @@
----
-'@openfn/runtime': patch
----
-
-Log job start and end (with duration)
-Demote operation timings down to info and debug

--- a/.changeset/unlucky-socks-brush.md
+++ b/.changeset/unlucky-socks-brush.md
@@ -1,5 +1,0 @@
----
-'@openfn/logger': patch
----
-
-Add a \_find function to the mock

--- a/integration-tests/cli/package.json
+++ b/integration-tests/cli/package.json
@@ -7,12 +7,12 @@
   "license": "ISC",
   "type": "module",
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist repo",
     "build:pack": "pnpm clean && cd ../.. && pnpm pack:local integration-tests/cli/dist --no-version",
     "build": "pnpm build:pack && docker build --tag cli-integration-tests .",
     "start": "docker run cli-integration-tests",
-    "test": "node prelude.js && npx ava -s --timeout 2m",
-    "test:dev": "node prelude.js && pnpm ava -s"
+    "test": "node prelude.js && npx ava -s --timeout 2m && pnpm clean",
+    "test:dev": "node prelude.js && pnpm ava -s && pnpm clean"
   },
   "dependencies": {
     "@types/node": "^18.7.18",

--- a/integration-tests/cli/test/errors.test.ts
+++ b/integration-tests/cli/test/errors.test.ts
@@ -130,7 +130,6 @@ test.serial('invalid start', async (t) => {
   t.is(err.code, 1);
 
   const errlogs = extractLogs(stderr);
-  console.log(errlogs);
   assertLog(t, errlogs, /Invalid workflow/i);
   assertLog(t, errlogs, /could not find start job: nope/i);
 });

--- a/integration-tests/cli/test/execute-workflow.test.ts
+++ b/integration-tests/cli/test/execute-workflow.test.ts
@@ -166,6 +166,14 @@ test.serial(
       data: {
         number: 32,
       },
+      errors: {
+        start: {
+          error: {},
+          jobId: 'start',
+          message: 'abort',
+          name: 'Error',
+        },
+      },
     });
   }
 );

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @openfn/cli
 
+## 0.0.39
+
+### Patch Changes
+
+- f9b9e07: Tweak log output
+- 5b2a866: Run in non-strict mode by default
+- 8d5c405: Rename strict-output -> strict
+- 26024a7: Better error handling and reporting
+
+- Updated dependencies [6f51ce2]
+  - @openfn/logger@0.0.13
+  - @openfn/runtime@0.0.24
+  - @openfn/compiler@0.0.32
+
 ## 0.0.38
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/compiler
 
+## 0.0.32
+
+### Patch Changes
+
+- Updated dependencies [6f51ce2]
+  - @openfn/logger@0.0.13
+
 ## 0.0.31
 
 ### Patch Changes

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/compiler",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Compiler and language tooling for openfn jobs.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openfn/logger
 
+## 0.0.13
+
+### Patch Changes
+
+- 2696581: Don't stringify error objects
+- 3cc4456: Add an 'always' log level
+- 92e9fdc: mock break() shoulnd't print anything
+- 6f51ce2: Add a \_find function to the mock
+
 ## 0.0.12
 
 ### Patch Changes

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/logger",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Cross-package logging utility",
   "module": "dist/index.js",
   "author": "Open Function Group <admin@openfn.org>",

--- a/packages/runtime-manager/CHANGELOG.md
+++ b/packages/runtime-manager/CHANGELOG.md
@@ -1,5 +1,14 @@
 # runtime-manager
 
+## 0.0.33
+
+### Patch Changes
+
+- Updated dependencies [6f51ce2]
+  - @openfn/logger@0.0.13
+  - @openfn/runtime@0.0.24
+  - @openfn/compiler@0.0.32
+
 ## 0.0.32
 
 ### Patch Changes

--- a/packages/runtime-manager/package.json
+++ b/packages/runtime-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime-manager",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "An example runtime manager service.",
   "main": "index.js",
   "type": "module",
@@ -15,7 +15,7 @@
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",
   "dependencies": {
-    "@openfn/compiler": "workspace:^0.0.31",
+    "@openfn/compiler": "workspace:^0.0.32",
     "@openfn/language-common": "2.0.0-rc3",
     "@openfn/logger": "workspace:*",
     "@openfn/runtime": "workspace:*",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @openfn/runtime
 
+## 0.0.24
+
+### Patch Changes
+
+- 8d5c405: Support strict mode
+- 0c5ee29: Throw when a workflow is invalid
+- 26024a7: Better error handling and reporting
+- 8d5c405: Better state handling in workflows
+- 79f6d7c: Log job start and end (with duration)
+  Demote operation timings down to info and debug
+- Updated dependencies [6f51ce2]
+  - @openfn/logger@0.0.13
+
 ## 0.0.23
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Job processing runtime.",
   "type": "module",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,12 +59,6 @@ importers:
       tslib: 2.4.0
       typescript: 4.8.3
 
-  integration-tests/cli/repo:
-    specifiers:
-      '@openfn/language-common_1.7.7': npm:@openfn/language-common@^1.7.7
-    dependencies:
-      '@openfn/language-common_1.7.7': /@openfn/language-common/1.7.7
-
   packages/cli:
     specifiers:
       '@openfn/compiler': workspace:*
@@ -616,17 +610,6 @@ packages:
       - debug
     dev: true
 
-  /@openfn/language-common/1.7.7:
-    resolution: {integrity: sha512-GSoAbo6oL0b8jHufhLKvIzHJ271aE2AKv/ibeuiWU3CqN1gRmaHArlA/omlCs/rsfcieSp2VWAvWeGuFY8buZw==}
-    dependencies:
-      axios: 1.1.3
-      date-fns: 2.29.3
-      jsonpath-plus: 4.0.0
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /@openfn/language-common/2.0.0-rc3:
     resolution: {integrity: sha512-7kwhBnCd1idyTB3MD9dXmUqROAhoaUIkz2AGDKuv9vn/cbZh7egEv9/PzKkRcDJYFV9qyyS+cVT3Xbgsg2ii5g==}
     bundledDependencies: []
@@ -1070,6 +1053,7 @@ packages:
 
   /asynckit/0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: true
 
   /atob/2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
@@ -1143,6 +1127,7 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+    dev: true
 
   /b4a/1.6.1:
     resolution: {integrity: sha512-AsKjNhz72yxteo/0EtQEiwkMUgk/tGmycXlbG4g3Ard2/ULtNLUykGOkeK0egmN27h0xMAhb76jYccW+XTBExA==}
@@ -1538,6 +1523,7 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
+    dev: true
 
   /commander/4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1808,6 +1794,7 @@ packages:
   /delayed-stream/1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+    dev: true
 
   /delegates/1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -2847,6 +2834,7 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: true
 
   /for-in/1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
@@ -2860,6 +2848,7 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+    dev: true
 
   /fragment-cache/0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
@@ -3578,6 +3567,7 @@ packages:
   /jsonpath-plus/4.0.0:
     resolution: {integrity: sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==}
     engines: {node: '>=10.0'}
+    dev: true
 
   /keygrip/1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
@@ -4527,6 +4517,7 @@ packages:
 
   /proxy-from-env/1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: true
 
   /proxy-middleware/0.15.0:
     resolution: {integrity: sha512-EGCG8SeoIRVMhsqHQUdDigB2i7qU7fCsWASwn54+nPutYO8n4q6EiwMzyfWlC+dzRFExP+kvcnDFdBDHoZBU7Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,7 +228,7 @@ importers:
 
   packages/runtime-manager:
     specifiers:
-      '@openfn/compiler': workspace:^0.0.31
+      '@openfn/compiler': workspace:^0.0.32
       '@openfn/language-common': 2.0.0-rc3
       '@openfn/logger': workspace:*
       '@openfn/runtime': workspace:*


### PR DESCRIPTION
This PR contains version bumps for the CLI 0.0.39 plus dependencies.

Strict mode is now disabled by default, and error handling is much improved.

To release, `install`, `build` and `publish`