### PR TITLE
Docs fixes

### DIFF
--- a/.changeset/small-toys-judge.md
+++ b/.changeset/small-toys-judge.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Fix CLI docs (strict mode, workflow with autoinstall)

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -76,8 +76,8 @@ const executeCommand = {
         'Execute foo/job.js with no adaptor and write the final state to foo/job.json'
       )
       .example(
-        'openfn workflow.json -ia common',
-        'Execute workflow.json using @openfn/language-commom (with autoinstall enabled)'
+        'openfn workflow.json -i',
+        'Execute workflow.json with autoinstall enabled'
       )
       .example(
         'openfn job.js -a common --log info',

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -265,12 +265,12 @@ export const strictOutput: CLIOption = {
 };
 
 export const strict: CLIOption = {
-  name: 'no-strict',
+  name: 'strict',
   yargs: {
     default: false,
     boolean: true,
     description:
-      'Strict state handling, meaning only state.data is returned from a job.',
+      'Enables strict state handling, meaning only state.data is returned from a job.',
   },
   ensure: (opts) => {
     if (!opts.hasOwnProperty('strictOutput')) {

--- a/packages/cli/test/compile/compile.test.ts
+++ b/packages/cli/test/compile/compile.test.ts
@@ -117,9 +117,9 @@ test('throw an AbortError if a workflow contains an uncompilable jon', async (t)
 });
 
 test('stripVersionSpecifier: remove version specifier from @openfn', (t) => {
-  const specifier = '@openfn/language-commmon@3.0.0-rc2';
+  const specifier = '@openfn/language-common@3.0.0-rc2';
   const transformed = stripVersionSpecifier(specifier);
-  const expected = '@openfn/language-commmon';
+  const expected = '@openfn/language-common';
   t.assert(transformed == expected);
 });
 
@@ -138,9 +138,9 @@ test('stripVersionSpecifier: remove version specifier from arbitrary namespaced 
 });
 
 test("stripVersionSpecifier: do nothing if there's no specifier", (t) => {
-  const specifier = '@openfn/language-commmon';
+  const specifier = '@openfn/language-common';
   const transformed = stripVersionSpecifier(specifier);
-  const expected = '@openfn/language-commmon';
+  const expected = '@openfn/language-common';
   t.assert(transformed == expected);
 });
 

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -1,5 +1,5 @@
 // bunch of unit tests on the execute function itself
-// so far this is only done in ands.test.ts, which has the cli overhead
+// so far this is only done in commands.test.ts, which has the cli overhead
 // I don't want any io or adaptor tests here, really just looking for the actual execute flow
 import mock from 'mock-fs';
 import path from 'node:path';

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -1,5 +1,5 @@
 // bunch of unit tests on the execute function itself
-// so far this is only done in commmands.test.ts, which has the cli overhead
+// so far this is only done in ands.test.ts, which has the cli overhead
 // I don't want any io or adaptor tests here, really just looking for the actual execute flow
 import mock from 'mock-fs';
 import path from 'node:path';


### PR DESCRIPTION
A couple of lightweight docs fixes

* The `strict` option was wrongly listed as `no-strict`
* A workflow example wrongly included an adaptor name

Closes #242

We should probably merge and release quickly, its nice and low risk