### PR TITLE
Ensure jobs only receive upstream state

### DIFF
--- a/.changeset/mighty-timers-agree.md
+++ b/.changeset/mighty-timers-agree.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+Ensure jobs only receive direct upstream state

--- a/integration-tests/cli/test/execute-workflow.test.ts
+++ b/integration-tests/cli/test/execute-workflow.test.ts
@@ -24,7 +24,8 @@ test.afterEach(async () => {
 
 // Autoinstall adaptors
 test.serial(`openfn ${jobsPath}/wf-count.json -i`, async (t) => {
-  await run(t.title);
+  const { err } = await run(t.title);
+  t.falsy(err);
 
   const out = getJSON();
   t.is(out.data.count, 42);
@@ -34,7 +35,8 @@ test.serial(`openfn ${jobsPath}/wf-count.json -i`, async (t) => {
 test.serial(
   `openfn ${jobsPath}/wf-count.json -S "{ \\"data\\": { \\"count\\": 6 } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.is(out.data.count, 12);
@@ -43,7 +45,8 @@ test.serial(
 
 // Multiple steps, shared array
 test.serial(`openfn ${jobsPath}/wf-array.json`, async (t) => {
-  await run(t.title);
+  const { err } = await run(t.title);
+  t.falsy(err);
 
   const out = getJSON();
   t.is(out.data.items.length, 2);
@@ -55,7 +58,8 @@ test.serial(`openfn ${jobsPath}/wf-array.json`, async (t) => {
 test.serial(
   `openfn ${jobsPath}/wf-array.json -S "{ \\"data\\": { \\"items\\": [\\"z\\"] } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.is(out.data.items.length, 3);
@@ -69,16 +73,19 @@ test.serial(
 test.serial(
   `openfn ${jobsPath}/wf-array.json --start b -S "{ \\"data\\": { \\"items\\": [] } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
-    t.is(out.data.items.length, 1);
+    t.is(out.data.items.length, 2);
     t.true(out.data.items.includes('b'));
+    t.true(out.data.items.includes('c'));
   }
 );
 
 test.serial(`openfn ${jobsPath}/wf-conditional.json`, async (t) => {
-  await run(t.title);
+  const { err } = await run(t.title);
+  t.falsy(err);
 
   const out = getJSON();
   t.is(out.data.result, 'small');
@@ -87,7 +94,8 @@ test.serial(`openfn ${jobsPath}/wf-conditional.json`, async (t) => {
 test.serial(
   `openfn ${jobsPath}/wf-conditional.json -S "{ \\"data\\": { \\"number\\": 5 } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.is(out.data.result, 'small');
@@ -97,7 +105,8 @@ test.serial(
 test.serial(
   `openfn ${jobsPath}/wf-conditional.json -S "{ \\"data\\": { \\"number\\": 20 } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.is(out.data.result, 'large');
@@ -107,7 +116,8 @@ test.serial(
 test.serial(
   `openfn ${jobsPath}/wf-simple.json -S "{ \\"data\\": { \\"count\\": 2 } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.is(out.data.count, 4);
@@ -115,7 +125,8 @@ test.serial(
 );
 
 test.serial(`openfn ${jobsPath}/wf-strict.json --strict`, async (t) => {
-  await run(t.title);
+  const { err } = await run(t.title);
+  t.falsy(err);
 
   const out = getJSON();
   t.deepEqual(out, {
@@ -126,7 +137,8 @@ test.serial(`openfn ${jobsPath}/wf-strict.json --strict`, async (t) => {
 });
 
 test.serial(`openfn ${jobsPath}/wf-strict.json --no-strict`, async (t) => {
-  await run(t.title);
+  const { err } = await run(t.title);
+  t.falsy(err);
 
   const out = getJSON();
   t.deepEqual(out, {
@@ -143,9 +155,10 @@ test.serial(`openfn ${jobsPath}/wf-strict.json --no-strict`, async (t) => {
 });
 
 test.serial(
-  `openfn ${jobsPath}/wf-errors.json -i -S "{ \\"data\\": { \\"number\\": 2 } }"`,
+  `openfn ${jobsPath}/wf-errors.json -S "{ \\"data\\": { \\"number\\": 2 } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.deepEqual(out, {
@@ -159,7 +172,8 @@ test.serial(
 test.serial(
   `openfn ${jobsPath}/wf-errors.json -S "{ \\"data\\": { \\"number\\": 32 } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.deepEqual(out, {

--- a/integration-tests/cli/test/fixtures/wf-array.json
+++ b/integration-tests/cli/test/fixtures/wf-array.json
@@ -4,12 +4,13 @@
       "id": "a",
       "adaptor": "common",
       "expression": "fn((state) => { if (!state.data.items) { state.data.items = []; } return state; });",
-      "next": { "b": true, "c": true }
+      "next": { "b": true }
     },
     {
       "id": "b",
       "adaptor": "common",
-      "expression": "fn((state) => { state.data.items.push('b'); return state; });"
+      "expression": "fn((state) => { state.data.items.push('b'); return state; });",
+      "next": { "c": true }
     },
     {
       "id": "c",

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -174,7 +174,7 @@ test('run a workflow with config as a path', async (t) => {
     jobs: [
       {
         configuration: '/config.json',
-        expression: `${fn}fn((state) => state)`,
+        expression: `${fn}fn((state) => { state.cfg = state.configuration; return state;})`,
       },
     ],
   };
@@ -183,7 +183,7 @@ test('run a workflow with config as a path', async (t) => {
     workflow,
   };
   const result = await handler(options, logger);
-  t.is(result.configuration.id, 'x');
+  t.is(result.cfg.id, 'x');
 });
 
 test('run a workflow from a start node', async (t) => {

--- a/packages/runtime/src/execute/compile-plan.ts
+++ b/packages/runtime/src/execute/compile-plan.ts
@@ -49,6 +49,17 @@ const compileEdges = (
   return result;
 };
 
+// find the upstream job for a given job
+// Inefficient but fine for now (note that validation does something similar)
+// Note that right now we only support one upstream job
+const findUpstream = (plan: ExecutionPlan, id: string) => {
+  for (const job of plan.jobs) {
+    if (job.next && job.next[id]) {
+      return job.id;
+    }
+  }
+};
+
 export default (plan: ExecutionPlan) => {
   let autoJobId = 0;
   const generateJobId = () => `job-${++autoJobId}`;
@@ -81,20 +92,22 @@ export default (plan: ExecutionPlan) => {
       // Default the start job to the first
       newPlan.start = jobId;
     }
-    newPlan.jobs[jobId] = {
+    const newJob = {
       expression: job.expression, // TODO we should compile this here
     };
     if (job.data) {
-      newPlan.jobs[jobId].data = job.data;
+      newJob.data = job.data;
     }
     if (job.configuration) {
-      newPlan.jobs[jobId].configuration = job.configuration;
+      newJob.configuration = job.configuration;
     }
     if (job.next) {
       trapErrors(() => {
-        newPlan.jobs[jobId].next = compileEdges(jobId, job.next!, context);
+        newJob.next = compileEdges(jobId, job.next!, context);
       });
     }
+    newJob.previous = findUpstream(plan, jobId);
+    newPlan.jobs[jobId] = newJob;
   }
 
   if (errs.length) {

--- a/packages/runtime/src/execute/compile-plan.ts
+++ b/packages/runtime/src/execute/compile-plan.ts
@@ -81,18 +81,26 @@ export default (plan: ExecutionPlan) => {
     }
   };
 
+  // ensure ids before we start
+  for (const job of plan.jobs) {
+    if (!job.id) {
+      job.id = generateJobId();
+    }
+  }
+
   const newPlan = {
     jobs: {},
     start: plan.start,
   } as Pick<CompiledExecutionPlan, 'jobs' | 'start'>;
 
   for (const job of plan.jobs) {
-    const jobId = job.id || generateJobId();
+    const jobId = job.id;
     if (!newPlan.start) {
       // Default the start job to the first
       newPlan.start = jobId;
     }
     const newJob = {
+      id: jobId,
       expression: job.expression, // TODO we should compile this here
     };
     if (job.data) {

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -114,6 +114,9 @@ const prepareFinalState = (opts: Options, state: any) => {
   if (state) {
     if (opts.strict) {
       state = assignKeys(state, {}, ['data', 'error', 'references']);
+    } else {
+      // TODO this is new and needs unit tests
+      delete state.configuration;
     }
     const cleanState = stringify(state);
     return JSON.parse(cleanState);

--- a/packages/runtime/src/execute/plan.ts
+++ b/packages/runtime/src/execute/plan.ts
@@ -78,11 +78,12 @@ const executePlan = async (
     }
   }
 
-  // Squash all the leaf states together and return
-  return Object.keys(leaves).reduce((agg, next) => {
-    Object.assign(agg, leaves[next]);
-    return agg;
-  }, {});
+  // If there are multiple leaf results, return them
+  if (Object.keys(leaves).length > 1) {
+    return leaves;
+  }
+  // Return a single value
+  return Object.values(leaves)[0];
 };
 
 const executeJob = async (

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -59,6 +59,7 @@ export type JobNode = {
   data?: State['data']; // default state (globals)
 
   next?: string | Record<JobNodeID, true | JobEdge>;
+  previous?: JobNodeID;
 };
 
 export type JobEdge = {

--- a/packages/runtime/test/execute/compile-plan.test.ts
+++ b/packages/runtime/test/execute/compile-plan.test.ts
@@ -20,12 +20,22 @@ const planWithEdge = (edge: JobEdge) =>
 test('should convert jobs to an object', (t) => {
   const compiledPlan = compilePlan(testPlan);
   t.truthy(compiledPlan.jobs.a);
-  t.falsy(compiledPlan.jobs.a.id);
   t.is(compiledPlan.jobs.a.expression, 'x');
 
   t.truthy(compiledPlan.jobs.b);
-  t.falsy(compiledPlan.jobs.b.id);
   t.is(compiledPlan.jobs.b.expression, 'y');
+});
+
+test('should auto generate ids for jobs', (t) => {
+  const plan = {
+    start: 'a',
+    jobs: [{ expression: 'x' }, { expression: 'y' }],
+  };
+  const compiledPlan = compilePlan(plan);
+  const ids = Object.keys(compiledPlan.jobs);
+  t.truthy(ids[0]);
+  t.truthy(ids[1]);
+  t.assert(ids[0] !== ids[1]);
 });
 
 test('should convert jobs to an object with auto ids', (t) => {

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -293,7 +293,6 @@ test('Jobs only receive state from upstream jobs', async (t) => {
         },
       },
 
-      // should receive x:1, y:1
       {
         id: 'x-a',
         expression: `export default [s => {
@@ -304,7 +303,6 @@ test('Jobs only receive state from upstream jobs', async (t) => {
         }]`,
         next: { 'x-b': true },
       },
-      // should receive x:2, y:1
       {
         id: 'x-b',
         expression: `export default [s => {
@@ -314,7 +312,6 @@ test('Jobs only receive state from upstream jobs', async (t) => {
         }]`,
       },
 
-      // should receive x:1, y:1
       {
         id: 'y-a',
         expression: `export default [s => {
@@ -325,7 +322,6 @@ test('Jobs only receive state from upstream jobs', async (t) => {
         }]`,
         next: { 'y-b': true },
       },
-      // should receive x:1, y:2
       {
         id: 'y-b',
         expression: `export default [s => {

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -277,8 +277,7 @@ test('only allowed state is passed through in strict mode', async (t) => {
   });
 });
 
-// jobs only receive state of upstream jobs
-test.only('State is passed downstream properly', async (t) => {
+test('Jobs only receive state from upstream jobs', async (t) => {
   const assert = (expr: string) =>
     `if (!(${expr})) throw new Error('ASSERT FAIL')`;
 
@@ -338,20 +337,16 @@ test.only('State is passed downstream properly', async (t) => {
     ],
   };
 
-  // What is the final result here?
-  // This part of the problem hasn't really been worked out
-  // Luckily it's probably not a problem with these types of job
-  // Either:
-  // a) we merge all leaf states together
-  // b) we return an array/object of results
   const result = await executePlan(plan);
 
-  // Right now this will return an aggregated state, so the results are unpreditable in this test
-  // but so long as there's no error, we're good
+  // explicit check that no assertion failed and wrote an error to state
   t.falsy(result.error);
-  // console.log(result);
-  // t.is(result.data.x, 2);
-  // t.is(result.data.y, 2);
+
+  // Check there are two results
+  t.deepEqual(result, {
+    'x-b': { data: { x: 2, y: 1 } },
+    'y-b': { data: { x: 1, y: 2 } },
+  });
 });
 
 test('all state is passed through in non-strict mode', async (t) => {

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -370,7 +370,6 @@ test('all state is passed through in non-strict mode', async (t) => {
   };
   const result = await executePlan(plan, {}, { strict: false });
   t.deepEqual(result, {
-    configuration: {}, // TODO should this still be excluded?
     data: {},
     references: [],
     x: 22,
@@ -538,7 +537,11 @@ test('execute multiple steps in "parallel"', async (t) => {
     ],
   };
   const result = await executePlan(plan, { data: { x: 0 } });
-  t.is(result.data.x, 3);
+  t.deepEqual(result, {
+    a: { data: { x: 1 } },
+    b: { data: { x: 1 } },
+    c: { data: { x: 1 } },
+  });
 });
 
 test('return an error in state', async (t) => {
@@ -783,7 +786,6 @@ test('jobs can write circular references to state without blowing up downstream'
 
   t.notThrows(() => JSON.stringify(result));
   t.deepEqual(result, {
-    configuration: {},
     data: {
       b: {
         a: '[Circular]',
@@ -847,7 +849,7 @@ test('jobs can write functions to state without blowing up downstream', async (t
   const result = await executePlan(plan, { data: {} });
 
   t.notThrows(() => JSON.stringify(result));
-  t.deepEqual(result, { data: {}, configuration: {} });
+  t.deepEqual(result, { data: {} });
 });
 
 test('jobs cannot pass functions to each other', async (t) => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -48,10 +48,22 @@ test('run a workflow with state and parallel branching', async (t) => {
   };
 
   const result: any = await run(plan, { data: { count: 0 } });
-  t.true(result.data.a);
-  t.true(result.data.b);
-  t.true(result.data.c);
-  t.is(result.data.count, 3);
+  t.deepEqual(result, {
+    b: {
+      data: {
+        count: 2,
+        a: true,
+        b: true,
+      },
+    },
+    c: {
+      data: {
+        count: 2,
+        a: true,
+        c: true,
+      },
+    },
+  });
 });
 
 test('run a workflow with state and conditional branching', async (t) => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -195,6 +195,15 @@ test('do pass extraneous state in non-strict mode', async (t) => {
   });
 });
 
+test('Allow a job to return undefined', async (t) => {
+  const plan: ExecutionPlan = {
+    jobs: [{ expression: 'export default [() => {}]' }],
+  };
+
+  const result: any = await run(plan);
+  t.falsy(result);
+});
+
 test('log errors, write to state, and continue', async (t) => {
   const plan: ExecutionPlan = {
     jobs: [


### PR DESCRIPTION
At the moment, when a job runs in a workflow, we pass the _last_ state into it (merging in credentials and defaults of course).

This PR ensures that we only pass the state from the upstream job into the next one.

Closes #227

```
  a
 /   \
j     k
     / \
    x  y
```

In the workflow above, it's important that:
* `j` and `k` receive  immutable copies of the result of `a`
* `x` and `y` receive immutable copies of the state of `k`

As things stand at the moment it's a bit random. Because we just pass state as a pipeline, it'll be something like `k` will get the result of `j`; `x` will get the result of `k`, and `y` will get the result of `x`.

## Changes

Some changes introduced in this PR:

* Workflows with branches will now return multiple results
* The `configuration` key is now removed from the result state. We've discussed this but not actually done it (actually I think the CLI does something along these lines, but since workflows, the runtime needs to be a bit stricter about it).

## Final States

The runtime is designed to return a state object as the "result" of the workflow or expression. Up until now that's been straightforward - we just return the last state produced.

But if you have a branching workflow, what is the final state?
```
  a
 /   \
x     y
```
If `a`, `x`, and `y ` all return a state object, what should the result of the run look like?

This PR implements the following rules:

* If there is one one "leaf" node - one node which doesn't go anywhere else - we just return the final state
* If there are multiple leaf nodes, or branches, we return an object with each state as a value under the key of a job id.

So for the use-case above ,we probably return an object like this:
```
{
   x: { data: { ... } },
   y: { data: { ... } },
}
```
Note that errors will be written to the relevant nested state object. So if `x` and `y` both fail, you'll get:
```
{
   x: { data: { ... }, errors: [] },
   y: { data: { ... }, errors: []},
}
```
If a `a` fails but `x` and `y` both run, you'll get the same structure, with the error from `a` will be duplicated into both downstream states.

Also note that branches are dynamic - a branch is only a branch if two downstream jobs are created at runtime. So if we have a workflow like this:
```
        a
    /         \
error       success
 /                \
x                  y
```
Only x OR y will run, so a single result state will be returned.

In other words, we're only sensitive to ACTUAL branches, not theoretical ones.

## Future Work

This isn't the end of the story for handling multiple return states. It's just a first pass.

I don't like that the final result object is a bit inpredictable. Will I get a state or an object of states? It's actually made a bit worse by dynamics, because the same workflow with different inputs or at different times could return different data structures.

At the moment, with workflows so new, we don't really have any  real-life cases to test against (and no legacy to break). So it's a safe point to try something.

And in practice, for a workflow which branches like this, there probably isn't a desire to return a result state. The branch is because state is being pushed to two different systems and the result is immaterial.

I think we'll want to come back and revisit this in a  couple of months and add some kind of option. Maybe you want to force all your state to be squashed into a final result object (this is fine if your jobs use different slices of state).  Maybe you only care about the result of a single job and you want to mark it as  "result" or "final" node. Maybe we need to introduce an aggregator node, as discussed in #227 .