### PR TITLE
CLI Release 0.0.40

### DIFF
--- a/.changeset/beige-hats-tease.md
+++ b/.changeset/beige-hats-tease.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Refactor repo command

--- a/.changeset/beige-hats-tease.md
+++ b/.changeset/beige-hats-tease.md
@@ -1,5 +1,0 @@
----
-'@openfn/cli': patch
----
-
-Refactor repo command

--- a/.changeset/mighty-timers-agree.md
+++ b/.changeset/mighty-timers-agree.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+Ensure jobs only receive direct upstream state

--- a/.changeset/mighty-timers-agree.md
+++ b/.changeset/mighty-timers-agree.md
@@ -1,5 +1,0 @@
----
-'@openfn/runtime': patch
----
-
-Ensure jobs only receive direct upstream state

--- a/.changeset/small-toys-judge.md
+++ b/.changeset/small-toys-judge.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Fix CLI docs (strict mode, workflow with autoinstall)

--- a/.changeset/small-toys-judge.md
+++ b/.changeset/small-toys-judge.md
@@ -1,5 +1,0 @@
----
-'@openfn/cli': patch
----
-
-Fix CLI docs (strict mode, workflow with autoinstall)

--- a/integration-tests/cli/src/util.ts
+++ b/integration-tests/cli/src/util.ts
@@ -14,3 +14,6 @@ export const extractLogs = (jsonLogString: string) =>
     .split(/\n/)
     .filter((j) => j.startsWith('{'))
     .map((j) => JSON.parse(j));
+
+export const assertLog = (t: any, logs: any[], re: RegExp) =>
+  t.assert(logs.find(({ message }) => re.test(message[0])));

--- a/integration-tests/cli/test/errors.test.ts
+++ b/integration-tests/cli/test/errors.test.ts
@@ -1,14 +1,11 @@
 import test from 'ava';
 import path from 'node:path';
 import run from '../src/run';
-import { extractLogs } from '../src/util';
+import { extractLogs, assertLog } from '../src/util';
 
 const jobsPath = path.resolve('test/fixtures');
 
 // These are all errors that will stop the CLI from even running
-
-const assertLog = (t: any, logs: any[], re: RegExp) =>
-  t.assert(logs.find(({ message }) => re.test(message[0])));
 
 test.serial('job not found', async (t) => {
   const { stdout, stderr, err } = await run('openfn blah.js --log-json');

--- a/integration-tests/cli/test/execute-workflow.test.ts
+++ b/integration-tests/cli/test/execute-workflow.test.ts
@@ -24,7 +24,8 @@ test.afterEach(async () => {
 
 // Autoinstall adaptors
 test.serial(`openfn ${jobsPath}/wf-count.json -i`, async (t) => {
-  await run(t.title);
+  const { err } = await run(t.title);
+  t.falsy(err);
 
   const out = getJSON();
   t.is(out.data.count, 42);
@@ -34,7 +35,8 @@ test.serial(`openfn ${jobsPath}/wf-count.json -i`, async (t) => {
 test.serial(
   `openfn ${jobsPath}/wf-count.json -S "{ \\"data\\": { \\"count\\": 6 } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.is(out.data.count, 12);
@@ -43,7 +45,8 @@ test.serial(
 
 // Multiple steps, shared array
 test.serial(`openfn ${jobsPath}/wf-array.json`, async (t) => {
-  await run(t.title);
+  const { err } = await run(t.title);
+  t.falsy(err);
 
   const out = getJSON();
   t.is(out.data.items.length, 2);
@@ -55,7 +58,8 @@ test.serial(`openfn ${jobsPath}/wf-array.json`, async (t) => {
 test.serial(
   `openfn ${jobsPath}/wf-array.json -S "{ \\"data\\": { \\"items\\": [\\"z\\"] } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.is(out.data.items.length, 3);
@@ -69,16 +73,19 @@ test.serial(
 test.serial(
   `openfn ${jobsPath}/wf-array.json --start b -S "{ \\"data\\": { \\"items\\": [] } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
-    t.is(out.data.items.length, 1);
+    t.is(out.data.items.length, 2);
     t.true(out.data.items.includes('b'));
+    t.true(out.data.items.includes('c'));
   }
 );
 
 test.serial(`openfn ${jobsPath}/wf-conditional.json`, async (t) => {
-  await run(t.title);
+  const { err } = await run(t.title);
+  t.falsy(err);
 
   const out = getJSON();
   t.is(out.data.result, 'small');
@@ -87,7 +94,8 @@ test.serial(`openfn ${jobsPath}/wf-conditional.json`, async (t) => {
 test.serial(
   `openfn ${jobsPath}/wf-conditional.json -S "{ \\"data\\": { \\"number\\": 5 } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.is(out.data.result, 'small');
@@ -97,7 +105,8 @@ test.serial(
 test.serial(
   `openfn ${jobsPath}/wf-conditional.json -S "{ \\"data\\": { \\"number\\": 20 } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.is(out.data.result, 'large');
@@ -107,7 +116,8 @@ test.serial(
 test.serial(
   `openfn ${jobsPath}/wf-simple.json -S "{ \\"data\\": { \\"count\\": 2 } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.is(out.data.count, 4);
@@ -115,7 +125,8 @@ test.serial(
 );
 
 test.serial(`openfn ${jobsPath}/wf-strict.json --strict`, async (t) => {
-  await run(t.title);
+  const { err } = await run(t.title);
+  t.falsy(err);
 
   const out = getJSON();
   t.deepEqual(out, {
@@ -126,7 +137,8 @@ test.serial(`openfn ${jobsPath}/wf-strict.json --strict`, async (t) => {
 });
 
 test.serial(`openfn ${jobsPath}/wf-strict.json --no-strict`, async (t) => {
-  await run(t.title);
+  const { err } = await run(t.title);
+  t.falsy(err);
 
   const out = getJSON();
   t.deepEqual(out, {
@@ -143,9 +155,10 @@ test.serial(`openfn ${jobsPath}/wf-strict.json --no-strict`, async (t) => {
 });
 
 test.serial(
-  `openfn ${jobsPath}/wf-errors.json -i -S "{ \\"data\\": { \\"number\\": 2 } }"`,
+  `openfn ${jobsPath}/wf-errors.json -S "{ \\"data\\": { \\"number\\": 2 } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.deepEqual(out, {
@@ -159,7 +172,8 @@ test.serial(
 test.serial(
   `openfn ${jobsPath}/wf-errors.json -S "{ \\"data\\": { \\"number\\": 32 } }"`,
   async (t) => {
-    await run(t.title);
+    const { err } = await run(t.title);
+    t.falsy(err);
 
     const out = getJSON();
     t.deepEqual(out, {

--- a/integration-tests/cli/test/fixtures/wf-array.json
+++ b/integration-tests/cli/test/fixtures/wf-array.json
@@ -4,12 +4,13 @@
       "id": "a",
       "adaptor": "common",
       "expression": "fn((state) => { if (!state.data.items) { state.data.items = []; } return state; });",
-      "next": { "b": true, "c": true }
+      "next": { "b": true }
     },
     {
       "id": "b",
       "adaptor": "common",
-      "expression": "fn((state) => { state.data.items.push('b'); return state; });"
+      "expression": "fn((state) => { state.data.items.push('b'); return state; });",
+      "next": { "c": true }
     },
     {
       "id": "c",

--- a/integration-tests/cli/test/repo.test.ts
+++ b/integration-tests/cli/test/repo.test.ts
@@ -1,0 +1,118 @@
+import test from 'ava';
+import run from '../src/run';
+import { extractLogs, assertLog } from '../src/util';
+
+test.before(async () => {
+  await run('openfn repo clean -f --log none');
+  await run('openfn repo clean --repo-dir=/tmp/openfn/repo-2  -f --log none');
+});
+
+// Not a very thorough test - BUT if clean breaks, many of these tests will also fail
+test.serial('openfn repo clean -f', async (t) => {
+  const { stdout, err } = await run(t.title);
+  t.falsy(err);
+
+  t.regex(stdout, /Repo cleaned/);
+});
+
+test.serial('openfn repo --log-json', async (t) => {
+  const { stdout, err } = await run(t.title);
+  t.falsy(err);
+
+  const stdlogs = extractLogs(stdout);
+  t.is(stdlogs.length, 2);
+  t.regex(stdlogs[0].message[0], /Repo working directory/);
+  t.regex(stdlogs[1].message[0], /Installed packages/);
+});
+
+test.serial('openfn repo list --log-json --log info', async (t) => {
+  const { stdout, err } = await run(t.title);
+  t.falsy(err);
+
+  const stdlogs = extractLogs(stdout);
+  t.is(stdlogs.length, 3);
+  t.regex(stdlogs[0].message[0], /OPENFN_REPO_DIR is set to/);
+  t.regex(stdlogs[1].message[0], /Repo working directory/);
+  t.regex(stdlogs[2].message[0], /Installed packages/);
+});
+
+test.serial('openfn repo --help', async (t) => {
+  const { stdout, err } = await run(t.title);
+  t.falsy(err);
+
+  t.regex(stdout, /Run commands on the module repo/);
+  t.regex(stdout, /repo install \[packages...\]/);
+  t.regex(stdout, /repo clean/);
+  t.regex(stdout, /repo list/);
+});
+
+test.serial('openfn repo install -a common --log-json', async (t) => {
+  const { stdout, err } = await run(t.title);
+  t.falsy(err);
+
+  const stdlogs = extractLogs(stdout);
+  assertLog(t, stdlogs, /Installing packages/);
+  assertLog(t, stdlogs, /Installed @openfn\/language-common@/);
+  assertLog(t, stdlogs, /Installation complete in .*s/);
+});
+
+test.serial('openfn repo install is-array --log-json', async (t) => {
+  const { stdout, err } = await run(t.title);
+  t.falsy(err);
+
+  const stdlogs = extractLogs(stdout);
+  assertLog(t, stdlogs, /Installing packages/);
+  assertLog(t, stdlogs, /Installed is-array@/);
+  assertLog(t, stdlogs, /Installation complete in .*s/);
+});
+
+test.serial('openfn repo install is-array --log-json --log info', async (t) => {
+  const { stdout, err } = await run(t.title);
+  t.falsy(err);
+
+  const stdlogs = extractLogs(stdout);
+  assertLog(t, stdlogs, /Installing packages/);
+  assertLog(t, stdlogs, /Skipping is-array@/);
+  assertLog(t, stdlogs, /Installation complete in .*s/);
+});
+
+test.serial('openfn repo list --log-json', async (t) => {
+  const { stdout, err } = await run(t.title);
+  t.falsy(err);
+
+  const stdlogs = extractLogs(stdout);
+  t.regex(stdlogs[0].message[0], /Repo working directory/);
+  t.regex(stdlogs[1].message[0], /Installed packages/);
+
+  assertLog(t, stdlogs, /@openfn\/language-common/);
+  assertLog(t, stdlogs, /is-array/);
+});
+
+test.serial(
+  'openfn repo list --repo-dir=/tmp/openfn/repo-2 --log-json',
+  async (t) => {
+    const { stdout, err } = await run(t.title);
+    t.falsy(err);
+
+    const stdlogs = extractLogs(stdout);
+    t.true(stdlogs.length === 2);
+    t.regex(
+      stdlogs[0].message[0],
+      /Repo working directory is: \/tmp\/openfn\/repo-2/
+    );
+    t.regex(stdlogs[1].message[0], /Installed packages/);
+  }
+);
+
+test.serial(
+  'openfn repo install -a common --repo-dir=/tmp/openfn/repo-2 --log-json --log info',
+  async (t) => {
+    const { stdout, err } = await run(t.title);
+    t.falsy(err);
+
+    const stdlogs = extractLogs(stdout);
+    assertLog(t, stdlogs, /Installing packages/);
+    assertLog(t, stdlogs, /Installed @openfn\/language-common@/);
+    assertLog(t, stdlogs, /Installation complete in .*s/);
+  }
+);

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openfn/cli
 
+## 0.0.40
+
+### Patch Changes
+
+- e5e1d7d: Refactor repo command
+- fd946a7: Fix CLI docs (strict mode, workflow with autoinstall)
+- Updated dependencies [2024ce8]
+  - @openfn/runtime@0.0.25
+
 ## 0.0.39
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -50,7 +50,7 @@ export type SafeOpts = Required<Omit<Opts, 'log' | 'adaptor' | 'statePath'>> & {
 
 const maybeEnsureOpts = (basePath: string, options: Opts) =>
   // If the command is compile or execute, just return the opts (yargs will do all the validation)
-  /^(execute|compile|test)$/.test(options.command!)
+  /(^(execute|compile|test)$)|(repo-)/.test(options.command!)
     ? ensureLogOpts(options)
     : // Otherwise  older commands still need to go through ensure opts
       ensureOpts(basePath, options);

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_REPO_DIR = '/tmp/openfn/repo';

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -1,7 +1,8 @@
 import yargs from 'yargs';
-import { Opts } from '../options';
 import { build, ensure } from '../util/command-builders';
 import * as o from '../options';
+
+import type { Opts } from '../options';
 
 export type ExecuteOptions = Required<
   Pick<

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -76,8 +76,8 @@ const executeCommand = {
         'Execute foo/job.js with no adaptor and write the final state to foo/job.json'
       )
       .example(
-        'openfn workflow.json -ia common',
-        'Execute workflow.json using @openfn/language-commom (with autoinstall enabled)'
+        'openfn workflow.json -i',
+        'Execute workflow.json with autoinstall enabled'
       )
       .example(
         'openfn job.js -a common --log info',

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -2,9 +2,9 @@ import path from 'node:path';
 import yargs from 'yargs';
 import type { ExecutionPlan } from '@openfn/runtime';
 import doExpandAdaptors from './util/expand-adaptors';
-import { DEFAULT_REPO_DIR } from './util/ensure-opts';
 import type { CommandList } from './commands';
 import { CLIExecutionPlan } from './types';
+import { DEFAULT_REPO_DIR } from './constants';
 
 // Central type definition for the main options
 // This is in flux as options are being refactored
@@ -50,7 +50,8 @@ export type UnparsedOpts = Opts & {
 
 export type CLIOption = {
   name: string;
-  yargs: yargs.Options;
+  // Allow this to take a function to lazy-evaluate env vars
+  yargs: yargs.Options | (() => yargs.Options);
   ensure?: (opts: Opts) => void;
 };
 
@@ -233,10 +234,10 @@ export const outputPath: CLIOption = {
 
 export const repoDir: CLIOption = {
   name: 'repo-dir',
-  yargs: {
+  yargs: () => ({
     description: 'Provide a path to the repo root dir',
     default: process.env.OPENFN_REPO_DIR || DEFAULT_REPO_DIR,
-  },
+  }),
 };
 
 export const start: CLIOption = {

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -265,12 +265,12 @@ export const strictOutput: CLIOption = {
 };
 
 export const strict: CLIOption = {
-  name: 'no-strict',
+  name: 'strict',
   yargs: {
     default: false,
     boolean: true,
     description:
-      'Strict state handling, meaning only state.data is returned from a job.',
+      'Enables strict state handling, meaning only state.data is returned from a job.',
   },
   ensure: (opts) => {
     if (!opts.hasOwnProperty('strictOutput')) {

--- a/packages/cli/src/repo/handler.ts
+++ b/packages/cli/src/repo/handler.ts
@@ -4,24 +4,20 @@ import treeify from 'treeify';
 import { install as rtInstall, loadRepoPkg } from '@openfn/runtime';
 import type { Opts } from '../options';
 import { defaultLogger, Logger } from '../util/logger';
-import expandAdaptors from '../util/expand-adaptors';
 
-type InstallOpts = Pick<Opts, 'packages' | 'adaptor' | 'repoDir'>;
+type InstallOpts = Pick<Opts, 'packages' | 'adaptors' | 'repoDir'>;
 
 export const install = async (
   opts: InstallOpts,
   log: Logger = defaultLogger
 ) => {
-  let { packages, adaptor, repoDir } = opts;
-  if (packages) {
+  let { packages, adaptors, repoDir } = opts;
+  const targets = ([] as string[]).concat(packages ?? [], adaptors ?? []);
+  if (targets) {
     log.timer('install');
     log.success('Installing packages...'); // not really success but I want it to default
     log.debug('repoDir is set to:', repoDir);
-    if (adaptor) {
-      const expanded = expandAdaptors({ adaptors: packages });
-      packages = expanded.adaptors;
-    }
-    await rtInstall(packages ?? [], repoDir, log);
+    await rtInstall(targets, repoDir, log);
     const duration = log.timer('install');
     log.success(`Installation complete in ${duration}`);
   }

--- a/packages/cli/src/util/command-builders.ts
+++ b/packages/cli/src/util/command-builders.ts
@@ -2,9 +2,16 @@ import yargs from 'yargs';
 import { CommandList } from '../commands';
 import type { Opts, CLIOption } from '../options';
 
+const expandYargs = (y: {} | (() => any)) => {
+  if (typeof y === 'function') {
+    return y();
+  }
+  return y;
+};
+
 // build helper to chain options
 export const build = (opts: CLIOption[], yargs: yargs.Argv) =>
-  opts.reduce((_y, o) => yargs.option(o.name, o.yargs), yargs);
+  opts.reduce((_y, o) => yargs.option(o.name, expandYargs(o.yargs)), yargs);
 
 // Mutate the incoming argv with defaults etc
 export const ensure =

--- a/packages/cli/src/util/ensure-opts.ts
+++ b/packages/cli/src/util/ensure-opts.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { SafeOpts } from '../commands';
+import { DEFAULT_REPO_DIR } from '../constants';
 import { Opts } from '../options';
 import { LogLevel, isValidLogLevel } from './logger';
 
@@ -13,8 +14,6 @@ export const ERROR_MESSAGE_LOG_LEVEL =
   'Unknown log level. Valid levels are none, debug, info and default.';
 export const ERROR_MESSAGE_LOG_COMPONENT =
   'Unknown log component. Valid components are cli, compiler, runtime and job.';
-
-export const DEFAULT_REPO_DIR = '/tmp/openfn/repo';
 
 const componentShorthands: Record<string, string> = {
   cmp: 'compiler',

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -7,7 +7,7 @@ import { createMockLogger } from '@openfn/logger';
 import { cmd } from '../src/cli';
 import commandParser from '../src/commands';
 import type { Opts } from '../src/options';
-import { DEFAULT_REPO_DIR } from '../src/util/ensure-opts';
+import { DEFAULT_REPO_DIR } from '../src/constants';
 
 const logger = createMockLogger('', { level: 'debug' });
 
@@ -541,77 +541,6 @@ test.serial('compile a workflow: openfn compile wf.json to file', async (t) => {
   const result = JSON.parse(output);
   t.truthy(result);
   t.is(result.jobs[0].expression, 'export default [x()];');
-});
-
-test.serial('pwd should return the default repo path', async (t) => {
-  const dir = process.env.OPENFN_REPO_DIR;
-  delete process.env.OPENFN_REPO_DIR; // ensure this is unset
-
-  const options = {
-    logger,
-  };
-  await run('repo pwd', '', options);
-
-  const { message } = logger._parse(logger._last);
-  t.is(message, `Repo working directory is: ${DEFAULT_REPO_DIR}`);
-
-  process.env.OPENFN_REPO_DIR = dir;
-});
-
-test.serial('pwd if modules_home is passed', async (t) => {
-  const options = {
-    repoDir: 'a/b/c',
-    logger,
-  };
-  await run('repo pwd', '', options);
-
-  const { message } = logger._parse(logger._last);
-  t.is(message, 'Repo working directory is: a/b/c');
-});
-
-test.serial('pwd with modules_home from env', async (t) => {
-  const dir = process.env.OPENFN_REPO_DIR;
-  process.env.OPENFN_REPO_DIR = 'x/y/z';
-
-  const options = {
-    logger,
-  };
-  await run('repo pwd', '', options);
-
-  const { message } = logger._parse(logger._last);
-  t.is(message, 'Repo working directory is: x/y/z');
-
-  process.env.OPENFN_REPO_DIR = dir;
-});
-
-test.serial('list should return something', async (t) => {
-  const options = {
-    logger,
-    repoDir: 'a/b/c',
-  };
-  await run('repo list', '', options);
-
-  // Rough check of the shape of the output
-  const [_dir, pwd, installed] = logger._history;
-  t.is(logger._parse(pwd).message, 'Repo working directory is: a/b/c');
-
-  const message = logger._parse(installed).message as string;
-  t.assert(message.startsWith('Installed packages:'));
-});
-
-// This used to throw, see #70
-test.serial('list does not throw if repo is not initialised', async (t) => {
-  mock({
-    '/repo/': {}, // empty dir
-  });
-
-  const opts = cmd.parse('repo list') as Opts;
-  opts.repoDir = '/repo/';
-
-  await commandParser('', opts, logger);
-
-  const { message } = logger._parse(logger._last);
-  t.truthy(message);
 });
 
 test.serial('docs should print documentation with full names', async (t) => {

--- a/packages/cli/test/compile/compile.test.ts
+++ b/packages/cli/test/compile/compile.test.ts
@@ -117,9 +117,9 @@ test('throw an AbortError if a workflow contains an uncompilable jon', async (t)
 });
 
 test('stripVersionSpecifier: remove version specifier from @openfn', (t) => {
-  const specifier = '@openfn/language-commmon@3.0.0-rc2';
+  const specifier = '@openfn/language-common@3.0.0-rc2';
   const transformed = stripVersionSpecifier(specifier);
-  const expected = '@openfn/language-commmon';
+  const expected = '@openfn/language-common';
   t.assert(transformed == expected);
 });
 
@@ -138,9 +138,9 @@ test('stripVersionSpecifier: remove version specifier from arbitrary namespaced 
 });
 
 test("stripVersionSpecifier: do nothing if there's no specifier", (t) => {
-  const specifier = '@openfn/language-commmon';
+  const specifier = '@openfn/language-common';
   const transformed = stripVersionSpecifier(specifier);
-  const expected = '@openfn/language-commmon';
+  const expected = '@openfn/language-common';
   t.assert(transformed == expected);
 });
 

--- a/packages/cli/test/compile/compile.test.ts
+++ b/packages/cli/test/compile/compile.test.ts
@@ -96,7 +96,7 @@ test('throw an AbortError if a job is uncompilable', async (t) => {
   t.assert(logger._find('error', /critical error: aborting command/i));
 });
 
-test('throw an AbortError if a workflow contains an uncompilable jon', async (t) => {
+test('throw an AbortError if a workflow contains an uncompilable job', async (t) => {
   const workflow = {
     start: 'a',
     jobs: [{ id: 'a', expression: 'x b' }],

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -174,7 +174,7 @@ test('run a workflow with config as a path', async (t) => {
     jobs: [
       {
         configuration: '/config.json',
-        expression: `${fn}fn((state) => { state.cfg = state.configuration; return state;})`,
+        expression: `${fn}fn((state) => { state.cfg = state.configuration; return state; })`,
       },
     ],
   };

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -1,5 +1,5 @@
 // bunch of unit tests on the execute function itself
-// so far this is only done in commmands.test.ts, which has the cli overhead
+// so far this is only done in commands.test.ts, which has the cli overhead
 // I don't want any io or adaptor tests here, really just looking for the actual execute flow
 import mock from 'mock-fs';
 import path from 'node:path';

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -174,7 +174,7 @@ test('run a workflow with config as a path', async (t) => {
     jobs: [
       {
         configuration: '/config.json',
-        expression: `${fn}fn((state) => state)`,
+        expression: `${fn}fn((state) => { state.cfg = state.configuration; return state;})`,
       },
     ],
   };
@@ -183,7 +183,7 @@ test('run a workflow with config as a path', async (t) => {
     workflow,
   };
   const result = await handler(options, logger);
-  t.is(result.configuration.id, 'x');
+  t.is(result.cfg.id, 'x');
 });
 
 test('run a workflow from a start node', async (t) => {

--- a/packages/cli/test/options/execute.test.ts
+++ b/packages/cli/test/options/execute.test.ts
@@ -1,0 +1,54 @@
+import test from 'ava';
+import yargs from 'yargs';
+
+import execute from '../../src/execute/command';
+
+import type { Opts } from '../../src/options';
+import { DEFAULT_REPO_DIR } from '../../src/constants';
+
+// Build the execute command and test the options it returns
+
+const cmd = yargs().command(execute);
+
+const parse = (command: string) => cmd.parse(command) as yargs.Arguments<Opts>;
+
+test("execute: jobPath'.'", (t) => {
+  const options = parse('execute job.js');
+  t.assert(options.jobPath === 'job.js');
+});
+
+test('execute: default outputPath to ./output.json', (t) => {
+  const options = parse('execute tmp/job.js');
+  t.assert(options.outputPath === 'tmp/output.json');
+});
+
+test('execute: set outputPath to ./output.json', (t) => {
+  const options = parse('execute tmp/job.js -o /result/out.json');
+  t.assert(options.outputPath === '/result/out.json');
+});
+
+test('repoDir: use the built-in default if no env var', (t) => {
+  const dir = process.env.OPENFN_REPO_DIR;
+  delete process.env.OPENFN_REPO_DIR;
+
+  const options = parse('repo');
+
+  t.is(options.repoDir, DEFAULT_REPO_DIR);
+  process.env.OPENFN_REPO_DIR = dir;
+});
+
+test('repoDir: use OPENFN_REPO_DIR env var if set', (t) => {
+  const dir = process.env.OPENFN_REPO_DIR;
+  process.env.OPENFN_REPO_DIR = 'x/y/z';
+
+  const options = parse('repo');
+
+  t.is(options.repoDir, 'x/y/z');
+  process.env.OPENFN_REPO_DIR = dir;
+});
+
+test('repoDir: accept an argument', (t) => {
+  const options = parse('repo --repoDir=a/b/c');
+
+  t.is(options.repoDir, 'a/b/c');
+});

--- a/packages/cli/test/options/repo.test.ts
+++ b/packages/cli/test/options/repo.test.ts
@@ -1,0 +1,62 @@
+import test from 'ava';
+import yargs from 'yargs';
+
+import { repo } from '../../src/repo/command';
+
+import type { Opts } from '../../src/options';
+import { DEFAULT_REPO_DIR } from '../../src/constants';
+
+// Build the repo command and test the options it returns
+// Note that this will re-parse the command each time, so env vars will be re-calculated
+const parse = (command: string) =>
+  yargs().command(repo).parse(command) as yargs.Arguments<Opts>;
+
+test('repoDir: use the built-in default if no env var', (t) => {
+  const dir = process.env.OPENFN_REPO_DIR;
+  delete process.env.OPENFN_REPO_DIR;
+
+  const options = parse('repo');
+
+  t.is(options.repoDir, DEFAULT_REPO_DIR);
+  process.env.OPENFN_REPO_DIR = dir;
+});
+
+test('repoDir: use OPENFN_REPO_DIR env var if set', (t) => {
+  const dir = process.env.OPENFN_REPO_DIR;
+  process.env.OPENFN_REPO_DIR = 'x/y/z';
+
+  const options = parse('repo');
+
+  t.is(options.repoDir, 'x/y/z');
+  process.env.OPENFN_REPO_DIR = dir;
+});
+
+test('repoDir: accept an argument', (t) => {
+  const options = parse('repo --repoDir=a/b/c');
+
+  t.is(options.repoDir, 'a/b/c');
+});
+
+test('install: always expand adaptors', (t) => {
+  const options = parse('repo install');
+
+  t.true(options.expandAdaptors);
+});
+
+test('install: install a module', (t) => {
+  const options = parse('repo install common');
+
+  t.deepEqual(options.packages, ['common']);
+});
+
+test('install: install an adaptor', (t) => {
+  const options = parse('repo install -a common');
+
+  t.deepEqual(options.adaptors, ['@openfn/language-common']);
+});
+
+test('clean: force', (t) => {
+  const options = parse('repo clean -f');
+
+  t.true(options.force);
+});

--- a/packages/cli/test/repo/index.ts
+++ b/packages/cli/test/repo/index.ts
@@ -1,0 +1,5 @@
+// See ../../integration-tests/cli/test/repo.test.ts
+// Unit tests against the repo commands are hard because they rely so heavily on npm
+// So we rely more on the integration testing to test this stuff
+
+export {};

--- a/packages/runtime-manager/CHANGELOG.md
+++ b/packages/runtime-manager/CHANGELOG.md
@@ -1,5 +1,12 @@
 # runtime-manager
 
+## 0.0.34
+
+### Patch Changes
+
+- Updated dependencies [2024ce8]
+  - @openfn/runtime@0.0.25
+
 ## 0.0.33
 
 ### Patch Changes

--- a/packages/runtime-manager/package.json
+++ b/packages/runtime-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime-manager",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "An example runtime manager service.",
   "main": "index.js",
   "type": "module",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/runtime
 
+## 0.0.25
+
+### Patch Changes
+
+- 2024ce8: Ensure jobs only receive direct upstream state
+
 ## 0.0.24
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Job processing runtime.",
   "type": "module",
   "exports": {

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -114,6 +114,9 @@ const prepareFinalState = (opts: Options, state: any) => {
   if (state) {
     if (opts.strict) {
       state = assignKeys(state, {}, ['data', 'error', 'references']);
+    } else {
+      // TODO this is new and needs unit tests
+      delete state.configuration;
     }
     const cleanState = stringify(state);
     return JSON.parse(cleanState);

--- a/packages/runtime/src/execute/plan.ts
+++ b/packages/runtime/src/execute/plan.ts
@@ -5,6 +5,7 @@ import assembleState from '../util/assemble-state';
 import type {
   CompiledExecutionPlan,
   ExecutionPlan,
+  JobNode,
   JobNodeID,
   State,
 } from '../types';
@@ -44,39 +45,52 @@ const executePlan = async (
     report: createErrorReporter(logger),
   };
 
-  let lastState = initialState;
+  const stateHistory: Record<string, any> = {};
+  const leaves = {};
 
   // Right now this executes in series, even if jobs are parallelised
   while (queue.length) {
-    const next = queue.shift();
-    const result = await executeJob(ctx, next!, clone(lastState));
+    const next = queue.shift()!;
+    const job = compiledPlan.jobs[next];
+
+    const prevState = stateHistory[job.previous || ''] ?? initialState;
+
+    const state = assembleState(
+      clone(prevState),
+      job.configuration,
+      job.data,
+      ctx.opts.strict
+    );
+    const result = await executeJob(ctx, job, state);
+    stateHistory[next] = result.state;
+
+    if (!result.next.length) {
+      leaves[next] = stateHistory[next];
+    }
+
     if (result.next) {
       queue.push(...result.next);
     }
-    lastState = result.state;
   }
-  return lastState;
+  // If there are multiple leaf results, return them
+  if (Object.keys(leaves).length > 1) {
+    return leaves;
+  }
+  // Return a single value
+  return Object.values(leaves)[0];
 };
 
 const executeJob = async (
   ctx: ExeContext,
-  jobId: string,
-  initialState: State
+  job: JobNode,
+  state: State
 ): Promise<{ next: JobNodeID[]; state: any }> => {
   const next: string[] = [];
 
   // We should by this point have validated the plan, so the job MUST exist
-  const job = ctx.plan.jobs[jobId];
 
   ctx.logger.timer('job');
-  ctx.logger.always('Starting job', jobId);
-
-  const state = assembleState(
-    initialState,
-    job.configuration,
-    job.data,
-    ctx.opts.strict
-  );
+  ctx.logger.always('Starting job', job.id);
 
   let result: any = state;
   if (job.expression) {
@@ -89,11 +103,11 @@ const executeJob = async (
         ctx.opts
       );
       const duration = ctx.logger.timer('job');
-      ctx.logger.success(`Completed job ${jobId} in ${duration}`);
+      ctx.logger.success(`Completed job ${job.id} in ${duration}`);
     } catch (e: any) {
       const duration = ctx.logger.timer('job');
-      ctx.logger.error(`Failed job ${jobId} after ${duration}`);
-      ctx.report(state, jobId, e);
+      ctx.logger.error(`Failed job ${job.id} after ${duration}`);
+      ctx.report(state, job.id, e);
     }
   }
 

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -59,6 +59,7 @@ export type JobNode = {
   data?: State['data']; // default state (globals)
 
   next?: string | Record<JobNodeID, true | JobEdge>;
+  previous?: JobNodeID;
 };
 
 export type JobEdge = {

--- a/packages/runtime/test/execute/compile-plan.test.ts
+++ b/packages/runtime/test/execute/compile-plan.test.ts
@@ -20,12 +20,22 @@ const planWithEdge = (edge: JobEdge) =>
 test('should convert jobs to an object', (t) => {
   const compiledPlan = compilePlan(testPlan);
   t.truthy(compiledPlan.jobs.a);
-  t.falsy(compiledPlan.jobs.a.id);
   t.is(compiledPlan.jobs.a.expression, 'x');
 
   t.truthy(compiledPlan.jobs.b);
-  t.falsy(compiledPlan.jobs.b.id);
   t.is(compiledPlan.jobs.b.expression, 'y');
+});
+
+test('should auto generate ids for jobs', (t) => {
+  const plan = {
+    start: 'a',
+    jobs: [{ expression: 'x' }, { expression: 'y' }],
+  };
+  const compiledPlan = compilePlan(plan);
+  const ids = Object.keys(compiledPlan.jobs);
+  t.truthy(ids[0]);
+  t.truthy(ids[1]);
+  t.assert(ids[0] !== ids[1]);
 });
 
 test('should convert jobs to an object with auto ids', (t) => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -48,10 +48,22 @@ test('run a workflow with state and parallel branching', async (t) => {
   };
 
   const result: any = await run(plan, { data: { count: 0 } });
-  t.true(result.data.a);
-  t.true(result.data.b);
-  t.true(result.data.c);
-  t.is(result.data.count, 3);
+  t.deepEqual(result, {
+    b: {
+      data: {
+        count: 2,
+        a: true,
+        b: true,
+      },
+    },
+    c: {
+      data: {
+        count: 2,
+        a: true,
+        c: true,
+      },
+    },
+  });
 });
 
 test('run a workflow with state and conditional branching', async (t) => {
@@ -181,6 +193,15 @@ test('do pass extraneous state in non-strict mode', async (t) => {
     x: 1,
     data: {},
   });
+});
+
+test('Allow a job to return undefined', async (t) => {
+  const plan: ExecutionPlan = {
+    jobs: [{ expression: 'export default [() => {}]' }],
+  };
+
+  const result: any = await run(plan);
+  t.falsy(result);
 });
 
 test('log errors, write to state, and continue', async (t) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,14 @@ importers:
       tslib: 2.4.0
       typescript: 4.8.3
 
+  integration-tests/cli/repo:
+    specifiers:
+      '@openfn/language-common_1.7.7': npm:@openfn/language-common@^1.7.7
+      is-array_1.0.1: npm:is-array@^1.0.1
+    dependencies:
+      '@openfn/language-common_1.7.7': /@openfn/language-common/1.7.7
+      is-array_1.0.1: /is-array/1.0.1
+
   packages/cli:
     specifiers:
       '@openfn/compiler': workspace:*
@@ -610,6 +618,17 @@ packages:
       - debug
     dev: true
 
+  /@openfn/language-common/1.7.7:
+    resolution: {integrity: sha512-GSoAbo6oL0b8jHufhLKvIzHJ271aE2AKv/ibeuiWU3CqN1gRmaHArlA/omlCs/rsfcieSp2VWAvWeGuFY8buZw==}
+    dependencies:
+      axios: 1.1.3
+      date-fns: 2.29.3
+      jsonpath-plus: 4.0.0
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@openfn/language-common/2.0.0-rc3:
     resolution: {integrity: sha512-7kwhBnCd1idyTB3MD9dXmUqROAhoaUIkz2AGDKuv9vn/cbZh7egEv9/PzKkRcDJYFV9qyyS+cVT3Xbgsg2ii5g==}
     bundledDependencies: []
@@ -1053,7 +1072,6 @@ packages:
 
   /asynckit/0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
 
   /atob/2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
@@ -1127,7 +1145,6 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
-    dev: true
 
   /b4a/1.6.1:
     resolution: {integrity: sha512-AsKjNhz72yxteo/0EtQEiwkMUgk/tGmycXlbG4g3Ard2/ULtNLUykGOkeK0egmN27h0xMAhb76jYccW+XTBExA==}
@@ -1523,7 +1540,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /commander/4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1794,7 +1810,6 @@ packages:
   /delayed-stream/1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /delegates/1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -2834,7 +2849,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: true
 
   /for-in/1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
@@ -2848,7 +2862,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: true
 
   /fragment-cache/0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
@@ -3251,6 +3264,10 @@ packages:
       kind-of: 6.0.3
     dev: true
 
+  /is-array/1.0.1:
+    resolution: {integrity: sha512-gxiZ+y/u67AzpeFmAmo4CbtME/bs7J2C++su5zQzvQyaxUqVzkh69DI+jN+KZuSO6JaH6TIIU6M6LhqxMjxEpw==}
+    dev: false
+
   /is-arrayish/0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
     dev: true
@@ -3567,7 +3584,6 @@ packages:
   /jsonpath-plus/4.0.0:
     resolution: {integrity: sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==}
     engines: {node: '>=10.0'}
-    dev: true
 
   /keygrip/1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
@@ -4517,7 +4533,6 @@ packages:
 
   /proxy-from-env/1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: true
 
   /proxy-middleware/0.15.0:
     resolution: {integrity: sha512-EGCG8SeoIRVMhsqHQUdDigB2i7qU7fCsWASwn54+nPutYO8n4q6EiwMzyfWlC+dzRFExP+kvcnDFdBDHoZBU7Q==}


### PR DESCRIPTION
Release for CLI 0.0.40 and dependencies:

This contains:

* State gets properly passed to downstream jobs #247 
* CLI doc fixes #243
* Internal refactor of the repo command (`openfn repo pwd` is removed; `openfn repo` is now an alias for `openfn repo list`)

It would be great to get a bit of basic QA on the new state handling stuff.

Remember to install `openfn` by running `pnpm install:global`.

Versions have been bumped here, so you should be able to install, build and publish from this branch.