### PR TITLE
Ensure workflows use the monorepo

### DIFF
--- a/.changeset/little-doors-do.md
+++ b/.changeset/little-doors-do.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Ensure workflows can use the monorepo

--- a/.changeset/little-doors-do.md
+++ b/.changeset/little-doors-do.md
@@ -1,5 +1,0 @@
----
-'@openfn/cli': patch
----
-
-Ensure workflows can use the monorepo

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "pack": "pnpm -r run pack",
     "pack:local": "pnpm run pack && node ./build/pack-local.js",
     "install:global": "pnpm build && pnpm run pack && node ./build/install-global.js",
+    "install:openfnx": "pnpm install:global",
     "export": "sh scripts/export.sh"
   },
   "keywords": [],

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/cli
 
+## 0.0.41
+
+### Patch Changes
+
+- 8ac138f: Ensure workflows can use the monorepo
+
 ## 0.0.40
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -10,7 +10,9 @@ import { clean, install, pwd, list } from './repo/handler';
 import createLogger, { CLI, Logger, LogLevel } from './util/logger';
 import ensureOpts, { ensureLogOpts } from './util/ensure-opts';
 import expandAdaptors from './util/expand-adaptors';
-import useAdaptorsRepo from './util/use-adaptors-repo';
+import mapAdaptorsToMonorepo, {
+  MapAdaptorsToMonorepoOptions,
+} from './util/map-adaptors-to-monorepo';
 import printVersions from './util/print-versions';
 
 export type CommandList =
@@ -74,11 +76,7 @@ const parse = async (basePath: string, options: Opts, log?: Logger) => {
       logger.error('Set OPENFN_ADAPTORS_REPO to a path pointing to the repo');
       process.exit(9); // invalid argument
     }
-    opts.adaptors = await useAdaptorsRepo(
-      opts.adaptors,
-      opts.monorepoPath,
-      logger
-    );
+    await mapAdaptorsToMonorepo(opts as MapAdaptorsToMonorepoOptions, logger);
   } else if (opts.adaptors && opts.expandAdaptors) {
     // TODO this will be removed once all options have been refactored
     //      This is safely redundant in execute and compile

--- a/packages/cli/src/compile/handler.ts
+++ b/packages/cli/src/compile/handler.ts
@@ -4,9 +4,23 @@ import type { Logger } from '../util/logger';
 
 import compile from './compile';
 import loadInput from '../util/load-input';
+import expandAdaptors from '../util/expand-adaptors';
+import mapAdaptorsToMonorepo, {
+  MapAdaptorsToMonorepoOptions,
+} from '../util/map-adaptors-to-monorepo';
 
 const compileHandler = async (options: CompileOptions, logger: Logger) => {
   await loadInput(options, logger);
+
+  if (options.workflow) {
+    // expand shorthand adaptors in the workflow jobs
+    expandAdaptors(options);
+    await mapAdaptorsToMonorepo(
+      options as MapAdaptorsToMonorepoOptions,
+      logger
+    );
+  }
+
   let result = await compile(options, logger);
   if (options.workflow) {
     result = JSON.stringify(result);

--- a/packages/cli/src/execute/handler.ts
+++ b/packages/cli/src/execute/handler.ts
@@ -10,6 +10,9 @@ import loadState from '../util/load-state';
 import validateAdaptors from '../util/validate-adaptors';
 import loadInput from '../util/load-input';
 import expandAdaptors from '../util/expand-adaptors';
+import mapAdaptorsToMonorepo, {
+  MapAdaptorsToMonorepoOptions,
+} from '../util/map-adaptors-to-monorepo';
 
 const executeHandler = async (options: ExecuteOptions, logger: Logger) => {
   const start = new Date().getTime();
@@ -21,6 +24,10 @@ const executeHandler = async (options: ExecuteOptions, logger: Logger) => {
   if (options.workflow) {
     // expand shorthand adaptors in the workflow jobs
     expandAdaptors(options);
+    await mapAdaptorsToMonorepo(
+      options as MapAdaptorsToMonorepoOptions,
+      logger
+    );
   }
 
   const { repoDir, monorepoPath, autoinstall } = options;

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -7,7 +7,6 @@ import { createMockLogger } from '@openfn/logger';
 import { cmd } from '../src/cli';
 import commandParser from '../src/commands';
 import type { Opts } from '../src/options';
-import { DEFAULT_REPO_DIR } from '../src/constants';
 
 const logger = createMockLogger('', { level: 'debug' });
 
@@ -34,7 +33,7 @@ type RunOptions = {
     log: (s: string) => void;
   };
   disableMock?: boolean;
-  mockfs: object;
+  mockfs?: object;
 };
 
 // Helper function to mock a file system with particular paths and values,
@@ -77,7 +76,8 @@ async function run(command: string, job: string, options: RunOptions = {}) {
   opts.path = jobPath;
   opts.repoDir = options.repoDir;
 
-  opts.log = ['none'];
+  // opts.log = ['none'];
+  opts.log = ['debug'];
   opts.skipAdaptorValidation = true;
 
   await commandParser(jobPath, opts, logger);
@@ -503,6 +503,29 @@ test.serial(
     const job = 'export default [alterState(() => 39)]';
     const result = await run('openfn job.js -m -a common', job);
     t.assert(result === 39);
+    delete process.env.OPENFN_ADAPTORS_REPO;
+  }
+);
+
+test.serial.only(
+  'load an workflow adaptor from the monorepo: openfn workflow.json -m',
+  async (t) => {
+    process.env.OPENFN_ADAPTORS_REPO = '/monorepo/';
+    const workflow = JSON.stringify({
+      jobs: [
+        {
+          adaptor: 'common',
+          data: { done: true },
+          expression: 'alterState(s => s)',
+        },
+      ],
+    });
+
+    const result = await run('openfn workflow.json -m', workflow, {
+      jobPath: 'workflow.json',
+    });
+    console.log(result);
+    t.true(result.done);
     delete process.env.OPENFN_ADAPTORS_REPO;
   }
 );

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -76,8 +76,7 @@ async function run(command: string, job: string, options: RunOptions = {}) {
   opts.path = jobPath;
   opts.repoDir = options.repoDir;
 
-  // opts.log = ['none'];
-  opts.log = ['debug'];
+  opts.log = ['none'];
   opts.skipAdaptorValidation = true;
 
   await commandParser(jobPath, opts, logger);
@@ -501,14 +500,14 @@ test.serial(
   async (t) => {
     process.env.OPENFN_ADAPTORS_REPO = '/monorepo/';
     const job = 'export default [alterState(() => 39)]';
-    const result = await run('openfn job.js -m -a common', job);
+    const result = await run('job.js -m -a common', job);
     t.assert(result === 39);
     delete process.env.OPENFN_ADAPTORS_REPO;
   }
 );
 
-test.serial.only(
-  'load an workflow adaptor from the monorepo: openfn workflow.json -m',
+test.serial(
+  'load a workflow adaptor from the monorepo: openfn workflow.json -m',
   async (t) => {
     process.env.OPENFN_ADAPTORS_REPO = '/monorepo/';
     const workflow = JSON.stringify({
@@ -521,11 +520,10 @@ test.serial.only(
       ],
     });
 
-    const result = await run('openfn workflow.json -m', workflow, {
+    const result = await run('workflow.json -m', workflow, {
       jobPath: 'workflow.json',
     });
-    console.log(result);
-    t.true(result.done);
+    t.true(result.data.done);
     delete process.env.OPENFN_ADAPTORS_REPO;
   }
 );


### PR DESCRIPTION
Turns out that if you use workflows with the monorepo, the adaptors in the workflow don't  get mapped properly.

There's a utility function which look at the `options.adaptors` array and map each adaptor to a path in the monorepo.

This PR updates that function to also look at a workflow object.

To support this I've refactored the function a bit.

I've bumped versions: I suggest after a bit of QA we release this straight off this branch.