### PR TITLE
Workflow Tweaks

### DIFF
--- a/integration-tests/cli/test/fixtures/wf-conditional.json
+++ b/integration-tests/cli/test/fixtures/wf-conditional.json
@@ -3,8 +3,10 @@
   "jobs": [
     {
       "id": "start",
-      "data": {
-        "number": 1
+      "state": {
+        "data": {
+          "number": 1
+        }
       },
       "adaptor": "common",
       "expression": "fn((state) => state);",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Patch Changes
 
 - 8ac138f: Ensure workflows can use the monorepo
+- Updated dependencies
+  - @openfn/runtime@0.0.26
 
 ## 0.0.40
 

--- a/packages/cli/src/test/handler.ts
+++ b/packages/cli/src/test/handler.ts
@@ -16,7 +16,7 @@ const testHandler = async (options: ExecuteOptions, logger: Logger) => {
     jobs: [
       {
         id: 'start',
-        data: { defaultAnswer: 42 },
+        state: { data: { defaultAnswer: 42 } },
         expression:
           "const fn = () => (state) => { console.log('Starting computer...'); return state; }; fn()",
         next: {
@@ -55,7 +55,7 @@ const testHandler = async (options: ExecuteOptions, logger: Logger) => {
 
   const state = await loadState(options, silentLogger);
   const code = await compile(options, logger);
-  const result = await execute(code, state, options);
+  const result = await execute(code, state, options, silentLogger);
   logger.success(`Result: ${result.data.answer}`);
   return result;
 };

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -514,7 +514,7 @@ test.serial(
       jobs: [
         {
           adaptor: 'common',
-          data: { done: true },
+          state: { data: { done: true } },
           expression: 'alterState(s => s)',
         },
       ],

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -125,7 +125,7 @@ test.serial('run a workflow', async (t) => {
     jobs: [
       {
         id: 'job1',
-        data: { x: 0 },
+        state: { data: { x: 0 } },
         expression: 'export default [s => { s.data.x += 1; return s; } ]',
         next: { job2: true },
       },
@@ -149,7 +149,7 @@ test.serial('run a workflow with config as an object', async (t) => {
   const workflow = {
     jobs: [
       {
-        data: { x: 0 },
+        state: { data: { x: 0 } },
         configuration: { y: 0 },
         expression:
           'export default [s => { s.data.y = s.configuration.y; return s}]',
@@ -171,7 +171,7 @@ test.serial('run a workflow with config as a path', async (t) => {
   const workflow = {
     jobs: [
       {
-        data: { x: 0 },
+        state: { data: { x: 0 } },
         configuration: '/config.json',
         expression:
           'export default [s => { s.data.y = s.configuration.y; return s}]',

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -110,13 +110,13 @@ test('run a workflow with state', async (t) => {
     jobs: [
       {
         id: 'a',
-        data: { count: 1 },
+        state: { data: { count: 1 } },
         expression: `${fn}fn((state) => { state.data.count += 1; return state;});`,
         next: { b: true },
       },
       {
         id: 'b',
-        data: { diff: 2 },
+        state: { data: { diff: 2 } },
         expression: `${fn}fn((state) => { state.data.count += state.data.diff; return state; });`,
       },
     ],

--- a/packages/runtime-manager/CHANGELOG.md
+++ b/packages/runtime-manager/CHANGELOG.md
@@ -1,5 +1,12 @@
 # runtime-manager
 
+## 0.0.35
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/runtime@0.0.26
+
 ## 0.0.34
 
 ### Patch Changes

--- a/packages/runtime-manager/package.json
+++ b/packages/runtime-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime-manager",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "An example runtime manager service.",
   "main": "index.js",
   "type": "module",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/runtime
 
+## 0.0.26
+
+### Patch Changes
+
+- Workflow jobs take state, rather than data (eg job.data -> job.state)
+  Fix falsy edges (next: { job2: false })
+
 ## 0.0.25
 
 ### Patch Changes

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -53,7 +53,7 @@ A workflow looks like this:
   jobs: [{
     id: 'a',
     expression: "source or path",
-    data: { /* default data */ },
+    state: { /* default state */ },
     configuration: { /* credentials */ },
     next: {
       'b': true, // edge to another job

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Job processing runtime.",
   "type": "module",
   "exports": {

--- a/packages/runtime/src/execute/compile-plan.ts
+++ b/packages/runtime/src/execute/compile-plan.ts
@@ -25,6 +25,8 @@ const compileEdges = (
       const edge = edges[edgeId];
       if (typeof edge === 'boolean') {
         result[edgeId] = edge;
+      } else if (typeof edge === 'string') {
+        result[edgeId] = { condition: compileFunction(edge, context) };
       } else {
         const newEdge = {
           ...edge,

--- a/packages/runtime/src/execute/compile-plan.ts
+++ b/packages/runtime/src/execute/compile-plan.ts
@@ -12,7 +12,7 @@ import { conditionContext, Context } from './context';
 // eg { start: 'a' }, { next: 'b' }, { start: { a: { condition: '!state.error' }}}
 const compileEdges = (
   from: string,
-  edges: string | Record<string, true | JobEdge>,
+  edges: string | Record<string, boolean | JobEdge>,
   context: Context
 ) => {
   if (typeof edges === 'string') {
@@ -20,19 +20,21 @@ const compileEdges = (
   }
   const errs = [];
 
-  const result = {} as Record<string, CompiledJobEdge>;
+  const result = {} as Record<string, boolean | CompiledJobEdge>;
   for (const edgeId in edges) {
     try {
       const edge = edges[edgeId];
-      const compiledEdge = {} as CompiledJobEdge;
-      if (edge !== true) {
+      if (typeof edge === 'boolean') {
+        result[edgeId] = edge;
+      } else {
+        const compiledEdge = {} as CompiledJobEdge;
         if (typeof edge.condition === 'string') {
           compiledEdge.condition = compileFunction(edge.condition, context);
         } else {
           compiledEdge.condition = edge.condition;
         }
+        result[edgeId] = compiledEdge;
       }
-      result[edgeId] = compiledEdge;
     } catch (e: any) {
       errs.push(
         new Error(

--- a/packages/runtime/src/execute/plan.ts
+++ b/packages/runtime/src/execute/plan.ts
@@ -114,7 +114,7 @@ const executeJob = async (
   if (job.next) {
     for (const nextJobId in job.next) {
       const edge = job.next[nextJobId];
-      if (!edge.condition || edge.condition(result)) {
+      if (edge === true || !edge.condition || edge.condition(result)) {
         next.push(nextJobId);
       }
       // TODO errors

--- a/packages/runtime/src/execute/plan.ts
+++ b/packages/runtime/src/execute/plan.ts
@@ -4,8 +4,8 @@ import compilePlan from './compile-plan';
 import assembleState from '../util/assemble-state';
 import type {
   CompiledExecutionPlan,
+  CompiledJobNode,
   ExecutionPlan,
-  JobNode,
   JobNodeID,
   State,
 } from '../types';
@@ -45,8 +45,11 @@ const executePlan = async (
     report: createErrorReporter(logger),
   };
 
-  const stateHistory: Record<string, any> = {};
-  const leaves = {};
+  type State = any;
+  // record of state returned by every job
+  const stateHistory: Record<string, State> = {};
+  // Record of state on lead nodes (nodes with no next)
+  const leaves: Record<string, State> = {};
 
   // Right now this executes in series, even if jobs are parallelised
   while (queue.length) {
@@ -58,7 +61,7 @@ const executePlan = async (
     const state = assembleState(
       clone(prevState),
       job.configuration,
-      job.data,
+      job.state,
       ctx.opts.strict
     );
     const result = await executeJob(ctx, job, state);
@@ -82,7 +85,7 @@ const executePlan = async (
 
 const executeJob = async (
   ctx: ExeContext,
-  job: JobNode,
+  job: CompiledJobNode,
   state: State
 ): Promise<{ next: JobNodeID[]; state: any }> => {
   const next: string[] = [];
@@ -114,7 +117,10 @@ const executeJob = async (
   if (job.next) {
     for (const nextJobId in job.next) {
       const edge = job.next[nextJobId];
-      if (edge === true || !edge.condition || edge.condition(result)) {
+      if (
+        edge &&
+        (edge === true || !edge.condition || edge.condition(result))
+      ) {
         next.push(nextJobId);
       }
       // TODO errors

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -64,6 +64,7 @@ export type JobNode = {
 
 export type JobEdge =
   | boolean
+  | string
   | {
       condition?: string; // Javascript expression (function body, not function)
       label?: string;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -18,9 +18,9 @@ export type ErrorReport = {
   data?: any; // General store for related error information
 };
 
-export declare interface State<D = object, C = object> {
+export declare interface State<S = object, C = object> {
   configuration?: C;
-  data?: D;
+  state?: S;
   references?: Array<any>;
   index?: number;
 
@@ -47,7 +47,7 @@ export type ExecutionPlan = {
 };
 
 export type JobNode = {
-  id?: string;
+  id?: JobNodeID;
 
   // The runtime itself will ignore the adaptor flag
   // The adaptor import should be compiled in by the compiler, and dependency managed by the runtime manager
@@ -56,25 +56,29 @@ export type JobNode = {
   expression?: string | Operation[]; // the code we actually want to execute. Can be a path.
 
   configuration?: object; // credential object
-  data?: State['data']; // default state (globals)
+  state?: Omit<State, 'configuration'>; // default state (globals)
 
-  next?: Record<JobNodeID, boolean | JobEdge>;
+  next?: string | Record<JobNodeID, JobEdge>;
   previous?: JobNodeID;
 };
 
-export type JobEdge = {
-  condition?: string; // Javascript expression (function body, not function)
-  label?: string;
-};
+export type JobEdge =
+  | boolean
+  | {
+      condition?: string; // Javascript expression (function body, not function)
+      label?: string;
+    };
 
 export type JobNodeID = string;
 
-// Discard label information that we don't need here
-export type CompiledJobEdge = {
-  condition?: Function;
-};
+export type CompiledJobEdge =
+  | boolean
+  | {
+      condition?: Function;
+    };
 
 export type CompiledJobNode = Omit<JobNode, 'next'> & {
+  id: JobNodeID;
   next?: Record<JobNodeID, CompiledJobEdge>;
 };
 

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -58,7 +58,7 @@ export type JobNode = {
   configuration?: object; // credential object
   data?: State['data']; // default state (globals)
 
-  next?: string | Record<JobNodeID, true | JobEdge>;
+  next?: Record<JobNodeID, boolean | JobEdge>;
   previous?: JobNodeID;
 };
 

--- a/packages/runtime/src/util/assemble-state.ts
+++ b/packages/runtime/src/util/assemble-state.ts
@@ -2,10 +2,15 @@
 const assembleState = (
   initialState: any = {}, // previous or initial state
   configuration = {},
-  defaultData = {}, // This is default data provided by the job
+  defaultState: any = {}, // This is default state provided by the job
   strictState: boolean = true
 ) => {
-  const obj = strictState ? {} : { ...initialState };
+  const obj = strictState
+    ? {}
+    : {
+        ...defaultState,
+        ...initialState,
+      };
   if (initialState.references) {
     obj.references = initialState.references;
   }
@@ -18,7 +23,7 @@ const assembleState = (
       initialState.configuration ?? {},
       configuration
     ),
-    data: Object.assign({}, defaultData, initialState.data),
+    data: Object.assign({}, defaultState.data, initialState.data),
   });
   return obj;
 };

--- a/packages/runtime/test/execute/compile-plan.test.ts
+++ b/packages/runtime/test/execute/compile-plan.test.ts
@@ -101,7 +101,7 @@ test('should compile a shorthand edge', (t) => {
   const compiledPlan = compilePlan(plan);
 
   t.deepEqual(compiledPlan.jobs.a.next!, {
-    y: {},
+    y: true,
   });
 });
 

--- a/packages/runtime/test/execute/compile-plan.test.ts
+++ b/packages/runtime/test/execute/compile-plan.test.ts
@@ -112,7 +112,8 @@ test('should not recompile a functional edge', (t) => {
   });
 
   const compiledPlan = compilePlan(plan);
-  const result = compiledPlan.jobs.a.next!.b.condition?.({});
+  // @ts-ignore
+  const result = compiledPlan.jobs.a.next!.b.condition({});
   t.true(result);
 });
 
@@ -121,7 +122,18 @@ test('should compile a truthy edge', (t) => {
 
   const compiledPlan = compilePlan(plan);
 
-  const result = compiledPlan.jobs.a.next!.b.condition?.({});
+  // @ts-ignore
+  const result = compiledPlan.jobs.a.next!.b.condition({});
+  t.true(result);
+});
+
+test('should compile a string edge', (t) => {
+  const plan = planWithEdge('true');
+
+  const compiledPlan = compilePlan(plan);
+
+  // @ts-ignore
+  const result = compiledPlan.jobs.a.next!.b.condition();
   t.true(result);
 });
 
@@ -130,7 +142,8 @@ test('should compile a falsy edge', (t) => {
 
   const compiledPlan = compilePlan(plan);
 
-  const result = compiledPlan.jobs.a.next!.b.condition?.({});
+  // @ts-ignore
+  const result = compiledPlan.jobs.a.next!.b.condition({});
   t.false(result);
 });
 
@@ -139,7 +152,8 @@ test('should compile an edge with arithmetic', (t) => {
 
   const compiledPlan = compilePlan(plan);
 
-  const result = compiledPlan.jobs.a.next!.b.condition?.({});
+  // @ts-ignore
+  const result = compiledPlan.jobs.a.next!.b.condition({});
   t.is(result, 2);
 });
 
@@ -148,7 +162,8 @@ test('should compile an edge which uses state', (t) => {
 
   const compiledPlan = compilePlan(plan);
 
-  const result = compiledPlan.jobs.a.next!.b.condition?.({});
+  // @ts-ignore
+  const result = compiledPlan.jobs.a.next!.b.condition({});
   t.true(result);
 });
 
@@ -157,7 +172,8 @@ test('condition cannot require', (t) => {
 
   const compiledPlan = compilePlan(plan);
 
-  t.throws(() => compiledPlan.jobs.a.next!.b.condition?.({ data: {} }), {
+  // @ts-ignore
+  t.throws(() => compiledPlan.jobs.a.next!.b.condition({ data: {} }), {
     message: 'require is not defined',
   });
 });
@@ -167,7 +183,8 @@ test('condition cannot access process', (t) => {
 
   const compiledPlan = compilePlan(plan);
 
-  t.throws(() => compiledPlan.jobs.a.next!.b.condition?.({ data: {} }), {
+  // @ts-ignore
+  t.throws(() => compiledPlan.jobs.a.next!.b.condition({ data: {} }), {
     message: 'process is not defined',
   });
 });
@@ -177,7 +194,8 @@ test('condition cannot access process #2', (t) => {
 
   const compiledPlan = compilePlan(plan);
 
-  t.throws(() => compiledPlan.jobs.a.next!.b.condition?.({ data: {} }), {
+  // @ts-ignore
+  t.throws(() => compiledPlan.jobs.a.next!.b.condition({ data: {} }), {
     message: 'process is not defined',
   });
 });
@@ -187,7 +205,8 @@ test('condition cannot eval', (t) => {
 
   const compiledPlan = compilePlan(plan);
 
-  t.throws(() => compiledPlan.jobs.a.next!.b.condition?.({ data: {} }), {
+  // @ts-ignore
+  t.throws(() => compiledPlan.jobs.a.next!.b.condition({ data: {} }), {
     message: 'Code generation from strings disallowed for this context',
   });
 });

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -117,7 +117,7 @@ test('execute a one-job execution plan with inline state', async (t) => {
     jobs: [
       {
         expression: 'export default [s => s.data.x]',
-        data: { x: 22 }, // this is state.data, not state
+        state: { data: { x: 22 } },
       },
     ],
   };
@@ -204,7 +204,7 @@ test('merge initial and inline state', async (t) => {
     jobs: [
       {
         expression: 'export default [s => s]',
-        data: { y: 11 },
+        state: { data: { y: 11 } },
       },
     ],
   };
@@ -218,7 +218,7 @@ test('Initial state overrides inline data', async (t) => {
     jobs: [
       {
         expression: 'export default [s => s]',
-        data: { x: 11 },
+        state: { data: { x: 11 } },
       },
     ],
   };
@@ -233,7 +233,7 @@ test('Previous state overrides inline data', async (t) => {
       {
         id: 'job1',
         expression: 'export default [s => s]',
-        data: { x: 5 },
+        state: { data: { x: 5 } },
         next: {
           job2: true,
         },
@@ -243,7 +243,7 @@ test('Previous state overrides inline data', async (t) => {
       {
         id: 'job2',
         expression: 'export default [s => { s.data.x +=1 ; return s; }]',
-        data: { x: 88 },
+        state: { data: { x: 88 } },
       },
     ],
   };
@@ -286,7 +286,7 @@ test('Jobs only receive state from upstream jobs', async (t) => {
       {
         id: 'start',
         expression: 'export default [s => s]',
-        data: { x: 1, y: 1 },
+        state: { data: { x: 1, y: 1 } },
         next: {
           'x-a': true,
           'y-a': true,
@@ -378,7 +378,7 @@ test('execute edge based on state in the condition', async (t) => {
     jobs: [
       {
         id: 'job1',
-        data: {},
+        state: {},
         expression: 'export default [(s) => { s.data.x = 10; return s;}]',
         next: {
           job2: { condition: 'state.data.x === 10' },
@@ -399,7 +399,7 @@ test('skip edge based on state in the condition ', async (t) => {
     jobs: [
       {
         id: 'job1',
-        data: {},
+        state: {},
         expression: 'export default [s => { s.data.x = 10; return s;}]',
         next: {
           job2: { condition: 'false' },

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -256,7 +256,7 @@ test('only allowed state is passed through in strict mode', async (t) => {
     jobs: [
       {
         expression:
-          'export default [s => ({ data: {}, references: [], x: 22, y: 33 })]',
+          'export default [s => ({ state: {}, references: [], x: 22, y: 33 })]',
         next: {
           job2: true,
         },
@@ -272,7 +272,7 @@ test('only allowed state is passed through in strict mode', async (t) => {
   };
   const result = await executePlan(plan, {}, { strict: true });
   t.deepEqual(result, {
-    data: {},
+    state: {},
     references: [],
   });
 });
@@ -350,7 +350,7 @@ test('all state is passed through in non-strict mode', async (t) => {
     jobs: [
       {
         expression:
-          'export default [s => ({ data: {}, references: [], x: 22, y: 33 })]',
+          'export default [s => ({ state: {}, references: [], x: 22, y: 33 })]',
         next: {
           job2: true,
         },
@@ -366,7 +366,7 @@ test('all state is passed through in non-strict mode', async (t) => {
   };
   const result = await executePlan(plan, {}, { strict: false });
   t.deepEqual(result, {
-    data: {},
+    state: {},
     references: [],
     x: 22,
     y: 33,
@@ -563,7 +563,7 @@ test('return an error in state', async (t) => {
     jobs: [
       {
         id: 'a',
-        data: {},
+        state: {},
         expression: 'export default [s => { throw Error("e")}]',
       },
     ],
@@ -578,7 +578,7 @@ test('keep executing after an error', async (t) => {
     jobs: [
       {
         id: 'a',
-        data: {},
+        state: {},
         expression: 'export default [s => { throw Error("e"); state.x = 20 }]',
         next: {
           b: true,
@@ -600,7 +600,7 @@ test('simple on-error handler', async (t) => {
     jobs: [
       {
         id: 'job1',
-        data: {},
+        state: {},
         expression: 'export default [s => { throw Error("e")}]',
         next: {
           job2: { condition: 'state.errors' },
@@ -627,7 +627,7 @@ test('log appopriately on error', async (t) => {
     jobs: [
       {
         id: 'job1',
-        data: {},
+        state: {},
         expression: 'export default [s => { throw Error("e")}]',
       },
     ],
@@ -908,8 +908,8 @@ test('Plans log for each job start and end', async (t) => {
   await executePlan(plan, {}, {}, logger);
 
   const start = logger._find('always', /starting job/i);
-  t.is(start.message, 'Starting job a');
+  t.is(start!.message, 'Starting job a');
 
   const end = logger._find('success', /completed job/i);
-  t.regex(end.message, /Completed job a in \d+ms/);
+  t.regex(end!.message as string, /Completed job a in \d+ms/);
 });

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -256,7 +256,7 @@ test('only allowed state is passed through in strict mode', async (t) => {
     jobs: [
       {
         expression:
-          'export default [s => ({ state: {}, references: [], x: 22, y: 33 })]',
+          'export default [s => ({ data: {}, references: [], x: 22, y: 33 })]',
         next: {
           job2: true,
         },
@@ -272,7 +272,7 @@ test('only allowed state is passed through in strict mode', async (t) => {
   };
   const result = await executePlan(plan, {}, { strict: true });
   t.deepEqual(result, {
-    state: {},
+    data: {},
     references: [],
   });
 });
@@ -350,7 +350,7 @@ test('all state is passed through in non-strict mode', async (t) => {
     jobs: [
       {
         expression:
-          'export default [s => ({ state: {}, references: [], x: 22, y: 33 })]',
+          'export default [s => ({ data: {}, references: [], x: 22, y: 33 })]',
         next: {
           job2: true,
         },
@@ -366,7 +366,7 @@ test('all state is passed through in non-strict mode', async (t) => {
   };
   const result = await executePlan(plan, {}, { strict: false });
   t.deepEqual(result, {
-    state: {},
+    data: {},
     references: [],
     x: 22,
     y: 33,

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -433,6 +433,24 @@ test('execute a two-job execution plan', async (t) => {
   t.is(result.data.x, 2);
 });
 
+test('only execute one job in a two-job execution plan', async (t) => {
+  const plan: ExecutionPlan = {
+    jobs: [
+      {
+        id: 'job1',
+        expression: 'export default [s => { s.data.x += 1; return s; } ]',
+        next: { job2: false },
+      },
+      {
+        id: 'job2',
+        expression: 'export default [s => { s.data.x += 1; return s; } ]',
+      },
+    ],
+  };
+  const result = await executePlan(plan, { data: { x: 0 } });
+  t.is(result.data.x, 1);
+});
+
 test('execute a two-job execution plan with custom start in state', async (t) => {
   const plan: ExecutionPlan = {
     start: 'job2',

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -150,9 +150,11 @@ test('prefer initial state to inline state', async (t) => {
   const plan: ExecutionPlan = {
     jobs: [
       {
-        data: {
-          x: 20, // this will be overriden by the incoming state
-          y: 20, // This will be untouched
+        state: {
+          data: {
+            x: 20, // this will be overriden by the incoming state
+            y: 20, // This will be untouched
+          },
         },
         expression: 'export default [(s) => s]',
       },

--- a/packages/runtime/test/util/assemble-state.test.ts
+++ b/packages/runtime/test/util/assemble-state.test.ts
@@ -6,9 +6,9 @@ import assembleState from '../../src/util/assemble-state';
 
 test('with no arguments, returns a basic state object', (t) => {
   const initial = undefined;
-  const data = undefined;
+  const defaultState = undefined;
   const config = undefined;
-  const result = assembleState(initial, config, data);
+  const result = assembleState(initial, config, defaultState);
   t.deepEqual(result, {
     configuration: {},
     data: {},
@@ -17,9 +17,9 @@ test('with no arguments, returns a basic state object', (t) => {
 
 test('strict: ignores initial state', (t) => {
   const initial = { x: 22 };
-  const data = undefined;
+  const defaultState = undefined;
   const config = undefined;
-  const result = assembleState(initial, config, data, true);
+  const result = assembleState(initial, config, defaultState, true);
   t.deepEqual(result, {
     configuration: {},
     data: {},
@@ -28,9 +28,9 @@ test('strict: ignores initial state', (t) => {
 
 test('strict: ignores initial state except references', (t) => {
   const initial = { references: [] };
-  const data = undefined;
+  const defaultState = undefined;
   const config = undefined;
-  const result = assembleState(initial, config, data, true);
+  const result = assembleState(initial, config, defaultState, true);
   t.deepEqual(result, {
     references: [],
     configuration: {},
@@ -40,9 +40,9 @@ test('strict: ignores initial state except references', (t) => {
 
 test('non-strict: includes initial state', (t) => {
   const initial = { x: 22 };
-  const data = undefined;
+  const defaultState = undefined;
   const config = undefined;
-  const result = assembleState(initial, config, data, false);
+  const result = assembleState(initial, config, defaultState, false);
   t.deepEqual(result, {
     x: 22,
     configuration: {},
@@ -52,10 +52,10 @@ test('non-strict: includes initial state', (t) => {
 
 test('merges default and initial data objects', (t) => {
   const initial = { data: { x: 1 } };
-  const data = { y: 1 };
+  const defaultState = { data: { y: 1 } };
   const config = undefined;
 
-  const strict = assembleState(initial, config, data, true);
+  const strict = assembleState(initial, config, defaultState, true);
   t.deepEqual(strict, {
     configuration: {},
     data: {
@@ -65,16 +65,16 @@ test('merges default and initial data objects', (t) => {
   });
 
   // Ensure the same behaviour in non-strict mode
-  const nonStrict = assembleState(initial, config, data, false);
+  const nonStrict = assembleState(initial, config, defaultState, false);
   t.deepEqual(strict, nonStrict);
 });
 
 test('Initial data is prioritised over default data', (t) => {
   const initial = { data: { x: 1 } };
-  const data = { x: 2 };
+  const defaultState = { data: { x: 2 } };
   const config = undefined;
 
-  const strict = assembleState(initial, config, data, true);
+  const strict = assembleState(initial, config, defaultState, true);
   t.deepEqual(strict, {
     configuration: {},
     data: {
@@ -82,16 +82,16 @@ test('Initial data is prioritised over default data', (t) => {
     },
   });
 
-  const nonStrict = assembleState(initial, config, data, false);
+  const nonStrict = assembleState(initial, config, defaultState, false);
   t.deepEqual(strict, nonStrict);
 });
 
 test('merges default and initial config objects', (t) => {
   const initial = { configuration: { x: 1 } };
-  const data = undefined;
+  const defaultState = undefined;
   const config = { y: 1 };
 
-  const strict = assembleState(initial, config, data, true);
+  const strict = assembleState(initial, config, defaultState, true);
   t.deepEqual(strict, {
     configuration: {
       x: 1,
@@ -101,16 +101,16 @@ test('merges default and initial config objects', (t) => {
   });
 
   // Ensure the same behaviour in non-strict mode
-  const nonStrict = assembleState(initial, config, data, false);
+  const nonStrict = assembleState(initial, config, defaultState, false);
   t.deepEqual(strict, nonStrict);
 });
 
 test('configuration overrides initialState.configuration', (t) => {
   const initial = { configuration: { x: 1 } };
-  const data = undefined;
+  const defaultState = undefined;
   const config = { x: 2 };
 
-  const strict = assembleState(initial, config, data, true);
+  const strict = assembleState(initial, config, defaultState, true);
   t.deepEqual(strict, {
     configuration: {
       x: 2,
@@ -119,6 +119,6 @@ test('configuration overrides initialState.configuration', (t) => {
   });
 
   // Ensure the same behaviour in non-strict mode
-  const nonStrict = assembleState(initial, config, data, false);
+  const nonStrict = assembleState(initial, config, defaultState, false);
   t.deepEqual(strict, nonStrict);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,14 +59,6 @@ importers:
       tslib: 2.4.0
       typescript: 4.8.3
 
-  integration-tests/cli/repo:
-    specifiers:
-      '@openfn/language-common_1.7.7': npm:@openfn/language-common@^1.7.7
-      is-array_1.0.1: npm:is-array@^1.0.1
-    dependencies:
-      '@openfn/language-common_1.7.7': /@openfn/language-common/1.7.7
-      is-array_1.0.1: /is-array/1.0.1
-
   packages/cli:
     specifiers:
       '@openfn/compiler': workspace:*
@@ -618,17 +610,6 @@ packages:
       - debug
     dev: true
 
-  /@openfn/language-common/1.7.7:
-    resolution: {integrity: sha512-GSoAbo6oL0b8jHufhLKvIzHJ271aE2AKv/ibeuiWU3CqN1gRmaHArlA/omlCs/rsfcieSp2VWAvWeGuFY8buZw==}
-    dependencies:
-      axios: 1.1.3
-      date-fns: 2.29.3
-      jsonpath-plus: 4.0.0
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /@openfn/language-common/2.0.0-rc3:
     resolution: {integrity: sha512-7kwhBnCd1idyTB3MD9dXmUqROAhoaUIkz2AGDKuv9vn/cbZh7egEv9/PzKkRcDJYFV9qyyS+cVT3Xbgsg2ii5g==}
     bundledDependencies: []
@@ -1072,6 +1053,7 @@ packages:
 
   /asynckit/0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: true
 
   /atob/2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
@@ -1145,6 +1127,7 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+    dev: true
 
   /b4a/1.6.1:
     resolution: {integrity: sha512-AsKjNhz72yxteo/0EtQEiwkMUgk/tGmycXlbG4g3Ard2/ULtNLUykGOkeK0egmN27h0xMAhb76jYccW+XTBExA==}
@@ -1540,6 +1523,7 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
+    dev: true
 
   /commander/4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1810,6 +1794,7 @@ packages:
   /delayed-stream/1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+    dev: true
 
   /delegates/1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -2849,6 +2834,7 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: true
 
   /for-in/1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
@@ -2862,6 +2848,7 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+    dev: true
 
   /fragment-cache/0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
@@ -3264,10 +3251,6 @@ packages:
       kind-of: 6.0.3
     dev: true
 
-  /is-array/1.0.1:
-    resolution: {integrity: sha512-gxiZ+y/u67AzpeFmAmo4CbtME/bs7J2C++su5zQzvQyaxUqVzkh69DI+jN+KZuSO6JaH6TIIU6M6LhqxMjxEpw==}
-    dev: false
-
   /is-arrayish/0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
     dev: true
@@ -3584,6 +3567,7 @@ packages:
   /jsonpath-plus/4.0.0:
     resolution: {integrity: sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==}
     engines: {node: '>=10.0'}
+    dev: true
 
   /keygrip/1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
@@ -4533,6 +4517,7 @@ packages:
 
   /proxy-from-env/1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: true
 
   /proxy-middleware/0.15.0:
     resolution: {integrity: sha512-EGCG8SeoIRVMhsqHQUdDigB2i7qU7fCsWASwn54+nPutYO8n4q6EiwMzyfWlC+dzRFExP+kvcnDFdBDHoZBU7Q==}


### PR DESCRIPTION
This PR introduces a couple of subtle changes to workflows:

* [x] Allow an edge to be false, ie `{ job2: false }` #261 
* [x] Refactor `job.data` to `job.state` 258

Versions have been bumped so please release directly from this branch after QA.

There are also some typing changes to support the work.

Basically this:
```
{
  jobs: [{
     id: 'job1'
     data: { count: 22 },
     next: { job2: false }
  }, {
     id: 'job2'
  }]
}
```
Should now be this (and will work):
```
{
  jobs: [{
     id: 'job1'
     state: { data: { count: 22 } },
     next: { job2: false }
  }, {
     id: 'job2'
  }]
}
```