### PR TITLE
Pretty logging

### DIFF
--- a/.changeset/few-trainers-hang.md
+++ b/.changeset/few-trainers-hang.md
@@ -1,0 +1,5 @@
+---
+'@openfn/logger': patch
+---
+
+Pretty print output

--- a/packages/logger/src/sanitize.ts
+++ b/packages/logger/src/sanitize.ts
@@ -12,7 +12,7 @@ type SanitizeOptions = {
 const sanitize = (item: any, options: SanitizeOptions = {}) => {
   // Stringify output to ensure we show deep nesting
   const maybeStringify = (o: any) =>
-    options.stringify === false ? o : stringify(o);
+    options.stringify === false ? o : stringify(o, null, 2);
 
   if (item instanceof Error) {
     return item;

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -73,7 +73,12 @@ test('should log objects as strings', (t) => {
   logger.success(obj);
 
   const { message } = logger._parse(logger._last);
-  t.is(message, '{"a":22}');
+  t.is(
+    message,
+    `{
+  "a": 22
+}`
+  );
 
   const messageObj = JSON.parse(message as string);
   t.deepEqual(messageObj.a, 22);
@@ -346,7 +351,14 @@ test('log a circular object', async (t) => {
   logger.success(a);
 
   const { message } = logger._parse(logger._last);
-  t.is(message, '{"z":{"a":"[Circular]"}}');
+  t.is(
+    message,
+    `{
+  "z": {
+    "a": "[Circular]"
+  }
+}`
+  );
 });
 
 test('log a circular object as JSON', async (t) => {
@@ -375,7 +387,12 @@ test('ignore functions on logged objects', async (t) => {
   logger.success(obj);
 
   const { message } = logger._parse(logger._last);
-  t.is(message, '{"a":1}');
+  t.is(
+    message,
+    `{
+  "a": 1
+}`
+  );
 });
 
 test('log an error object', (t) => {


### PR DESCRIPTION
A simple PR to ensure the logger pretty-prints any objects it logs.

This does not affect json logging, so lightning's logs should be unaffected (lightning's logs should be prettified downstream by the log viewer)

We could add an option for this but I'm not sure I see the point right now.