### PR TITLE
Fail on type errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,11 @@ jobs:
           paths:
             - node_modules
       - run:
-          name: Type check
-          command: pnpm test:types
-      - run:
           name: Build packages
           command: pnpm build
+      - run:
+          name: Type check
+          command: pnpm test:types
       - run:
           name: Run Tests
           command: pnpm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ jobs:
           paths:
             - node_modules
       - run:
+          name: Type check
+          command: pnpm test:types
+      - run:
           name: Build packages
           command: pnpm build
       - run:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "pnpm ava",
     "test:watch": "pnpm ava -w",
-    "test:types": "pnpm tsc --noEmit --project tsconfig.json",
+    "test:types": "pnpm tsc --project tsconfig.test.json",
     "build": "tsup --config ./tsup.config.js",
     "build:watch": "pnpm build --watch",
     "openfn": "node --no-warnings dist/index.js",
@@ -47,6 +47,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "@inquirer/prompts": "^1.1.4",
     "@openfn/compiler": "workspace:*",
     "@openfn/deploy": "workspace:*",
     "@openfn/describe-package": "workspace:*",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,34 +15,39 @@ import testCommand from './test/command';
 const y = yargs(hideBin(process.argv));
 
 export const cmd = y
+  // TODO Typescipt hacks because signatures don't seem to align
   .command(executeCommand as any)
-  .command(compileCommand as any)
+  .command(compileCommand)
   .command(deployCommand as any)
   .command(installCommand) // allow install to run from the top as well as repo
   .command(repoCommand)
   .command(testCommand)
   .command(docsCommand)
   .command(metadataCommand)
-  .command(docgenCommand)
-  .command(pullCommand)
+  .command(docgenCommand as any)
+  .command(pullCommand as any)
   // Common options
   .option('log', {
     alias: ['l'],
     description: 'Set the default log level to none, default, info or debug',
     array: true,
   })
-  .option('log-json', {
-    description: 'Output all logs as JSON objects',
-    boolean: true,
-  })
-  .example('openfn execute help', 'Show documentation for the execute command')
-  .example(
-    'openfn docs @openfn/language-common each',
-    'Get more help on the common.each command'
-  )
+  // TODO there's a bit of confusion right now about where log json lives
+  // Let's finish removing ensure-opts and sort this out there
+  // .option('log-json', {
+  //   description: 'Output all logs as JSON objects',
+  //   boolean: true,
+  // })
+  // .example('openfn execute help', 'Show documentation for the execute command')
+  // .example(
+  //   'openfn docs @openfn/language-common each',
+  //   'Get more help on the common.each command'
+  // )
   .command({
     command: 'version',
-    handler: (argv: Arguments<Opts>) => {
+    describe:
+      'Show the currently installed version of the CLI, compiler and runtime.',
+    handler: (argv: Arguments<Partial<Opts>>) => {
       argv.command = 'version';
     },
   })

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -65,7 +65,7 @@ const maybeEnsureOpts = (basePath: string, options: Opts) =>
 
 // Top level command parser
 const parse = async (basePath: string, options: Opts, log?: Logger) => {
-  const opts = maybeEnsureOpts(basePath, options);
+  const opts = maybeEnsureOpts(basePath, options) as SafeOpts;
   const logger = log || createLogger(CLI, opts);
 
   // In execute and test, always print version info FIRST

--- a/packages/cli/src/compile/command.ts
+++ b/packages/cli/src/compile/command.ts
@@ -38,7 +38,6 @@ const options = [
 ];
 
 const compileCommand: yargs.CommandModule<CompileOptions> = {
-  wibble: 'yum yum',
   command: 'compile [path]',
   describe:
     'Compile an openfn job or workflow and print or save the resulting JavaScript.',

--- a/packages/cli/src/compile/command.ts
+++ b/packages/cli/src/compile/command.ts
@@ -38,6 +38,7 @@ const options = [
 ];
 
 const compileCommand: yargs.CommandModule<CompileOptions> = {
+  wibble: 'yum yum',
   command: 'compile [path]',
   describe:
     'Compile an openfn job or workflow and print or save the resulting JavaScript.',

--- a/packages/cli/src/compile/command.ts
+++ b/packages/cli/src/compile/command.ts
@@ -37,9 +37,10 @@ const options = [
   o.useAdaptorsMonorepo,
 ];
 
-const compileCommand = {
+const compileCommand: yargs.CommandModule<CompileOptions> = {
   command: 'compile [path]',
-  desc: 'Compile an openfn job or workflow and print or save the resulting JavaScript.',
+  describe:
+    'Compile an openfn job or workflow and print or save the resulting JavaScript.',
   handler: ensure('compile', options),
   builder: (yargs) =>
     build(options, yargs)
@@ -56,6 +57,6 @@ const compileCommand = {
         'compile foo/workflow.json -o foo/workflow-compiled.json',
         'Compiles the workflow at foo/work.json and prints the result to -o foo/workflow-compiled.json'
       ),
-} as yargs.CommandModule<CompileOptions>;
+};
 
 export default compileCommand;

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -10,7 +10,8 @@ export default async (opts: CompileOptions, log: Logger) => {
   log.debug('Compiling...');
   let job;
   if (opts.workflow) {
-    job = compileWorkflow(opts.workflow, opts, log);
+    // Note that the workflow will be loaded into an object by this point
+    job = compileWorkflow(opts.workflow as ExecutionPlan, opts, log);
   } else {
     job = await compileJob((opts.job || opts.jobPath) as string, opts, log);
   }

--- a/packages/cli/src/deploy/command.ts
+++ b/packages/cli/src/deploy/command.ts
@@ -13,19 +13,22 @@ export type DeployOptions = Required<
     | 'projectPath'
     | 'configPath'
     | 'confirm'
-    | 'describe'
   >
 >;
 
-const options = [o.statePath, o.projectPath, o.configPath, o.confirm, o.describe];
+const options = [
+  o.statePath,
+  o.projectPath,
+  o.configPath,
+  o.confirm,
+  o.describe,
+];
 
-const deployCommand = {
+const deployCommand: yargs.CommandModule<DeployOptions> = {
   command: 'deploy',
-  desc: "Deploy a project's config to a remote Lightning instance",
-  builder: (yargs: yargs.Argv<DeployOptions>) => {
-    return build(options, yargs).example('deploy', '');
-  },
+  describe: "Deploy a project's config to a remote Lightning instance",
   handler: ensure('deploy', options),
+  builder: (yargs) => build(options, yargs),
 };
 
 export default deployCommand;

--- a/packages/cli/src/deploy/handler.ts
+++ b/packages/cli/src/deploy/handler.ts
@@ -3,7 +3,6 @@ import {
   DeployError,
   deploy,
   getConfig,
-  getYaml,
   validateConfig,
 } from '@openfn/deploy';
 import type { Logger } from '../util/logger';
@@ -27,7 +26,6 @@ async function deployHandler(
 ) {
   try {
     const config = mergeOverrides(await getConfig(options.configPath), options);
-   
 
     logger.debug('Deploying with config', JSON.stringify(config, null, 2));
 
@@ -36,7 +34,7 @@ async function deployHandler(
     }
 
     if (process.env['OPENFN_API_KEY']) {
-      logger.info('Using OPENFN_API_KEY environment variable'); 
+      logger.info('Using OPENFN_API_KEY environment variable');
       config.apiKey = process.env['OPENFN_API_KEY'];
     }
 

--- a/packages/cli/src/docgen/command.ts
+++ b/packages/cli/src/docgen/command.ts
@@ -1,16 +1,17 @@
-import yargs, { Arguments } from 'yargs';
+import yargs, { ArgumentsCamelCase } from 'yargs';
 import { Opts } from '../options';
 
-const docgenCommand = {
+type DocGenOptions = Partial<Opts>; // TODO
+
+const docgenCommand: yargs.CommandModule<Opts> = {
   command: 'docgen <specifier>',
   // Hide this command as it's not really for public usage
-  desc: false, // 'Generate documentation into the repo. Specifier must include a version number.'
-  handler: (argv: Arguments<Opts>) => {
+  describe: false, // 'Generate documentation into the repo. Specifier must include a version number.'
+  handler: (argv: ArgumentsCamelCase<DocGenOptions>) => {
     argv.command = 'docgen';
   },
-  builder: (yargs: yargs.Argv) => {
-    return yargs.example('docgen @openfn/language-common@1.7.5', '');
-  },
-} as yargs.CommandModule<Opts>;
+  builder: (yargs: yargs.Argv) =>
+    yargs.example('docgen @openfn/language-common@1.7.5', ''),
+};
 
 export default docgenCommand;

--- a/packages/cli/src/docgen/handler.ts
+++ b/packages/cli/src/docgen/handler.ts
@@ -129,7 +129,7 @@ const docgenHandler = (
     // Return or wait for the existing docs
     // If there's a timeout error, don't remove the placeholder
     return waitForDocs(json, path, logger, retryDuration);
-  } catch (e) {
+  } catch (e: any) {
     // Generate docs from scratch
     if (e.message !== 'TIMEOUT') {
       logger.info(`Docs JSON not found at ${path}`);

--- a/packages/cli/src/docs/command.ts
+++ b/packages/cli/src/docs/command.ts
@@ -1,12 +1,15 @@
-import yargs, { Arguments } from 'yargs';
+import yargs, { ArgumentsCamelCase } from 'yargs';
 import { Opts } from '../options';
+
+type DocsOptions = Partial<Opts>; // TODO
 
 export default {
   command: 'docs <adaptor> [operation]',
-  desc: 'Print help for an adaptor function. You can use short-hand for adaptor names (ie, common instead of @openfn/language-common)',
-  handler: (argv: Arguments<Opts>) => {
+  describe:
+    'Print help for an adaptor function. You can use short-hand for adaptor names (ie, common instead of @openfn/language-common)',
+  handler: (argv: ArgumentsCamelCase<DocsOptions>) => {
     argv.command = 'docs';
   },
   builder: (yargs: yargs.Argv) =>
     yargs.example('docs common fn', 'Print help for the common fn operation'),
-} as unknown as yargs.CommandModule<Opts>;
+} as yargs.CommandModule<DocsOptions>;

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -57,9 +57,9 @@ const options = [
   o.useAdaptorsMonorepo,
 ];
 
-const executeCommand = {
+const executeCommand: yargs.CommandModule<ExecuteOptions> = {
   command: 'execute [path]',
-  desc: `Run an openfn job or workflow. Get more help by running openfn <command> help.
+  describe: `Run an openfn job or workflow. Get more help by running openfn <command> help.
   \nExecute will run a job/workflow at the path and write the output state to disk (to ./state.json unless otherwise specified)
   \nBy default only state.data will be returned fron a job. Include --no-strict to write the entire state object.
   \nRemember to include the adaptor name with -a. Auto install adaptors with the -i flag.`,
@@ -88,6 +88,6 @@ const executeCommand = {
         'openfn compile job.js -a http',
         'Compile job.js with the http adaptor and print the code to stdout'
       ),
-} as yargs.CommandModule<ExecuteOptions>;
+};
 
 export default executeCommand;

--- a/packages/cli/src/metadata/command.ts
+++ b/packages/cli/src/metadata/command.ts
@@ -29,11 +29,11 @@ const options = [
 
 export default {
   command: 'metadata',
-  desc: 'Generate metadata for an adaptor config',
+  describe: 'Generate metadata for an adaptor config',
   handler: ensure('metadata', options),
   builder: (yargs) =>
     build(options, yargs).example(
       'metadata -a salesforce -s tmp/state.json',
       'Generate salesforce metadata from config in state.json'
     ),
-} as yargs.CommandModule<{}>;
+} as yargs.CommandModule<MetadataOpts>;

--- a/packages/cli/src/metadata/handler.ts
+++ b/packages/cli/src/metadata/handler.ts
@@ -2,7 +2,7 @@ import { Logger } from '../util/logger';
 import { SafeOpts } from '../commands';
 import loadState from '../util/load-state';
 import cache from './cache';
-import { getModuleEntryPoint, getNameAndVersion } from '@openfn/runtime';
+import { getModuleEntryPoint } from '@openfn/runtime';
 
 // Add extra, uh, metadata to the, uh, metadata object
 const decorateMetadata = (metadata: any) => {

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -56,12 +56,17 @@ export type CLIOption = {
   name: string;
   // Allow this to take a function to lazy-evaluate env vars
   yargs: yargs.Options | (() => yargs.Options);
-  ensure?: (opts: Opts) => void;
+  ensure?: (opts: Partial<Opts>) => void;
 };
 
-const setDefaultValue = (opts: Opts, key: keyof Opts, value: any) => {
-  const v: any = opts[key];
-  if (isNaN(v) && !v) {
+const setDefaultValue = (
+  opts: Partial<Opts>,
+  key: keyof Opts,
+  value: unknown
+) => {
+  const v = opts[key];
+  if (isNaN(v as number) && !v) {
+    // @ts-ignore
     opts[key] = value;
   }
 };
@@ -134,20 +139,19 @@ export const configPath: CLIOption = {
     alias: ['c', 'config-path'],
     description: 'The location of your config file',
     default: './.config.json',
-  }
-};
-
-export const describe: CLIOption = {
-    name: 'describe',
-    yargs : {
-        boolean: true,
-        description: "Downloads the project yaml from the specified instance"
-    },
-    ensure: (opts) => {
-    setDefaultValue(opts, 'describe', true);
   },
 };
 
+export const describe: CLIOption = {
+  name: 'describe',
+  yargs: {
+    boolean: true,
+    description: 'Downloads the project yaml from the specified instance',
+  },
+  ensure: (opts) => {
+    setDefaultValue(opts, 'describe', true);
+  },
+};
 
 export const expandAdaptors: CLIOption = {
   name: 'no-expand-adaptors',
@@ -194,7 +198,7 @@ export const ignoreImports: CLIOption = {
   },
 };
 
-const getBaseDir = (opts: Opts) => {
+const getBaseDir = (opts: { path?: string }) => {
   const basePath = opts.path ?? '.';
   if (/\.(jso?n?)$/.test(basePath)) {
     return path.dirname(basePath);
@@ -274,7 +278,7 @@ export const projectPath: CLIOption = {
     string: true,
     alias: ['p'],
     description: 'The location of your project.yaml file',
-  }
+  },
 };
 
 export const repoDir: CLIOption = {

--- a/packages/cli/src/pull/command.ts
+++ b/packages/cli/src/pull/command.ts
@@ -6,22 +6,21 @@ import * as o from '../options';
 export type DeployOptions = Required<
   Pick<
     Opts,
-    | 'command'
-    | 'log'
-    | 'logJson'
-    | 'statePath'
-    | 'projectPath'
-    | 'configPath'
+    'command' | 'log' | 'logJson' | 'statePath' | 'projectPath' | 'configPath'
   >
 >;
 
 const options = [o.statePath, o.projectPath, o.configPath];
 
-const pullCommand = {
+const pullCommand: yargs.CommandModule<DeployOptions> = {
   command: 'pull',
-  desc:  "Pull aproject's state and spec from a Lightning Instance to the local directory",
+  describe:
+    "Pull a project's state and spec from a Lightning Instance to the local directory",
   builder: (yargs: yargs.Argv<DeployOptions>) => {
-    return build(options, yargs).example('pull', 'Pull an updated copy of a project spec and state from a Lightning Instance');
+    return build(options, yargs).example(
+      'pull',
+      'Pull an updated copy of a project spec and state from a Lightning Instance'
+    );
   },
   handler: ensure('pull', options),
 };

--- a/packages/cli/src/pull/handler.ts
+++ b/packages/cli/src/pull/handler.ts
@@ -1,32 +1,27 @@
 import path from 'path';
 import fs from 'node:fs/promises';
-import {
-  DeployConfig,
-  getProject,
-  getConfig,
-  getState ,
-} from '@openfn/deploy';
+import { DeployConfig, getProject, getConfig, getState } from '@openfn/deploy';
 import type { Logger } from '../util/logger';
 import { DeployOptions } from '../deploy/command';
 
-
-
-async function pullHandler(
-  options: DeployOptions,
-  logger: Logger,
-) {
+async function pullHandler(options: DeployOptions, logger: Logger) {
   try {
     const config = mergeOverrides(await getConfig(options.configPath), options);
-    logger.always("Downloading project yaml and  state from instance");
+    logger.always('Downloading project yaml and  state from instance');
+
     const state = await getState(config.statePath);
     const { data: new_state } = await getProject(config, state.id);
     const url = new URL(`/download/yaml?id=${state.id}`, config.endpoint);
     const res = await fetch(url);
+
+    // @ts-ignore
     await fs.writeFile(path.resolve(config.specPath), res.body);
+    // @ts-ignore
     await fs.writeFile(path.resolve(config.statePath), new_state);
-    logger.success("Project pulled successfully");
+
+    logger.success('Project pulled successfully');
     process.exitCode = 0;
-    return true; 
+    return true;
   } catch (error: any) {
     throw error;
   }

--- a/packages/cli/src/repo/command.ts
+++ b/packages/cli/src/repo/command.ts
@@ -4,7 +4,7 @@ import { build, ensure, override } from '../util/command-builders';
 
 export const repo = {
   command: 'repo [subcommand]',
-  desc: 'Run commands on the module repo (install|clean)',
+  describe: 'Run commands on the module repo (install|clean)',
   builder: (yargs: yargs.Argv) =>
     yargs
       .command(clean)
@@ -12,7 +12,7 @@ export const repo = {
       .command(list)
       .example('repo install -a http', 'Install @openfn/language-http')
       .example('repo clean', 'Remove everything from the repo working dir'),
-} as unknown as yargs.CommandModule<{}>;
+} as yargs.CommandModule<{}>;
 
 const installOptions = [
   o.repoDir,
@@ -28,7 +28,8 @@ const installOptions = [
 
 export const install = {
   command: 'install [packages...]',
-  desc: 'install one or more packages to the runtime repo. Use -a to pass shorthand adaptor names.',
+  describe:
+    'install one or more packages to the runtime repo. Use -a to pass shorthand adaptor names.',
   handler: ensure('repo-install', installOptions),
   builder: (yargs) =>
     build(installOptions, yargs)
@@ -45,7 +46,7 @@ export const install = {
 
 export const clean = {
   command: 'clean',
-  desc: 'Removes all modules from the runtime module repo',
+  describe: 'Removes all modules from the runtime module repo',
   handler: ensure('repo-clean', [o.repoDir]),
   builder: (yargs) =>
     build(
@@ -66,7 +67,7 @@ export const clean = {
 
 export const list = {
   command: 'list',
-  desc: 'Show a report on what is installed in the repo',
+  describe: 'Show a report on what is installed in the repo',
   aliases: ['$0'],
   handler: ensure('repo-list', [o.repoDir]),
   builder: (yargs) => build([o.repoDir], yargs),

--- a/packages/cli/src/repo/handler.ts
+++ b/packages/cli/src/repo/handler.ts
@@ -79,5 +79,7 @@ export const list = async (options: Opts, logger: Logger) => {
   });
 
   // Print with treeify (not very good really)
-  logger.success('Installed packages:\n\n' + treeify.asTree(output));
+  logger.success(
+    'Installed packages:\n\n' + treeify.asTree(output, false, false)
+  );
 };

--- a/packages/cli/src/test/handler.ts
+++ b/packages/cli/src/test/handler.ts
@@ -55,7 +55,7 @@ const testHandler = async (options: ExecuteOptions, logger: Logger) => {
 
   const state = await loadState(options, silentLogger);
   const code = await compile(options, logger);
-  const result = await execute(code, state, options, silentLogger);
+  const result = await execute(code!, state, options, silentLogger);
   logger.success(`Result: ${result.data.answer}`);
   return result;
 };

--- a/packages/cli/src/util/command-builders.ts
+++ b/packages/cli/src/util/command-builders.ts
@@ -1,4 +1,4 @@
-import yargs from 'yargs';
+import yargs, { ArgumentsCamelCase } from 'yargs';
 import { CommandList } from '../commands';
 import type { Opts, CLIOption } from '../options';
 
@@ -10,7 +10,7 @@ const expandYargs = (y: {} | (() => any)) => {
 };
 
 // build helper to chain options
-export function build<T>(opts: CLIOption[], yargs: yargs.Argv<T>) {
+export function build(opts: CLIOption[], yargs: yargs.Argv<any>) {
   return opts.reduce(
     (_y, o) => yargs.option(o.name, expandYargs(o.yargs)),
     yargs
@@ -19,7 +19,8 @@ export function build<T>(opts: CLIOption[], yargs: yargs.Argv<T>) {
 
 // Mutate the incoming argv with defaults etc
 export const ensure =
-  (command: CommandList, opts: CLIOption[]) => (yargs: Opts) => {
+  (command: CommandList, opts: CLIOption[]) =>
+  (yargs: ArgumentsCamelCase<Partial<Opts>>) => {
     yargs.command = command;
     opts
       .filter((opt) => opt.ensure)

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.common",
   "include": ["src/**/*.ts", "test/**/*.ts"],
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "esnext",
     "paths": {
       "@openfn/*": ["../*"]
     }

--- a/packages/cli/tsconfig.test.json
+++ b/packages/cli/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.common",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "module": "esnext",
+    "noEmit": true
+  }
+}

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "test": "pnpm ava",
     "test:watch": "pnpm ava -w",
-    "test:types": "pnpm tsc --noEmit --project tsconfig.json",
+    "_test:types": "pnpm tsc --noEmit --project tsconfig.json --excludeDirectories test",
     "build": "tsup --config ../../tsup.config.js src/index.ts",
     "build:watch": "pnpm build --watch",
     "pack": "pnpm pack --pack-destination ../../dist"

--- a/packages/logger/src/sanitize.ts
+++ b/packages/logger/src/sanitize.ts
@@ -12,7 +12,7 @@ type SanitizeOptions = {
 const sanitize = (item: any, options: SanitizeOptions = {}) => {
   // Stringify output to ensure we show deep nesting
   const maybeStringify = (o: any) =>
-    options.stringify === false ? o : stringify(o, null, 2);
+    options.stringify === false ? o : stringify(o, undefined, 2);
 
   if (item instanceof Error) {
     return item;

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "test": "pnpm ava",
     "test:watch": "pnpm ava -w",
-    "test:types": "pnpm tsc --noEmit --project tsconfig.json",
+    "test:types": "pnpm tsc --project tsconfig.test.json",
     "build": "tsup --config ../../tsup.config.js src/index.ts",
     "build:watch": "pnpm build --watch",
     "pack": "pnpm pack --pack-destination ../../dist"

--- a/packages/runtime/src/modules/experimental-vm.ts
+++ b/packages/runtime/src/modules/experimental-vm.ts
@@ -3,19 +3,12 @@
  */
 import * as vm from 'node:vm';
 
-// Simple vm.Module type definition (just enough to keep ts happy)
-export interface Module {
-  link(handler: (specifier: string) => Promise<Module>): Promise<void>;
-  evaluate(): Promise<void>;
-  namespace: Record<string, any>;
-}
-
-export interface SyntheticModule extends Module {
+export interface SyntheticModule extends vm.Module {
   new (exports: string[], fn: () => void, context: vm.Context): SyntheticModule;
   setExport(name: string, value: any): void;
 }
 
-export interface SourceTextModule extends Module {
+export interface SourceTextModule extends vm.Module {
   new (source: string, options: any): SyntheticModule;
   setExport(name: string, value: any): void;
 }
@@ -26,4 +19,4 @@ export type ExperimentalVM = typeof vm & {
 };
 
 export default vm as ExperimentalVM;
-export type { Context } from 'node:vm';
+export type { Context, Module } from 'node:vm';

--- a/packages/runtime/src/util/log-error.ts
+++ b/packages/runtime/src/util/log-error.ts
@@ -1,11 +1,10 @@
 import { Logger } from '@openfn/logger';
-import type { Error } from '@types/node';
 import { ErrorReport, JobNodeID, State } from '../types';
 
 export type ErrorReporter = (
   state: State,
   jobId: JobNodeID,
-  error: Error
+  error: NodeJS.ErrnoException
 ) => ErrorReport;
 
 const createErrorReporter = (logger: Logger): ErrorReporter => {

--- a/packages/runtime/tsconfig.test.json
+++ b/packages/runtime/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.common",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@inquirer/prompts':
+        specifier: ^1.1.4
+        version: 1.1.4
       '@openfn/compiler':
         specifier: workspace:*
         version: link:../compiler


### PR DESCRIPTION
This PR:

1) Fixes (or ignores) all type issues (excluding deploy and all tests)
2) Adds a type checking step to CI

I am not aiming for perfect typings here, just trying to grow up a bit by failing builds on type fail.

There's some pretty flaky stuff in the yargs typings - there's something in the options that causes some commands to fail the type checker. I don't really get it. It may be to do with duplicating/overriding log options (which is due for refactor really soon anyway).

Closes #323 