### PR TITLE
Automate publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,3 +55,8 @@ workflows:
   build_and_test:
     jobs:
       - test
+          filters:
+            branches:
+              ignore:
+                main
+                main-tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,7 @@ workflows:
   build_and_test:
     jobs:
       - test:
-        filters:
-          branches:
-            ignore:
-              - main
-              - main-tmp
+        branches:
+          ignore:
+            - main
+            - main-tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,4 +59,3 @@ workflows:
           branches:
             ignore:
               - main
-              - main-tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,8 @@ workflows:
   build_and_test:
     jobs:
       - test:
-        branches:
-          ignore:
-            - main
-            - main-tmp
+        filters:
+          branches:
+            ignore:
+              - main
+              - main-tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,9 @@ jobs:
 workflows:
   build_and_test:
     jobs:
-      - test
-          filters:
-            branches:
-              ignore:
-                main
-                main-tmp
+      - test:
+        filters:
+          branches:
+            ignore:
+              - main
+              - main-tmp

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,9 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/packages' # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@types'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,29 @@
-## Any notes for the reviewer ?
+## Short Description
+
+A one or two-sentence description of what this PR does.
 
 ## Related issue
 
 Fixes #
 
+## Implementation Details
+
+A more detailed breakdown of the changes, including motivations (if not provided in the issue).
+
+## QA Notes
+
+List any considerations/cases/advice for testing/QA here.
+
 ## Checklist before requesting a review
 
 - [ ] I have performed a self-review of my code
-- [ ] If needed, I've updated the changelog
-- [ ] Amber has QA'd this feature
+- [ ] I have added unit tests
+- [ ] Changesets have been added (if there are production code changes)
+
+## Release branch checklist
+
+If this is a release branch:
+
+- [ ] Ensure versions have been bumped in package.json
+- [ ] Run `pnpm install` after bumping versions
+- [ ] Ensure tags have been pushed

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    # branches: main-tmp
+    # branches: main
     branches: main-tmp
 
 jobs:
@@ -21,6 +21,9 @@ jobs:
       - run: pnpm install
       - run: pnpm build
       - run: pnpm test
-      - run: pnpm publish -r --dry-run --report-summary --publish-branch main-tmp
+      - run: pnpm publish -r --report-summary --publish-branch main-tmp
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: pnpm generate_slack_report
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
           version: 8
       - run: pnpm install
       - run: pnpm build
-      - run: pnpm test:integration
+      - run: pnpm test
       - run: pnpm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,8 @@ jobs:
           version: 8
       - run: pnpm install
       - run: pnpm build
-      - run: pnpm test
+      # - run: pnpm test
+      - run: pnpm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
       - run: pnpm publish -r --report-summary --publish-branch main-tmp
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,6 +21,6 @@ jobs:
       - run: pnpm install
       - run: pnpm build
       - run: pnpm test
-      - run: pnpm publish -r
+      - run: pnpm publish -r --dry-run --report-summary --publish-branch main-tmp
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
       - run: pnpm test
       - run: pnpm publish -r --report-summary --publish-branch main-tmp
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: pnpm generate_slack_report
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
           version: 8
       - run: pnpm install
       - run: pnpm build
-      # - run: pnpm test
+      - run: pnpm test:integration
       - run: pnpm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,8 +19,8 @@ jobs:
         with:
           version: 8
       - run: pnpm install
-      - run: pnpm test
       - run: pnpm build
+      - run: pnpm test
       - run: pnpm publish -r
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,8 +2,7 @@ name: Publish
 
 on:
   push:
-    # branches: main
-    branches: main-tmp
+    branches: main
 
 jobs:
   publish:
@@ -24,7 +23,7 @@ jobs:
       - run: pnpm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: pnpm publish -r --report-summary --publish-branch main-tmp
+      - run: pnpm publish -r --report-summary --publish-branch main
       - run: pnpm run generate-slack-report
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,9 +22,9 @@ jobs:
       - run: pnpm build
       # - run: pnpm test
       - run: pnpm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
-      - run: pnpm publish -r --report-summary --publish-branch main-tmp
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: pnpm publish -r --report-summary --publish-branch main-tmp
       - run: pnpm generate_slack_report
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,26 @@
+name: Publish
+
+on:
+  push:
+    # branches: main-tmp
+    branches: main-tmp
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install
+      - run: pnpm test
+      - run: pnpm build
+      - run: pnpm publish -r
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,6 +25,6 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: pnpm publish -r --report-summary --publish-branch main-tmp
-      - run: pnpm generate_slack_report
+      - run: pnpm run generate-slack-report
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ ts.cache
 !.yarn/sdks
 !.yarn/versions
 
+pnpm-publish-summary.json
+
 # OS
 .DS_Store
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "pack:local": "pnpm run pack && node ./build/pack-local.js",
     "install:global": "pnpm build && pnpm run pack && node ./build/install-global.js",
     "install:openfnx": "pnpm install:global",
-    "export": "sh scripts/export.sh"
+    "export": "sh scripts/export.sh",
+    "generate-slack-report": "node ./scripts/slack-publish-message.js"
   },
   "keywords": [],
   "author": "Open Function Group",
@@ -25,5 +26,8 @@
     "gunzip-maybe": "^1.4.2",
     "rimraf": "^3.0.2",
     "tar-stream": "^3.0.0"
+  },
+  "dependencies": {
+    "@slack/web-api": "^6.8.1"
   }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/cli
 
+## 0.2.3
+
+### Patch Changes
+
+- Deploy test(no diff)
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/cli
 
+## 0.2.4
+
+### Patch Changes
+
+- Deploy test
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,7 +368,7 @@ importers:
   packages/runtime-manager:
     dependencies:
       '@openfn/compiler':
-        specifier: workspace:^0.0.35
+        specifier: workspace:^0.0.34
         version: link:../compiler
       '@openfn/language-common':
         specifier: 2.0.0-rc3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@slack/web-api':
+        specifier: ^6.8.1
+        version: 6.8.1
     devDependencies:
       '@changesets/cli':
         specifier: ^2.25.0
@@ -364,7 +368,7 @@ importers:
   packages/runtime-manager:
     dependencies:
       '@openfn/compiler':
-        specifier: workspace:^0.0.34
+        specifier: workspace:^0.0.35
         version: link:../compiler
       '@openfn/language-common':
         specifier: 2.0.0-rc3
@@ -1132,6 +1136,37 @@ packages:
     resolution: {integrity: sha512-7kwhBnCd1idyTB3MD9dXmUqROAhoaUIkz2AGDKuv9vn/cbZh7egEv9/PzKkRcDJYFV9qyyS+cVT3Xbgsg2ii5g==}
     bundledDependencies: []
 
+  /@slack/logger@3.0.0:
+    resolution: {integrity: sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+    dependencies:
+      '@types/node': 18.15.3
+    dev: false
+
+  /@slack/types@2.8.0:
+    resolution: {integrity: sha512-ghdfZSF0b4NC9ckBA8QnQgC9DJw2ZceDq0BIjjRSv6XAZBXJdWgxIsYz0TYnWSiqsKZGH2ZXbj9jYABZdH3OSQ==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+    dev: false
+
+  /@slack/web-api@6.8.1:
+    resolution: {integrity: sha512-eMPk2S99S613gcu7odSw/LV+Qxr8A+RXvBD0GYW510wJuTERiTjP5TgCsH8X09+lxSumbDE88wvWbuFuvGa74g==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+    dependencies:
+      '@slack/logger': 3.0.0
+      '@slack/types': 2.8.0
+      '@types/is-stream': 1.1.0
+      '@types/node': 18.15.3
+      axios: 0.27.2
+      eventemitter3: 3.1.2
+      form-data: 2.5.1
+      is-electron: 2.2.0
+      is-stream: 1.1.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@tailwindcss/forms@0.5.2(tailwindcss@3.1.8):
     resolution: {integrity: sha512-pSrFeJB6Bg1Mrg9CdQW3+hqZXAKsBrSG9MAfFLKy1pVA4Mb4W7C0k7mEhlmS2Dfo/otxrQOET7NJiJ9RrS563w==}
     peerDependencies:
@@ -1219,6 +1254,12 @@ packages:
     dependencies:
       ci-info: 3.4.0
     dev: true
+
+  /@types/is-stream@1.1.0:
+    resolution: {integrity: sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==}
+    dependencies:
+      '@types/node': 18.15.3
+    dev: false
 
   /@types/json-diff@1.0.0:
     resolution: {integrity: sha512-dCXC1F73Sqriz2d8Wt/sP/DztE+rlfIRPxW9WSYheHp/l3gvkeSvM6l4vhm7t4Dgn8AJAxNKajx/eobbPdP6Wg==}
@@ -1334,6 +1375,10 @@ packages:
       '@types/scheduler': 0.16.2
       csstype: 3.1.0
     dev: true
+
+  /@types/retry@0.12.0:
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+    dev: false
 
   /@types/scheduler@0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
@@ -1593,7 +1638,6 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
 
   /atob@2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
@@ -1658,6 +1702,15 @@ packages:
       yargs: 17.6.2
     transitivePeerDependencies:
       - supports-color
+
+  /axios@0.27.2:
+    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+    dependencies:
+      follow-redirects: 1.15.2
+      form-data: 4.0.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /axios@1.1.3:
     resolution: {integrity: sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==}
@@ -2052,7 +2105,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -2327,7 +2379,6 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -3024,6 +3075,14 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /eventemitter3@3.1.2:
+    resolution: {integrity: sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==}
+    dev: false
+
+  /eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+    dev: false
+
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -3243,12 +3302,20 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: true
 
   /for-in@1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /form-data@2.5.1:
+    resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
+    engines: {node: '>= 0.12'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
 
   /form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
@@ -3257,7 +3324,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: true
 
   /fragment-cache@0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
@@ -3763,6 +3829,10 @@ packages:
       kind-of: 6.0.3
     dev: true
 
+  /is-electron@2.2.0:
+    resolution: {integrity: sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==}
+    dev: false
+
   /is-error@2.2.2:
     resolution: {integrity: sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==}
 
@@ -3883,6 +3953,11 @@ packages:
     dependencies:
       call-bind: 1.0.2
     dev: true
+
+  /is-stream@1.1.0:
+    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -4658,6 +4733,11 @@ packages:
       p-map: 2.1.0
     dev: true
 
+  /p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+    dev: false
+
   /p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -4708,6 +4788,29 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       aggregate-error: 4.0.1
+
+  /p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+    dev: false
+
+  /p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+    dev: false
+
+  /p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-finally: 1.0.0
+    dev: false
 
   /p-timeout@5.1.0:
     resolution: {integrity: sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==}
@@ -5216,6 +5319,11 @@ packages:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
     engines: {node: '>=0.12'}
     dev: true
+
+  /retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+    dev: false
 
   /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}

--- a/scripts/slack-publish-message.js
+++ b/scripts/slack-publish-message.js
@@ -1,0 +1,95 @@
+const { readFileSync } = require('node:fs');
+const { WebClient } = require('@slack/web-api');
+
+const SLACK_DEV = 'C05JTEE22H5';
+
+const token = process.env.SLACK_TOKEN;
+const slack = new WebClient(token);
+
+// TODO: ignore all dependency updates
+// If the returned changelog is empty, don't bother listing the changes
+const extractChangelog = (package, version) => {
+  const [_, name] = package.split('@openfn/');
+  const log = readFileSync(`packages/${name}/CHANGELOG.md`, 'utf8').split('\n');
+  let shouldParse = false;
+  const changes = [];
+  for (const line of log) {
+    if (line === `## ${version}`) {
+      shouldParse = true;
+    } else if (shouldParse && line.startsWith('## ')) {
+      // This is the start of the next version, stop parsing
+      break;
+    } else if (shouldParse && line) {
+      changes.push(line);
+    }
+  }
+  return changes.join('\n');
+};
+
+const file = readFileSync('pnpm-publish-summary.json');
+if (file) {
+  const json = JSON.parse(file);
+
+  const cli = json.publishedPackages.find(({ name }) => name === '@openfn/cli');
+  if (cli) {
+    console.log('Generating slack post for CLI changes');
+    // Only post CLI changes!
+    const blocks = [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `🚀 *New CLI Release: ${cli.version}*`,
+        },
+      },
+      { type: 'divider' },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: 'To upgrade run: `npm -g install @openfn/cli`',
+        },
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: 'You can run `openfn test` to run a test job and verify your installed versions. If you have any trouble, uninstall the CLI with `npm remove -g @openfn.cli` and reinstall.',
+        },
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: 'If adaptors suddenly start breaking, try re-installing your repo with `openfn repo clean`',
+        },
+      },
+    ];
+
+    const attachments = [
+      {
+        // footer: 'Changelog',
+        blocks: [],
+      },
+    ];
+
+    json.publishedPackages.forEach((pkg) => {
+      const changelog = extractChangelog(pkg.name, pkg.version);
+      attachments[0].blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*${pkg.name} ${pkg.version}*\n${changelog}`,
+        },
+      });
+    });
+
+    slack.chat.postMessage({
+      attachments,
+      blocks,
+      channel: SLACK_DEV,
+    });
+  } else {
+    console.log('No CLI changes detected, doing nothing');
+  }
+}

--- a/scripts/slack-publish-message.js
+++ b/scripts/slack-publish-message.js
@@ -2,9 +2,125 @@ const { readFileSync } = require('node:fs');
 const { WebClient } = require('@slack/web-api');
 
 const SLACK_DEV = 'C05JTEE22H5';
+const ENGINEERING = 'G2LJCFFDW';
+const IMPLEMENTATION = 'C017ELVRSM8';
 
 const token = process.env.SLACK_TOKEN;
 const slack = new WebClient(token);
+
+const getEngineeringMessage = (cliVersion, changes) => {
+  const blocks = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `🚀 *New CLI Release: ${cliVersion}*`,
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: 'A new version of `openfn/cli` has just been released.\nUpgrade with `npm -g install @openfn/cli`',
+      },
+    },
+    // TODO I'd like to link to a full changelog but we don't really have one
+  ];
+
+  const versions = [];
+  changes.publishedPackages.forEach((pkg) => {
+    if (pkg.name !== '@openfn/cli') {
+      versions.push(`${pkg.version.padEnd(10)} ${pkg.name}`);
+    }
+  });
+
+  const attachments = [
+    {
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `\`\`\`${versions.join('\n')}\`\`\``,
+          },
+        },
+      ],
+    },
+  ];
+
+  return {
+    blocks,
+    attachments,
+    channel: ENGINEERING,
+  };
+};
+
+const getImplementationMessage = (cliVersion, changes) => {
+  const blocks = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `🚀 *New CLI Release: ${cliVersion}*`,
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: 'To upgrade run: `npm -g install @openfn/cli`',
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: 'You can run `openfn test` to run a test job and verify your installed versions. If you have any trouble, uninstall the CLI with `npm remove -g @openfn.cli` and reinstall.',
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: 'If adaptors suddenly start breaking, try re-installing your repo with `openfn repo clean`',
+      },
+    },
+  ];
+
+  const attachments = [
+    {
+      // footer: 'Changelog',
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*Changelog:*',
+          },
+        },
+      ],
+    },
+  ];
+
+  changes.publishedPackages.forEach((pkg) => {
+    const changelog = extractChangelog(pkg.name, pkg.version);
+    if (changelog.length) {
+      attachments[0].blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*${pkg.name} ${pkg.version}*\n${changelog}`,
+        },
+      });
+    }
+  });
+
+  return {
+    attachments,
+    blocks,
+    channel: IMPLEMENTATION,
+  };
+};
 
 // TODO: ignore all dependency updates
 // If the returned changelog is empty, don't bother listing the changes
@@ -12,14 +128,28 @@ const extractChangelog = (package, version) => {
   const [_, name] = package.split('@openfn/');
   const log = readFileSync(`packages/${name}/CHANGELOG.md`, 'utf8').split('\n');
   let shouldParse = false;
+  let skipDeps = false;
   const changes = [];
   for (const line of log) {
+    if (skipDeps) {
+      if (line.startsWith('  -')) {
+        continue;
+      } else {
+        skipDeps = false;
+      }
+    }
+
+    if (line.startsWith('- Updated dependencies')) {
+      // Ignore all the dependency stuff
+      skipDeps = true;
+      continue;
+    }
     if (line === `## ${version}`) {
       shouldParse = true;
     } else if (shouldParse && line.startsWith('## ')) {
       // This is the start of the next version, stop parsing
       break;
-    } else if (shouldParse && line) {
+    } else if (shouldParse && line.length > 2 && !line.startsWith('#')) {
       changes.push(line);
     }
   }
@@ -33,62 +163,9 @@ if (file) {
   const cli = json.publishedPackages.find(({ name }) => name === '@openfn/cli');
   if (cli) {
     console.log('Generating slack post for CLI changes');
-    // Only post CLI changes!
-    const blocks = [
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: `🚀 *New CLI Release: ${cli.version}*`,
-        },
-      },
-      { type: 'divider' },
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: 'To upgrade run: `npm -g install @openfn/cli`',
-        },
-      },
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: 'You can run `openfn test` to run a test job and verify your installed versions. If you have any trouble, uninstall the CLI with `npm remove -g @openfn.cli` and reinstall.',
-        },
-      },
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: 'If adaptors suddenly start breaking, try re-installing your repo with `openfn repo clean`',
-        },
-      },
-    ];
 
-    const attachments = [
-      {
-        // footer: 'Changelog',
-        blocks: [],
-      },
-    ];
-
-    json.publishedPackages.forEach((pkg) => {
-      const changelog = extractChangelog(pkg.name, pkg.version);
-      attachments[0].blocks.push({
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: `*${pkg.name} ${pkg.version}*\n${changelog}`,
-        },
-      });
-    });
-
-    slack.chat.postMessage({
-      attachments,
-      blocks,
-      channel: SLACK_DEV,
-    });
+    slack.chat.postMessage(getEngineeringMessage(cli.version, json));
+    slack.chat.postMessage(getImplementationMessage(cli.version, json));
   } else {
     console.log('No CLI changes detected, doing nothing');
   }

--- a/scripts/slack-publish-message.js
+++ b/scripts/slack-publish-message.js
@@ -33,6 +33,9 @@ const getEngineeringMessage = (cliVersion, changes) => {
       versions.push(`${pkg.version.padEnd(10)} ${pkg.name}`);
     }
   });
+  if (versions.length === 0) {
+    versions.push('No other versions released.');
+  }
 
   const attachments = [
     {


### PR DESCRIPTION
This PR adds a github action which will publish packages on merge to main.

Release branches should be assembled as a PR, have versions bumped and tags pushed, and be manually approved.

Once the release branch is merged, the new action will run to install, build, test (just in case) and publish.

Slack messages will be sent to #engineering and #implementation (with different messages).

This can be merged straight into main, ready for the next actual release.

Closes #324

I've also smuggled a dependabot update in here to make sure that examples is ignored and that it only updates once a week (it is infuriating to make a bunch of updates on Tuesday to wake up and see more on Wednesday)

## TODO

* [x] Disable circleCI for main
* [x] Deploy CLI from this branch
* [x] Notify on slack
* [x] Add Slack secret
* [x] [Add NPM secret](https://docs.npmjs.com/about-access-tokens) (granular access token would be a good idea)
* [x] Set main to a protected branch
* [x] Re-target the workflow at `main` (see review comments)

## Alternative Changeset Action

Just to note that there's already a changeset action created for this, but the flow is:

* Merge changes, including changesets, to main
* The action will generate a PR with version bumps
* On merge back to main, it'll publish.

I'm not really a fan of this: I prefer to manually maintain a release branch, track versions and changelogs in that, but just automate the actual publishing.