### PR TITLE
Logger: print errors to stdout

### DIFF
--- a/integration-tests/cli/test/errors.test.ts
+++ b/integration-tests/cli/test/errors.test.ts
@@ -8,125 +8,120 @@ const jobsPath = path.resolve('test/fixtures');
 // These are all errors that will stop the CLI from even running
 
 test.serial('job not found', async (t) => {
-  const { stdout, stderr, err } = await run('openfn blah.js --log-json');
+  const { stdout, err } = await run('openfn blah.js --log-json');
   t.is(err.code, 1);
 
   const stdlogs = extractLogs(stdout);
-  const errlogs = extractLogs(stderr);
 
-  assertLog(t, errlogs, /job not found/i);
+  assertLog(t, stdlogs, /job not found/i);
   assertLog(t, stdlogs, /failed to load the job from blah.js/i);
-  assertLog(t, errlogs, /critical error: aborting command/i);
+  assertLog(t, stdlogs, /critical error: aborting command/i);
 });
 
 test.serial('workflow not found', async (t) => {
-  const { stdout, stderr, err } = await run('openfn blah.json --log-json');
+  const { stdout, err } = await run('openfn blah.json --log-json');
   t.is(err.code, 1);
 
   const stdlogs = extractLogs(stdout);
-  const errlogs = extractLogs(stderr);
 
-  assertLog(t, errlogs, /workflow not found/i);
+  assertLog(t, stdlogs, /workflow not found/i);
   assertLog(t, stdlogs, /failed to load a workflow from blah.json/i);
-  assertLog(t, errlogs, /critical error: aborting command/i);
+  assertLog(t, stdlogs, /critical error: aborting command/i);
 });
 
 test.serial('job contains invalid js', async (t) => {
-  const { stdout, stderr, err } = await run(
-    `openfn ${jobsPath}/invalid.js --log-json`
-  );
+  const { stdout, err } = await run(`openfn ${jobsPath}/invalid.js --log-json`);
   t.is(err.code, 1);
 
   const stdlogs = extractLogs(stdout);
-  const errlogs = extractLogs(stderr);
 
-  assertLog(t, errlogs, /failed to compile job/i);
-  assertLog(t, errlogs, /unexpected token \(2:10\)/i);
+  assertLog(t, stdlogs, /failed to compile job/i);
+  assertLog(t, stdlogs, /unexpected token \(2:10\)/i);
   assertLog(t, stdlogs, /check the syntax of the job expression/i);
-  assertLog(t, errlogs, /critical error: aborting command/i);
+  assertLog(t, stdlogs, /critical error: aborting command/i);
 });
 
 // TODO this should really mention which job threw the error
 test.serial('workflow references a job with invalid js', async (t) => {
-  const { stdout, stderr, err } = await run(
+  const { stdout, err } = await run(
     `openfn ${jobsPath}/invalid-syntax.json --log-json`
   );
   t.is(err.code, 1);
 
   const stdlogs = extractLogs(stdout);
-  const errlogs = extractLogs(stderr);
 
-  assertLog(t, errlogs, /failed to compile job/i);
-  assertLog(t, errlogs, /unexpected token \(2:10\)/i);
+  assertLog(t, stdlogs, /failed to compile job/i);
+  assertLog(t, stdlogs, /unexpected token \(2:10\)/i);
   assertLog(t, stdlogs, /check the syntax of the job expression/i);
-  assertLog(t, errlogs, /critical error: aborting command/i);
+  assertLog(t, stdlogs, /critical error: aborting command/i);
 });
 
 test.serial("can't find an expression referenced in a workflow", async (t) => {
-  const { stdout, stderr, err } = await run(
+  const { stdout, err } = await run(
     `openfn ${jobsPath}/invalid-exp-path.json --log-json`
   );
   t.is(err.code, 1);
 
   const stdlogs = extractLogs(stdout);
-  const errlogs = extractLogs(stderr);
 
-  assertLog(t, errlogs, /File not found for job 1: does-not-exist.js/i);
+  assertLog(t, stdlogs, /File not found for job 1: does-not-exist.js/i);
   assertLog(
     t,
     stdlogs,
     /This workflow references a file which cannot be found at does-not-exist.js/i
   );
-  assertLog(t, errlogs, /critical error: aborting command/i);
+  assertLog(t, stdlogs, /critical error: aborting command/i);
 });
 
 test.serial("can't find config referenced in a workflow", async (t) => {
-  const { stdout, stderr, err } = await run(
+  const { stdout, err } = await run(
     `openfn ${jobsPath}/invalid-config-path.json --log-json`
   );
   t.is(err.code, 1);
 
   const stdlogs = extractLogs(stdout);
-  const errlogs = extractLogs(stderr);
 
-  assertLog(t, errlogs, /File not found for job 1: does-not-exist.js/i);
+  assertLog(t, stdlogs, /File not found for job 1: does-not-exist.js/i);
   assertLog(
     t,
     stdlogs,
     /This workflow references a file which cannot be found at does-not-exist.js/i
   );
-  assertLog(t, errlogs, /critical error: aborting command/i);
+  assertLog(t, stdlogs, /critical error: aborting command/i);
 });
 
 test.serial('circular workflow', async (t) => {
-  const { stderr, err } = await run(
+  const { stdout, err } = await run(
     `openfn ${jobsPath}/circular.json --log-json`
   );
   t.is(err.code, 1);
 
-  const errlogs = extractLogs(stderr);
-  assertLog(t, errlogs, /Invalid workflow/i);
-  assertLog(t, errlogs, /circular dependency: b <-> a/i);
+  const stdlogs = extractLogs(stdout);
+
+  assertLog(t, stdlogs, /Invalid workflow/i);
+  assertLog(t, stdlogs, /circular dependency: b <-> a/i);
 });
 
 test.serial('multiple inputs', async (t) => {
-  const { stderr, err } = await run(
+  const { stdout, err } = await run(
     `openfn ${jobsPath}/multiple-inputs.json --log-json`
   );
   t.is(err.code, 1);
 
-  const errlogs = extractLogs(stderr);
-  assertLog(t, errlogs, /Invalid workflow/i);
-  assertLog(t, errlogs, /multiple dependencies detected for: c/i);
+  const stdlogs = extractLogs(stdout);
+
+  assertLog(t, stdlogs, /Invalid workflow/i);
+  assertLog(t, stdlogs, /multiple dependencies detected for: c/i);
 });
 
 test.serial('invalid start', async (t) => {
-  const { stderr, err } = await run(
+  const { stdout, err } = await run(
     `openfn ${jobsPath}/invalid-start.json --log-json`
   );
   t.is(err.code, 1);
 
-  const errlogs = extractLogs(stderr);
-  assertLog(t, errlogs, /Invalid workflow/i);
-  assertLog(t, errlogs, /could not find start job: nope/i);
+  const stdlogs = extractLogs(stdout);
+
+  assertLog(t, stdlogs, /Invalid workflow/i);
+  assertLog(t, stdlogs, /could not find start job: nope/i);
 });

--- a/packages/logger/src/options.ts
+++ b/packages/logger/src/options.ts
@@ -40,6 +40,9 @@ export type LogOptions = {
 // but to support the success handler we need to alias console.log
 const defaultEmitter = {
   ...console,
+  // Direct error and warn logs to stdout, so that they appear in sequence
+  error: (...args: any[]) => console.log(...args),
+  warn: (...args: any[]) => console.log(...args),
   success: (...args: any[]) => console.log(...args),
   always: (...args: any[]) => console.log(...args),
 };


### PR DESCRIPTION
This might be contentious. Closes #257

This PR makes the logger, by default, redirect any `logger.error` or `logger.warn` message s to stdout.

The problem is that when errors are logged from job code, they appear out sequence in the shell because they're written to a different stream. This can result in very confusing log output.

The solution is to make the default log emitter - the thing the logger eventually calls `console.log` on - redirect errors and warnings. This is kinda nice because it doesn't affect the mock logger and none of our unit tests break.

This behaviour can be overridden by passing a different emitter (ie, `console`) object when calling `createLogger`.

An alternative implementation would be to make the CLI pass a different lo emitter, so that by default the logger uses stderr but the CLI is setup to only use stdout. This kind of puts us back to square one though.

This may affect Lightning so I don't want to merge it until @stuartc has taken a look and shared his thoughts. It will also affect the new runtime manager too - but it does feel appropriate that all job logs should print to stdout.

Note that although we may be able to re-assemble logs in the right order in the Lightning Log Viewer (sorting by timestamp, if we have the accuracy), the CLI still has this problem, which may be confusing for local devs.