### PR TITLE
Logger: Improvements to error handling

### DIFF
--- a/.changeset/fluffy-pets-fly.md
+++ b/.changeset/fluffy-pets-fly.md
@@ -1,0 +1,6 @@
+---
+'@openfn/logger': patch
+'@openfn/cli': patch
+---
+
+Always log errors (even if log=none)

--- a/.changeset/friendly-readers-pay.md
+++ b/.changeset/friendly-readers-pay.md
@@ -1,0 +1,5 @@
+---
+'@openfn/logger': patch
+---
+
+If log=none, don't log job logs

--- a/.changeset/slow-beans-behave.md
+++ b/.changeset/slow-beans-behave.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+better handling of non-Error errors

--- a/packages/cli/src/util/ensure-log-opts.ts
+++ b/packages/cli/src/util/ensure-log-opts.ts
@@ -53,6 +53,12 @@ const ensureLogOpts = (opts: IncomingOpts) => {
       } else {
         component = 'default';
         level = l.toLowerCase() as LogLevel;
+
+        if (level === 'none' && !parts.find((p) => p.startsWith('job'))) {
+          // if log is defaulted to none, and job hasn't explicitly seen set,
+          // don't log job logs
+          components['job'] = 'none';
+        }
       }
 
       if (!/^(cli|runtime|compiler|job|default)$/i.test(component)) {

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -2,6 +2,7 @@
 import actualCreateLogger, { printDuration } from '@openfn/logger';
 import type { Opts } from '../options';
 
+// TODO: add a "job" log level, which means, "only log job stuff"
 export type { Logger, LogOptions, LogLevel } from '@openfn/logger';
 export { isValidLogLevel, defaultLogger } from '@openfn/logger';
 

--- a/packages/cli/test/options/execute.test.ts
+++ b/packages/cli/test/options/execute.test.ts
@@ -29,12 +29,12 @@ test('execute: set outputPath to ./output.json', (t) => {
 
 test('execute: log none', (t) => {
   const options = parse('execute job.js --log none');
-  t.deepEqual(options.log, { default: 'none', job: 'debug' });
+  t.deepEqual(options.log, { default: 'none', job: 'none' });
 });
 
 test('execute: log default', (t) => {
   const options = parse('execute job.js --log none');
-  t.deepEqual(options.log, { default: 'none', job: 'debug' });
+  t.deepEqual(options.log, { default: 'none', job: 'none' });
 });
 
 test('execute: log info', (t) => {

--- a/packages/cli/test/util/ensure-opts.test.ts
+++ b/packages/cli/test/util/ensure-opts.test.ts
@@ -94,6 +94,39 @@ test('log: set default and a specific option', (t) => {
   t.is(opts.log!.compiler, 'debug');
 });
 
+test('log: if none, set job to none too', (t) => {
+  const initialOpts = {
+    log: ['none'],
+  };
+
+  const opts = ensureLogOpts(initialOpts);
+
+  t.is(opts.log!.default, 'none');
+  t.is(opts.log!.job, 'none');
+});
+
+test('log: if none, can still set job', (t) => {
+  const initialOpts = {
+    log: ['none', 'job=info'],
+  };
+
+  const opts = ensureLogOpts(initialOpts);
+
+  t.is(opts.log!.default, 'none');
+  t.is(opts.log!.job, 'info');
+});
+
+test('log: if none, can still set job (different order)', (t) => {
+  const initialOpts = {
+    log: ['job=info', 'none'],
+  };
+
+  const opts = ensureLogOpts(initialOpts);
+
+  t.is(opts.log!.default, 'none');
+  t.is(opts.log!.job, 'info');
+});
+
 test('log: default to info for test', (t) => {
   const initialOpts = {
     command: 'test',

--- a/packages/cli/test/util/ensure-opts.test.ts
+++ b/packages/cli/test/util/ensure-opts.test.ts
@@ -96,7 +96,7 @@ test('log: set default and a specific option', (t) => {
 
 test('log: if none, set job to none too', (t) => {
   const initialOpts = {
-    log: ['none'],
+    log: 'none',
   };
 
   const opts = ensureLogOpts(initialOpts);
@@ -107,7 +107,7 @@ test('log: if none, set job to none too', (t) => {
 
 test('log: if none, can still set job', (t) => {
   const initialOpts = {
-    log: ['none', 'job=info'],
+    log: 'none,job=info',
   };
 
   const opts = ensureLogOpts(initialOpts);
@@ -118,7 +118,7 @@ test('log: if none, can still set job', (t) => {
 
 test('log: if none, can still set job (different order)', (t) => {
   const initialOpts = {
-    log: ['job=info', 'none'],
+    log: 'job=info,none',
   };
 
   const opts = ensureLogOpts(initialOpts);

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -93,9 +93,9 @@ const priority: Record<LogFns | LogLevel, number> = {
   default: 2,
   [ALWAYS]: 2,
   [WARN]: 2,
-  [ERROR]: 2,
   [SUCCESS]: 2,
   [NONE]: 9,
+  [ERROR]: 100, // errors ALWAYS log
 };
 
 // // TODO I'd quite like each package to have its own colour, I think

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -245,7 +245,7 @@ test('log() should behave like info', (t) => {
   t.assert(result.message === 'abc');
 });
 
-test('with level=none, logs nothing', (t) => {
+test('with level=none, logs errors only', (t) => {
   // TODO this doesn't give me very documentary-style tests
   // because the signature is actually quite misleading
   const logger = createLogger(undefined, { level: 'none' });
@@ -253,22 +253,26 @@ test('with level=none, logs nothing', (t) => {
   logger.info('b');
   logger.debug('c');
   logger.warn('d');
-  logger.error('e');
   logger.log('e');
 
   t.assert(logger._history.length === 0);
+
+  logger.error('e');
+  t.assert(logger._history.length === 1);
 });
 
-test('in json mode with level=none, logs nothing', (t) => {
+test('in json mode with level=none, logs errors only', (t) => {
   const logger = createLogger(undefined, { level: 'none', json: true });
   logger.success('a');
   logger.info('b');
   logger.debug('c');
   logger.warn('d');
-  logger.error('e');
   logger.log('e');
 
   t.assert(logger._history.length === 0);
+
+  logger.error('e');
+  t.assert(logger._history.length === 1);
 });
 
 test('with level=default, logs success, error and warning but not info and debug', (t) => {

--- a/packages/runtime/src/util/log-error.ts
+++ b/packages/runtime/src/util/log-error.ts
@@ -26,10 +26,13 @@ const createErrorReporter = (logger: Logger): ErrorReporter => {
       logger.error(
         `${report.code || report.name || 'error'}: ${report.message}`
       );
+      logger.debug(error); // TODO the logger doesn't handle this very well
+    } else {
+      // This catches if a non-Error object is thrown, ie, `throw "e"`
+      logger.error('ERROR:', error);
     }
 
     logger.error(`Check state.errors.${jobId} for details.`);
-    logger.debug(error); // TODO the logger doesn't handle this very well
 
     if (!state.errors) {
       state.errors = {};


### PR DESCRIPTION
## Short Description

A few small improvements here:

* The logger will always log errors (even if logging is disabled) #163
* The CLI will not print job logs if errors #277
* If you throw a non Error (ie, `throw "whoopsie"`), the runtime will log it

This doesn't really affect much in practice. In the unlikely event that someone is using log=none, they'll start to see the output they expect.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added unit tests
- [x] Changesets have been added (if there are production code changes)
