### PR TITLE
Logger: Sensitive logging

### DIFF
--- a/.changeset/wet-swans-greet.md
+++ b/.changeset/wet-swans-greet.md
@@ -1,0 +1,5 @@
+---
+'@openfn/logger': patch
+---
+
+Don't log null

--- a/.changeset/wicked-kiwis-bake.md
+++ b/.changeset/wicked-kiwis-bake.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': minor
+---
+
+Added sanitize option

--- a/integration-tests/cli/README.md
+++ b/integration-tests/cli/README.md
@@ -10,7 +10,7 @@ During development, you can run the unit tests against a local build (ie, `packa
 
 `pnpm test:dev`
 
-You can run the test in isolation with a docker build. This can be useful while developign for CI, or if a test passes locally but fails in CI.
+You can run the test in isolation with a docker build. This can be useful while developing for CI, or if a test passes locally but fails in CI.
 
 `pnpm run build`
 `pnpm run start`
@@ -23,9 +23,9 @@ Test names should be the actual command under test. This makes it easy to reprod
 
 How it works:
 
-* Build and package the report into a set of tarballs. This uses `pack:local` so that the tarballs are self-referencing. 
-* Install the CLI globally in a clean environment from these tarballs.
-* Unit tests in ava will run commands against the global command (using child_process.exec). They assert against logging and JSON  output.
+- Build and package the report into a set of tarballs. This uses `pack:local` so that the tarballs are self-referencing.
+- Install the CLI globally in a clean environment from these tarballs.
+- Unit tests in ava will run commands against the global command (using child_process.exec). They assert against logging and JSON output.
 
 ## Creating tarballs
 

--- a/integration-tests/cli/test/execute-job.test.ts
+++ b/integration-tests/cli/test/execute-job.test.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from 'node:fs';
 import { rm, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import run from '../src/run';
-import { getJSON } from '../src/util';
+import { assertLog, extractLogs, getJSON } from '../src/util';
 
 const jobsPath = path.resolve('test/fixtures');
 const tmpPath = path.resolve('tmp');
@@ -105,5 +105,17 @@ test.serial(
     const out = getJSON();
     t.truthy(out.data.value);
     t.regex(out.data.value, /chuck norris/i);
+  }
+);
+
+test.serial.only(
+  `openfn ${jobsPath}/log.js -ia @openfn/language-common --sanitize=obfuscate`,
+  async (t) => {
+    const { stdout } = await run(t.title);
+    console.log(stdout);
+
+    const stdlogs = extractLogs(stdout);
+
+    assertLog(t, stdlogs, /\[object\]/);
   }
 );

--- a/integration-tests/cli/test/execute-job.test.ts
+++ b/integration-tests/cli/test/execute-job.test.ts
@@ -108,14 +108,78 @@ test.serial(
   }
 );
 
-test.serial.only(
-  `openfn ${jobsPath}/log.js -ia @openfn/language-common --sanitize=obfuscate`,
+test.serial(
+  `openfn ${jobsPath}/log.js -a @openfn/language-common --sanitize=obfuscate`,
   async (t) => {
     const { stdout } = await run(t.title);
-    console.log(stdout);
+
+    const jobLog = stdout.split(/\n/).find((l) => l.startsWith('[JOB]'));
+
+    t.truthy(jobLog);
+    t.true(jobLog.endsWith('[object]'));
+  }
+);
+
+test.serial(
+  `openfn ${jobsPath}/log.js -a @openfn/language-common --sanitize=obfuscate --log-json`,
+  async (t) => {
+    const { stdout } = await run(t.title);
 
     const stdlogs = extractLogs(stdout);
 
-    assertLog(t, stdlogs, /\[object\]/);
+    const log = stdlogs.find(
+      ({ message, name }) => name === 'JOB' && message[0] === '[object]'
+    );
+    t.truthy(log);
+  }
+);
+
+test.serial(
+  `openfn ${jobsPath}/log.js -a @openfn/language-common --sanitize=remove`,
+  async (t) => {
+    const { stdout } = await run(t.title);
+
+    const jobLog = stdout.split(/\n/).find((l) => l.startsWith('[JOB]'));
+
+    t.falsy(jobLog);
+  }
+);
+
+test.serial(
+  `openfn ${jobsPath}/log.js -a @openfn/language-common --sanitize=remove --log-json`,
+  async (t) => {
+    const { stdout } = await run(t.title);
+
+    const stdlogs = extractLogs(stdout);
+
+    const log = stdlogs.find(({ name }) => name === 'JOB');
+    t.falsy(log);
+  }
+);
+
+test.serial(
+  `openfn ${jobsPath}/log.js -a @openfn/language-common --sanitize=summarize`,
+  async (t) => {
+    const { stdout } = await run(t.title);
+
+    const jobLog = stdout.split(/\n/).find((l) => l.startsWith('[JOB]'));
+    t.truthy(jobLog);
+    t.true(jobLog.endsWith('(object with keys configuration, data)'));
+  }
+);
+
+test.serial(
+  `openfn ${jobsPath}/log.js -a @openfn/language-common --sanitize=summarize --log-json`,
+  async (t) => {
+    const { stdout } = await run(t.title);
+
+    const stdlogs = extractLogs(stdout);
+
+    const log = stdlogs.find(
+      ({ message, name }) =>
+        name === 'JOB' &&
+        message[0] === '(object with keys configuration, data)'
+    );
+    t.truthy(log);
   }
 );

--- a/integration-tests/cli/test/fixtures/log.js
+++ b/integration-tests/cli/test/fixtures/log.js
@@ -1,0 +1,4 @@
+fn((state) => {
+  console.log(state);
+  return state;
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
     "@openfn/describe-package": "workspace:*",
     "@openfn/logger": "workspace:*",
     "@openfn/runtime": "workspace:*",
+    "chalk": "^5.1.2",
     "figures": "^5.0.0",
     "rimraf": "^3.0.2",
     "treeify": "^1.1.0",

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -25,6 +25,7 @@ export type ExecuteOptions = Required<
     | 'start'
     | 'statePath'
     | 'stateStdin'
+    | 'sanitize'
     | 'strict'
     | 'timeout'
     | 'useAdaptorsMonorepo'
@@ -49,6 +50,7 @@ const options = [
   o.outputStdout,
   o.repoDir,
   o.skipAdaptorValidation,
+  o.sanitize,
   o.start,
   o.statePath,
   o.stateStdin,

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -401,6 +401,7 @@ export const sanitize: CLIOption = {
   name: 'sanitize',
   yargs: {
     string: true,
+    alias: ['sanitise'],
     description:
       'Sanitize logging of objects and arrays: none (default), remove, summarize, obfuscate.',
     default: 'none',

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -407,7 +407,10 @@ export const sanitize: CLIOption = {
     default: 'none',
   },
   ensure: (opts) => {
-    if (opts.sanitize?.match(/^(none|summarize|remove|obfuscate)$/)) {
+    if (
+      !opts.sanitize ||
+      opts.sanitize?.match(/^(none|summarize|remove|obfuscate)$/)
+    ) {
       return;
     }
     const err = 'Unknown sanitize value provided: ' + opts.sanitize;

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -409,6 +409,8 @@ export const sanitize: CLIOption = {
     if (opts.sanitize?.match(/^(none|summarize|remove|obfuscate)$/)) {
       return;
     }
-    throw new Error('Unknown sanitize value provided: ' + sanitize);
+    const err = 'Unknown sanitize value provided: ' + opts.sanitize;
+    console.error(err);
+    throw new Error(err);
   },
 };

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -44,6 +44,7 @@ export type Opts = {
   statePath?: string;
   stateStdin?: string;
   strict?: boolean; // Strict state handling (only forward state.data). Defaults to true
+  sanitize: 'none' | 'remove' | 'summarize' | 'obfuscate';
   timeout?: number; // ms
   useAdaptorsMonorepo?: boolean;
   workflow?: CLIExecutionPlan | ExecutionPlan;
@@ -393,5 +394,21 @@ export const useAdaptorsMonorepo: CLIOption = {
     if (opts.useAdaptorsMonorepo) {
       opts.monorepoPath = process.env.OPENFN_ADAPTORS_REPO || 'ERR';
     }
+  },
+};
+
+export const sanitize: CLIOption = {
+  name: 'sanitize',
+  yargs: {
+    string: true,
+    description:
+      'Sanitize logging of objects and arrays: none (default), remove, summarize, obfuscate.',
+    default: 'none',
+  },
+  ensure: (opts) => {
+    if (opts.sanitize?.match(/^(none|summarize|remove|obfuscate)$/)) {
+      return;
+    }
+    throw new Error('Unknown sanitize value provided: ' + sanitize);
   },
 };

--- a/packages/cli/src/util/command-builders.ts
+++ b/packages/cli/src/util/command-builders.ts
@@ -1,4 +1,6 @@
 import yargs, { ArgumentsCamelCase } from 'yargs';
+import c from 'chalk';
+
 import { CommandList } from '../commands';
 import type { Opts, CLIOption } from '../options';
 
@@ -25,7 +27,16 @@ export const ensure =
     opts
       .filter((opt) => opt.ensure)
       .forEach((opt) => {
-        opt.ensure!(yargs);
+        try {
+          opt.ensure!(yargs);
+        } catch (e) {
+          console.error(
+            c.red(`\nError parsing command arguments: ${command}.${opt.name}\n`)
+          );
+          console.error(c.red('Aborting'));
+          console.error();
+          process.exit(9); // invalid argument
+        }
       });
   };
 

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -20,7 +20,7 @@ const namespaces: Record<string, string> = {
 
 export const createLogger = (
   name: string = '',
-  options: Partial<Pick<Opts, 'log' | 'logJson'>>
+  options: Partial<Pick<Opts, 'log' | 'logJson' | 'sanitize'>>
 ) => {
   const logOptions = options.log || {};
   let json = false;
@@ -31,6 +31,7 @@ export const createLogger = (
   return actualCreateLogger(namespaces[name] || name, {
     level,
     json,
+    sanitize: options.sanitize || 'none',
     ...logOptions,
   });
 };

--- a/packages/cli/test/options/ensure/sanitize.test.ts
+++ b/packages/cli/test/options/ensure/sanitize.test.ts
@@ -1,0 +1,46 @@
+import test from 'ava';
+import { sanitize, Opts } from '../../../src/options';
+
+test('ensure should do nothing for none', (t) => {
+  const opts = {
+    sanitize: 'none',
+  } as Opts;
+  sanitize.ensure!(opts);
+
+  t.is(opts.sanitize, 'none');
+});
+
+test('ensure should do nothing for remove', (t) => {
+  const opts = {
+    sanitize: 'remove',
+  } as Opts;
+  sanitize.ensure!(opts);
+
+  t.is(opts.sanitize, 'remove');
+});
+
+test('ensure should do nothing for summarize', (t) => {
+  const opts = {
+    sanitize: 'summarize',
+  } as Opts;
+  sanitize.ensure!(opts);
+
+  t.is(opts.sanitize, 'summarize');
+});
+
+test('ensure should do nothing for obfuscate', (t) => {
+  const opts = {
+    sanitize: 'obfuscate',
+  } as Opts;
+  sanitize.ensure!(opts);
+
+  t.is(opts.sanitize, 'obfuscate');
+});
+
+test('ensure should throw for unknown value', (t) => {
+  const opts = {
+    sanitize: 'no-thank-you',
+  } as unknown as Opts;
+
+  t.throws(() => sanitize.ensure!(opts));
+});

--- a/packages/cli/test/options/execute.test.ts
+++ b/packages/cli/test/options/execute.test.ts
@@ -73,3 +73,28 @@ test('execute: log json', (t) => {
   const options = parse('execute job.js --log-json');
   t.true(options.logJson);
 });
+
+test('execute: sanitize none (by default)', (t) => {
+  const options = parse('execute job.js');
+  t.is(options.sanitize, 'none');
+});
+
+test('execute: sanitize none (explicit)', (t) => {
+  const options = parse('execute job.js --sanitize=none');
+  t.is(options.sanitize, 'none');
+});
+
+test('execute: sanitize remove ', (t) => {
+  const options = parse('execute job.js --sanitize=remove');
+  t.is(options.sanitize, 'remove');
+});
+
+test('execute: sanitize obfuscate ', (t) => {
+  const options = parse('execute job.js --sanitize=obfuscate');
+  t.is(options.sanitize, 'obfuscate');
+});
+
+test('execute: sanitize summarize ', (t) => {
+  const options = parse('execute job.js --sanitize=summarize');
+  t.is(options.sanitize, 'summarize');
+});

--- a/packages/cli/test/options/execute.test.ts
+++ b/packages/cli/test/options/execute.test.ts
@@ -63,7 +63,8 @@ test('execute: log debug by default but job none', (t) => {
   t.deepEqual(options.log, { default: 'debug', job: 'none' });
 });
 
-test('execute: throw for invalid log', (t) => {
+// This will now trigger a process.exit so we can't really test this here
+test.skip('execute: throw for invalid log', (t) => {
   t.throws(() => parse('execute job.js --log wibble'), {
     message: ERROR_MESSAGE_LOG_LEVEL,
   });

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -152,15 +152,22 @@ export default function (name?: string, options: LogOptions = {}): Logger {
   };
 
   const logJSON = (level: LogFns, ...args: LogArgs) => {
+    const message = args.map((o) =>
+      sanitize(o, {
+        stringify: false,
+        policy: options.sanitize,
+      })
+    );
+    if (message.length === 1 && message[0] === null) {
+      // Special case:
+      // If logging null only, don't log anything
+      // This enables the remove obfuscation policy to work properly
+      return;
+    }
     const output: JSONLog = {
       level,
       name,
-      message: args.map((o) =>
-        sanitize(o, {
-          stringify: false,
-          policy: options.sanitize,
-        })
-      ),
+      message,
       time: Date.now(),
     };
 

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -165,21 +165,28 @@ export default function (name?: string, options: LogOptions = {}): Logger {
 
   const logString = (level: LogFns, ...args: LogArgs) => {
     if (emitter.hasOwnProperty(level)) {
-      const output = [];
+      const cleanedArgs = args.map((o) => sanitize(o, options));
 
-      if (name && !opts.hideNamespace) {
-        // TODO how can we fix the with of the type column so that things
-        //      are nicely arranged in the CLI?
-        output.push(c.blue(`[${name}]`));
-      }
-      if (!opts.hideIcons) {
-        output.push(styleLevel(level));
+      if (cleanedArgs.length === 1 && cleanedArgs[0] === null) {
+        // Special case:
+        // If logging null only, don't log anything
+        // This enables the remove obfuscation policy to work properly
+        return;
       }
 
-      output.push(...args);
+      if (cleanedArgs.length) {
+        const output = [];
+        if (name && !opts.hideNamespace) {
+          // TODO how can we fix the with of the type column so that things
+          //      are nicely arranged in the CLI?
+          output.push(c.blue(`[${name}]`));
+        }
+        if (!opts.hideIcons) {
+          output.push(styleLevel(level));
+        }
 
-      const cleaned = output.map((o) => sanitize(o, options));
-      emitter[level](...cleaned);
+        emitter[level](...output.concat(cleanedArgs));
+      }
     }
   };
 

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -155,7 +155,12 @@ export default function (name?: string, options: LogOptions = {}): Logger {
     const output: JSONLog = {
       level,
       name,
-      message: args.map((o) => sanitize(o, { stringify: false })),
+      message: args.map((o) =>
+        sanitize(o, {
+          stringify: false,
+          policy: options.sanitize,
+        })
+      ),
       time: Date.now(),
     };
 
@@ -165,7 +170,13 @@ export default function (name?: string, options: LogOptions = {}): Logger {
 
   const logString = (level: LogFns, ...args: LogArgs) => {
     if (emitter.hasOwnProperty(level)) {
-      const cleanedArgs = args.map((o) => sanitize(o, options));
+      const cleanedArgs = args.map((o) =>
+        sanitize(o, {
+          stringify: true,
+          sanitizePaths: [],
+          policy: options.sanitize,
+        })
+      );
 
       if (cleanedArgs.length === 1 && cleanedArgs[0] === null) {
         // Special case:

--- a/packages/logger/src/options.ts
+++ b/packages/logger/src/options.ts
@@ -28,12 +28,12 @@ export type LogOptions = {
   // like if we on sensitive c in a.b.c, console.log(c) should
   sanitizePaths?: string[];
 
-  sanitiseState?: boolean; // defaults to true
+  sanitizeState?: boolean; // defaults to true
   detectState?: boolean; // defaults to true
 
   json?: boolean; // output as json objects
 
-  sanitise?: SanitizePolicies;
+  sanitize?: SanitizePolicies;
 };
 
 // TODO not crazy about the handling of this
@@ -55,7 +55,8 @@ export const defaults: Required<LogOptions> = {
   // Not implemented
   wrap: false,
   showTimestamps: false,
-  sanitiseState: false,
+  sanitizeState: false,
+  sanitize: 'none',
   detectState: false,
   sanitizePaths: ['configuration'],
   json: false,

--- a/packages/logger/src/options.ts
+++ b/packages/logger/src/options.ts
@@ -1,3 +1,5 @@
+import { SanitizePolicies } from './sanitize';
+
 export type LogLevel = 'debug' | 'info' | 'default' | 'none';
 
 export type LogEmitter = typeof console & {
@@ -30,6 +32,8 @@ export type LogOptions = {
   detectState?: boolean; // defaults to true
 
   json?: boolean; // output as json objects
+
+  sanitise?: SanitizePolicies;
 };
 
 // TODO not crazy about the handling of this

--- a/packages/logger/src/sanitize.ts
+++ b/packages/logger/src/sanitize.ts
@@ -1,4 +1,5 @@
 import stringify from 'fast-safe-stringify';
+import { isObject, isArray } from './util';
 
 export const SECRET = '****';
 
@@ -57,54 +58,21 @@ const sanitize = (item: any, options: SanitizeOptions = {}) => {
   return item;
 };
 
-// TODO move to utils
-// Also create isArray,which will just be a shallow clone
-export const isObject = (thing: any) => {
-  if (Array.isArray(thing) || thing === null || thing instanceof Error) {
-    return false;
-  }
+// Sanitize helpers
 
-  if (typeof thing === 'object') {
-    return true;
-  }
-  return false;
-};
-
-// replace an object with a string or the result of a function
-// But this affects arrays as well, argh
-// TODO is this actually pointless now that we only take a singletone argument?
-export const replaceObject = (
-  replace: string | ((logItem: any) => string),
-  logItem: any
-): any => {
-  if (isObject(logItem) || Array.isArray(logItem)) {
-    return typeof replace === 'function' ? replace(logItem) : replace;
-  }
-  return logItem;
-};
-
-// sanitize policy subject to options
-
-// remove all objects from the output
-// Note that we should refuse to log if there is nothing left
-// does that mean the logger never logs null?
+// Replace objects and arrays with null
 function remove(logItem: any): any {
-  // TODO incoming is an argument to console.log
-  if (isObject(logItem)) {
+  if (isObject(logItem) || isArray(logItem)) {
     return null;
-  } else if (Array.isArray(logItem)) {
-    // TODO if we find an array, I think we should remove all the objects inside?
-    // Or do we just remove the whole thing?
-    return logItem.map(remove);
   }
 
   return logItem;
 }
 
-// // summarise the object
-// // ie, array with 31 items or object with keys z, y, x
+// summarise the object
+// ie, array with 31 items or object with keys z, y, x
 function summarize(logItem: any): any {
-  if (Array.isArray(logItem)) {
+  if (isArray(logItem)) {
     if (logItem.length) {
       return `(array with ${logItem.length} items)`;
     } else {
@@ -122,9 +90,9 @@ function summarize(logItem: any): any {
   return logItem;
 }
 
-// // [object Object] or Array<Object>
+// obfuscate an object or array with a simple string
 function obfuscate(logItem: any): any {
-  if (Array.isArray(logItem)) {
+  if (isArray(logItem)) {
     return '[array]';
   }
   if (isObject(logItem)) {

--- a/packages/logger/src/sanitize.ts
+++ b/packages/logger/src/sanitize.ts
@@ -2,7 +2,7 @@ import stringify from 'fast-safe-stringify';
 
 export const SECRET = '****';
 
-type SanitizePolicies = 'remove' | 'obfuscate' | 'summarize' | 'none';
+export type SanitizePolicies = 'remove' | 'obfuscate' | 'summarize' | 'none';
 
 type SanitizeOptions = {
   stringify?: boolean; // true by default
@@ -10,6 +10,9 @@ type SanitizeOptions = {
   sanitizePaths?: string[]; // unimplemented
 
   // sanitisation policies (by default do nothing)
+  // TODO throw if an invalid policy is passed
+  // This is potentially important so we do want to break
+  // but! we should throw in the CLI< not here.
   policy?: SanitizePolicies;
 };
 

--- a/packages/logger/src/sanitize.ts
+++ b/packages/logger/src/sanitize.ts
@@ -101,6 +101,13 @@ function remove(logItem: any): any {
 // // summarise the object
 // // ie, array with 31 items or object with keys z, y, x
 function summarize(logItem: any): any {
+  if (Array.isArray(logItem)) {
+    if (logItem.length) {
+      return `(array with ${logItem.length} items)`;
+    } else {
+      return '(empty array)';
+    }
+  }
   if (isObject(logItem)) {
     const keys = Object.keys(logItem);
     if (keys.length) {

--- a/packages/logger/src/sanitize.ts
+++ b/packages/logger/src/sanitize.ts
@@ -40,4 +40,46 @@ const sanitize = (item: any, options: SanitizeOptions = {}) => {
   return item;
 };
 
+// TODO move to utils
+// Also create isArray,which will just be a shallow clone
+export const isObject = (thing: any) => {
+  if (Array.isArray(thing) || thing === null || thing instanceof Error) {
+    return false;
+  }
+
+  if (typeof thing === 'object') {
+    return true;
+  }
+  return false;
+};
+
+// replace an object with a string or the result of a function
+// But this affects arrays as well, argh
+export const replaceObject = (
+  replace: string | ((logItem: any) => string),
+  ...logItem: any[]
+): any[] =>
+  logItem.map((i: any) => {
+    if (isObject(i) || Array.isArray(i)) {
+      return typeof replace === 'function' ? replace(i) : replace;
+    }
+    return i;
+  });
+
+// sanitize policy subject to options
+
+// remove all objects from the output
+// Note that we should refuse to log if there is nothign left
+// does that mean the logger never logs null?
+export const remove = (logItem) => {
+  // TODO incoming is an argument to console.log
+};
+
+// // summarise the object
+// // ie, array with 31 items or object with keys z, y, x
+// const summarise = (logItem) => {};
+
+// // [object Object] or Array<Object>
+const obfuscate = (logItem) => {};
+
 export default sanitize;

--- a/packages/logger/src/util/index.ts
+++ b/packages/logger/src/util/index.ts
@@ -1,0 +1,17 @@
+import duration from './duration';
+import isValidLogLevel from './is-valid-log-level';
+
+const isObject = (thing: any) => {
+  if (Array.isArray(thing) || thing === null || thing instanceof Error) {
+    return false;
+  }
+
+  if (typeof thing === 'object') {
+    return true;
+  }
+  return false;
+};
+
+const isArray = Array.isArray;
+
+export { duration, isValidLogLevel, isObject, isArray };

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -91,6 +91,13 @@ test("don't log null by itself", (t) => {
   t.is(logger._history.length, 0);
 });
 
+test("don't log null by itself in json", (t) => {
+  const logger = createLogger(undefined, { level: 'debug', json: true });
+  logger.log(null);
+
+  t.is(logger._history.length, 0);
+});
+
 test('do log null after a string', (t) => {
   const logger = createLogger(undefined, { level: 'debug' });
   logger.log('result', null);
@@ -116,9 +123,6 @@ test('sanitize: remove object after string', (t) => {
   logger.log('result', {});
 
   const { message } = logger._parse(logger._last);
-  // TODO should this say result null?
-  // I mean, the remove policy says remove the object, so not really
-  // In fact null is an implementation detail, so yes we should not see this
   t.is(message, 'result ');
 });
 

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -84,6 +84,23 @@ test('should log objects as strings', (t) => {
   t.deepEqual(messageObj.a, 22);
 });
 
+test("don't log null by itself", (t) => {
+  const logger = createLogger(undefined, { level: 'debug' });
+  logger.log(null);
+
+  t.is(logger._history.length, 0);
+});
+
+test('do log null after a string', (t) => {
+  const logger = createLogger(undefined, { level: 'debug' });
+  logger.log('result', null);
+
+  t.is(logger._history.length, 1);
+});
+
+// TODO add some sanitise tests here using the policies (including json)
+// TODO don't log null after sanitising
+
 // Automated structural tests per level
 ['always', 'success', 'info', 'debug', 'error', 'warn'].forEach((l) => {
   // Set up some fiddly type aliases

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -98,8 +98,51 @@ test('do log null after a string', (t) => {
   t.is(logger._history.length, 1);
 });
 
-// TODO add some sanitise tests here using the policies (including json)
-// TODO don't log null after sanitising
+test('sanitize: remove object', (t) => {
+  const logger = createLogger(undefined, {
+    level: 'debug',
+    sanitize: 'remove',
+  });
+  logger.log({});
+
+  t.is(logger._history.length, 0);
+});
+
+test('sanitize: remove object after string', (t) => {
+  const logger = createLogger(undefined, {
+    level: 'debug',
+    sanitize: 'remove',
+  });
+  logger.log('result', {});
+
+  const { message } = logger._parse(logger._last);
+  // TODO should this say result null?
+  // I mean, the remove policy says remove the object, so not really
+  // In fact null is an implementation detail, so yes we should not see this
+  t.is(message, 'result ');
+});
+
+test('sanitize: obfuscate object', (t) => {
+  const logger = createLogger(undefined, {
+    level: 'debug',
+    sanitize: 'obfuscate',
+  });
+  logger.log({});
+
+  const { message } = logger._parse(logger._last);
+  t.is(message, '[object]');
+});
+
+test('sanitize: summarise object', (t) => {
+  const logger = createLogger(undefined, {
+    level: 'debug',
+    sanitize: 'summarize',
+  });
+  logger.log({ a: 1 });
+
+  const { message } = logger._parse(logger._last);
+  t.is(message, '(object with keys a)');
+});
 
 // Automated structural tests per level
 ['always', 'success', 'info', 'debug', 'error', 'warn'].forEach((l) => {

--- a/packages/logger/test/sanitize.test.ts
+++ b/packages/logger/test/sanitize.test.ts
@@ -1,7 +1,6 @@
 import test from 'ava';
 
-import sanitize, { isObject, replaceObject, SECRET } from '../src/sanitize';
-
+import sanitize, { SECRET } from '../src/sanitize';
 test('simply return a string', (t) => {
   const result = sanitize('x');
   t.is(result, 'x');
@@ -117,19 +116,14 @@ test('ignore a string with remove', (t) => {
   t.is(result, 'x');
 });
 
-test('sanitize array with remove', (t) => {
-  const result = sanitize([], { policy: 'remove' });
-  t.deepEqual(result, []);
-});
-
-test('sanitize array + items with remove', (t) => {
-  const result = sanitize([1, {}], { policy: 'remove' });
-  t.deepEqual(result, [1, null]);
-});
-
 test('sanitize object with remove', (t) => {
   const result = sanitize({}, { policy: 'remove' });
   t.is(result, null);
+});
+
+test('sanitize array with remove', (t) => {
+  const result = sanitize([1, '2', null, {}], { policy: 'remove' });
+  t.deepEqual(result, null);
 });
 
 test('ignore a string with summarize', (t) => {
@@ -156,47 +150,3 @@ test('sanitize array with summarize', (t) => {
   const result = sanitize([{}, {}, {}], { policy: 'summarize' });
   t.is(result, '(array with 3 items)');
 });
-
-test('isObject: recognise an object', (t) => {
-  t.true(isObject({}));
-
-  t.false(isObject(() => {}));
-  t.false(isObject(null));
-  t.false(isObject(undefined));
-  t.false(isObject(NaN));
-  t.false(isObject([]));
-  // what about errors, do they count?
-  // well, from a sanitisation point of view no, an error is not an object
-  t.false(isObject(new Error()));
-});
-
-test('replace object: one object', (t) => {
-  const result = replaceObject('X', {});
-
-  t.deepEqual(result, 'X');
-});
-
-test('replace object: one array', (t) => {
-  const result = replaceObject('X', []);
-
-  t.deepEqual(result, 'X');
-});
-
-test('replace object: ignore a string', (t) => {
-  const result = replaceObject('X', 'a');
-
-  t.deepEqual(result, 'a');
-});
-
-test('replace object: use function', (t) => {
-  const fn = (x: any) => (Array.isArray(x) ? 'a' : 'o');
-
-  t.deepEqual(replaceObject(fn, []), 'a');
-  t.deepEqual(replaceObject(fn, {}), 'o');
-});
-
-// test('replace object with null', (t) => {
-//   const result = remove({});
-
-//   t.is(result, null);
-// });

--- a/packages/logger/test/sanitize.test.ts
+++ b/packages/logger/test/sanitize.test.ts
@@ -1,6 +1,11 @@
 import test from 'ava';
 
-import sanitize, { SECRET } from '../src/sanitize';
+import sanitize, {
+  remove,
+  isObject,
+  replaceObject,
+  SECRET,
+} from '../src/sanitize';
 
 test('simply return a string', (t) => {
   const result = sanitize('x');
@@ -95,4 +100,53 @@ test('preserve top level stuff after sanitizing', (t) => {
   const json = JSON.parse(result);
 
   t.deepEqual(json, expectedState);
+});
+
+test('isObject: recognise an object', (t) => {
+  t.true(isObject({}));
+
+  t.false(isObject(() => {}));
+  t.false(isObject(null));
+  t.false(isObject(undefined));
+  t.false(isObject(NaN));
+  t.false(isObject([]));
+  // what about errors, do they count?
+  // well, from a sanitisation point of view no, an error is not an object
+  t.false(isObject(new Error()));
+});
+
+test.only('replace object: one object', (t) => {
+  const result = replaceObject('X', {});
+
+  t.deepEqual(result, ['X']);
+});
+
+test.only('replace object: one array', (t) => {
+  const result = replaceObject('X', []);
+
+  t.deepEqual(result, ['X']);
+});
+
+test.only('replace object: ignore a string', (t) => {
+  const result = replaceObject('X', 'a');
+
+  t.deepEqual(result, ['a']);
+});
+
+test.only('replace object: multiple items', (t) => {
+  const result = replaceObject('X', ['a'], {}, 'a', 2);
+
+  t.deepEqual(result, ['X', 'X', 'a', 2]);
+});
+
+test.only('replace object: use function', (t) => {
+  const result = replaceObject((x) => (Array.isArray(x) ? 'a' : 'o'), [], {});
+
+  t.deepEqual(result, ['a', 'o']);
+});
+
+test('replace object with null', (t) => {
+  const result = remove({});
+
+  t.is(result, null);
 });

--- a/packages/logger/test/sanitize.test.ts
+++ b/packages/logger/test/sanitize.test.ts
@@ -147,6 +147,16 @@ test('sanitize object with summarize', (t) => {
   t.is(result, '(object with keys a, b)');
 });
 
+test('sanitize empty array with summarize', (t) => {
+  const result = sanitize([], { policy: 'summarize' });
+  t.is(result, '(empty array)');
+});
+
+test('sanitize array with summarize', (t) => {
+  const result = sanitize([{}, {}, {}], { policy: 'summarize' });
+  t.is(result, '(array with 3 items)');
+});
+
 test('isObject: recognise an object', (t) => {
   t.true(isObject({}));
 

--- a/packages/logger/test/util/is-object.test.ts
+++ b/packages/logger/test/util/is-object.test.ts
@@ -1,0 +1,13 @@
+import test from 'ava';
+import { isObject } from '../../src/util/';
+
+test('an object', (t) => {
+  t.true(isObject({}));
+
+  t.false(isObject(() => {}));
+  t.false(isObject(null));
+  t.false(isObject(undefined));
+  t.false(isObject(NaN));
+  t.false(isObject([]));
+  t.false(isObject(new Error()));
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       '@openfn/runtime':
         specifier: workspace:*
         version: link:../runtime
+      chalk:
+        specifier: ^5.1.2
+        version: 5.3.0
       figures:
         specifier: ^5.0.0
         version: 5.0.0
@@ -3245,6 +3248,7 @@ packages:
   /esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
     engines: {node: '>=6'}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -3974,6 +3978,7 @@ packages:
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       safer-buffer: 2.1.2
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,15 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
 
+  integration-tests/cli/repo:
+    dependencies:
+      '@openfn/language-common_1.10.3':
+        specifier: npm:@openfn/language-common@^1.10.3
+        version: /@openfn/language-common@1.10.3
+      '@openfn/language-http_5.0.2':
+        specifier: npm:@openfn/language-http@^5.0.2
+        version: /@openfn/language-http@5.0.2
+
   packages/cli:
     dependencies:
       '@inquirer/prompts':
@@ -1160,6 +1169,19 @@ packages:
       semver: 7.5.4
     dev: true
 
+  /@openfn/language-common@1.10.3:
+    resolution: {integrity: sha512-abFOM/aj/L7qhiQEJyxX95HL2mARINNfXEt/SUcdMKcbENSbu+KRKGv7spBrn72PJ9pngo4/+OWxmQzzt4FEfQ==}
+    dependencies:
+      axios: 1.1.3
+      csv-parse: 5.4.0
+      csvtojson: 2.0.10
+      date-fns: 2.30.0
+      jsonpath-plus: 4.0.0
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@openfn/language-common@1.7.5:
     resolution: {integrity: sha512-QivV3v5Oq5fb4QMopzyqUUh+UGHaFXBdsGr6RCmu6bFnGXdJdcQ7GpGpW5hKNq29CkmE23L/qAna1OLr4rP/0w==}
     dependencies:
@@ -1174,6 +1196,22 @@ packages:
   /@openfn/language-common@2.0.0-rc3:
     resolution: {integrity: sha512-7kwhBnCd1idyTB3MD9dXmUqROAhoaUIkz2AGDKuv9vn/cbZh7egEv9/PzKkRcDJYFV9qyyS+cVT3Xbgsg2ii5g==}
     bundledDependencies: []
+
+  /@openfn/language-http@5.0.2:
+    resolution: {integrity: sha512-jSfMcObunuxsbv/nc3HtOOurw1kv1cPf1NmytZxr4x9E+zZGynQjt4GXbNeQEEAtABX9mcsl3F1k2N+IMsyHpQ==}
+    dependencies:
+      '@openfn/language-common': 1.10.3
+      cheerio: 1.0.0-rc.12
+      cheerio-tableparser: 1.0.1
+      csv-parse: 4.16.3
+      fast-safe-stringify: 2.1.1
+      form-data: 3.0.1
+      lodash: 4.17.21
+      request: 2.88.2
+      tough-cookie: 4.1.3
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1602,6 +1640,15 @@ packages:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
+  /ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+    dev: false
+
   /ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -1738,6 +1785,17 @@ packages:
     resolution: {integrity: sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==}
     engines: {node: '>=12'}
 
+  /asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
+
+  /assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+    dev: false
+
   /assign-symbols@1.0.0:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
     engines: {node: '>=0.10.0'}
@@ -1763,7 +1821,6 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
 
   /atob@2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
@@ -1835,6 +1892,14 @@ packages:
       fast-glob: 3.3.1
     dev: true
 
+  /aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+    dev: false
+
+  /aws4@1.12.0:
+    resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
+    dev: false
+
   /axios@0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
@@ -1852,7 +1917,6 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
-    dev: true
 
   /b4a@1.6.1:
     resolution: {integrity: sha512-AsKjNhz72yxteo/0EtQEiwkMUgk/tGmycXlbG4g3Ard2/ULtNLUykGOkeK0egmN27h0xMAhb76jYccW+XTBExA==}
@@ -1888,6 +1952,12 @@ packages:
   /batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
     dev: true
+
+  /bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+    dependencies:
+      tweetnacl: 0.14.5
+    dev: false
 
   /bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
@@ -1933,8 +2003,16 @@ packages:
       readable-stream: 4.2.0
     dev: true
 
+  /bluebird@3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+    dev: false
+
   /blueimp-md5@2.19.0:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
+
+  /boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: false
 
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -2106,6 +2184,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
+    dev: false
+
   /cbor@8.1.0:
     resolution: {integrity: sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==}
     engines: {node: '>=12.19'}
@@ -2139,6 +2221,34 @@ packages:
 
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  /cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.1.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+    dev: false
+
+  /cheerio-tableparser@1.0.1:
+    resolution: {integrity: sha512-SCSWdMoFvIue0jdFZqRNPXDCZ67vuirJEG3pfh3AAU2hwxe/qh1EQUkUNPWlZhd6DMjRlTfcpcPWbaowjwRnNQ==}
+    dev: false
+
+  /cheerio@1.0.0-rc.12:
+    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
+    engines: {node: '>= 6'}
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      htmlparser2: 8.0.2
+      parse5: 7.1.2
+      parse5-htmlparser2-tree-adapter: 7.0.0
+    dev: false
 
   /chokidar@2.1.8:
     resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
@@ -2310,7 +2420,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -2381,6 +2490,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+    dev: false
+
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
@@ -2431,6 +2544,21 @@ packages:
       which: 2.0.2
     dev: true
 
+  /css-select@5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      nth-check: 2.1.1
+    dev: false
+
+  /css-what@6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
+    dev: false
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -2447,7 +2575,10 @@ packages:
 
   /csv-parse@4.16.3:
     resolution: {integrity: sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==}
-    dev: true
+
+  /csv-parse@5.4.0:
+    resolution: {integrity: sha512-JiQosUWiOFgp4hQn0an+SBoV9IKdqzhROM0iiN4LB7UpfJBlsSJlWl9nq4zGgxgMAzHJ6V4t29VAVD+3+2NJAg==}
+    dev: false
 
   /csv-stringify@5.6.5:
     resolution: {integrity: sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==}
@@ -2463,11 +2594,28 @@ packages:
       stream-transform: 2.1.3
     dev: true
 
+  /csvtojson@2.0.10:
+    resolution: {integrity: sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+    dependencies:
+      bluebird: 3.7.2
+      lodash: 4.17.21
+      strip-bom: 2.0.0
+    dev: false
+
   /currently-unhandled@0.4.1:
     resolution: {integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==}
     engines: {node: '>=0.10.0'}
     dependencies:
       array-find-index: 1.0.2
+
+  /dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      assert-plus: 1.0.0
+    dev: false
 
   /date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
@@ -2584,7 +2732,6 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -2635,6 +2782,33 @@ packages:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
     dev: true
 
+  /dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+    dev: false
+
+  /domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
+
+  /domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
+  /domutils@3.1.0:
+    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+    dev: false
+
   /dreamopt@0.8.0:
     resolution: {integrity: sha512-vyJTp8+mC+G+5dfgsY+r3ckxlz+QMX40VjPQsZc5gxVAxLmi64TBoVkP54A/pRAXMXsbu2GMMBrZPxNv23waMg==}
     engines: {node: '>=0.4.0'}
@@ -2657,6 +2831,13 @@ packages:
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  /ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+    dev: false
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -2695,6 +2876,11 @@ packages:
     dependencies:
       ansi-colors: 4.1.3
     dev: true
+
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+    dev: false
 
   /err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -3352,6 +3538,10 @@ packages:
       is-extendable: 1.0.1
     dev: true
 
+  /extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: false
+
   /extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
     dev: true
@@ -3379,6 +3569,15 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+    dev: false
+
+  /fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: false
 
   /fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
@@ -3421,6 +3620,10 @@ packages:
 
   /fast-json-patch@3.1.1:
     resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
+    dev: false
+
+  /fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: false
 
   /fast-levenshtein@2.0.6:
@@ -3532,7 +3735,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: true
 
   /for-in@1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
@@ -3547,6 +3749,19 @@ packages:
       signal-exit: 4.0.2
     dev: true
 
+  /forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+    dev: false
+
+  /form-data@2.3.3:
+    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
+
   /form-data@2.5.1:
     resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
     engines: {node: '>= 0.12'}
@@ -3556,6 +3771,15 @@ packages:
       mime-types: 2.1.35
     dev: true
 
+  /form-data@3.0.1:
+    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
+
   /form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
@@ -3563,7 +3787,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: true
 
   /fragment-cache@0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
@@ -3682,6 +3905,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+    dependencies:
+      assert-plus: 1.0.0
+    dev: false
+
   /glob-parent@3.1.0:
     resolution: {integrity: sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==}
     dependencies:
@@ -3788,6 +4017,20 @@ packages:
       through2: 2.0.5
     dev: true
 
+  /har-schema@2.0.0:
+    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /har-validator@5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
+    dependencies:
+      ajv: 6.12.6
+      har-schema: 2.0.0
+    dev: false
+
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
@@ -3875,6 +4118,15 @@ packages:
       lru-cache: 7.18.3
     dev: true
 
+  /htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
+    dev: false
+
   /http-assert@1.5.0:
     resolution: {integrity: sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==}
     engines: {node: '>= 0.8'}
@@ -3943,6 +4195,15 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /http-signature@1.2.0:
+    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
+    engines: {node: '>=0.8', npm: '>=1.3.7'}
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.17.0
+    dev: false
 
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -4318,6 +4579,10 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
+  /is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+    dev: false
+
   /is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
@@ -4326,6 +4591,10 @@ packages:
   /is-unicode-supported@1.3.0:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
     engines: {node: '>=12'}
+
+  /is-utf8@0.2.1:
+    resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
+    dev: false
 
   /is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
@@ -4363,6 +4632,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
+    dev: false
+
   /jackspeak@2.2.2:
     resolution: {integrity: sha512-mgNtVv4vUuaKA97yxUHoA3+FkuhtxkjdXEWOyB/N76fjy0FjezEt34oy3epBtvCvS+7DyKwqCFWx/oJLV5+kCg==}
     engines: {node: '>=14'}
@@ -4399,6 +4672,10 @@ packages:
       argparse: 2.0.1
     dev: true
 
+  /jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+    dev: false
+
   /json-diff@1.0.6:
     resolution: {integrity: sha512-tcFIPRdlc35YkYdGxcamJjllUhXWv4n2rK9oJ2RsAzV4FBkuV4ojKEDgcZ+kpKxDmJKv+PFK65+1tVVOnSeEqA==}
     hasBin: true
@@ -4411,6 +4688,18 @@ packages:
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: true
+
+  /json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    dev: false
+
+  /json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+    dev: false
+
+  /json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+    dev: false
 
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -4426,7 +4715,6 @@ packages:
   /jsonpath-plus@4.0.0:
     resolution: {integrity: sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==}
     engines: {node: '>=10.0'}
-    dev: true
 
   /jsonpath@1.1.1:
     resolution: {integrity: sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==}
@@ -4435,6 +4723,16 @@ packages:
       static-eval: 2.0.2
       underscore: 1.12.1
     dev: true
+
+  /jsprim@1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+    dev: false
 
   /keygrip@1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
@@ -5115,6 +5413,16 @@ packages:
       path-key: 3.1.1
     dev: true
 
+  /nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+    dependencies:
+      boolbase: 1.0.0
+    dev: false
+
+  /oauth-sign@0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+    dev: false
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -5385,6 +5693,19 @@ packages:
     resolution: {integrity: sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==}
     engines: {node: '>=12'}
 
+  /parse5-htmlparser2-tree-adapter@7.0.0:
+    resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.1.2
+    dev: false
+
+  /parse5@7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+    dependencies:
+      entities: 4.5.0
+    dev: false
+
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -5452,6 +5773,10 @@ packages:
       duplexify: 3.7.1
       through2: 2.0.5
     dev: true
+
+  /performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+    dev: false
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -5656,7 +5981,6 @@ packages:
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: true
 
   /proxy-middleware@0.15.0:
     resolution: {integrity: sha512-EGCG8SeoIRVMhsqHQUdDigB2i7qU7fCsWASwn54+nPutYO8n4q6EiwMzyfWlC+dzRFExP+kvcnDFdBDHoZBU7Q==}
@@ -5666,6 +5990,10 @@ packages:
   /pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
     dev: true
+
+  /psl@1.9.0:
+    resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
+    dev: false
 
   /pstree.remy@1.1.8:
     resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
@@ -5689,7 +6017,15 @@ packages:
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
-    dev: true
+
+  /qs@6.5.3:
+    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
+    engines: {node: '>=0.6'}
+    dev: false
+
+  /querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+    dev: false
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5865,6 +6201,33 @@ packages:
     engines: {node: '>=0.10'}
     dev: true
 
+  /request@2.88.2:
+    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
+    engines: {node: '>= 6'}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.12.0
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.3
+      safe-buffer: 5.2.1
+      tough-cookie: 2.5.0
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
+    dev: false
+
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -5872,6 +6235,10 @@ packages:
   /require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
     dev: true
+
+  /requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+    dev: false
 
   /resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -6277,6 +6644,22 @@ packages:
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  /sshpk@1.17.0:
+    resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+    dev: false
+
   /ssri@10.0.4:
     resolution: {integrity: sha512-12+IR2CB2C28MMAw0Ncqwj5QbTcs0nGIhgJzYWzDkb21vWmfNI83KS4f3Ci6GI98WreIfG7o9UXp3C0qbpA8nQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -6385,6 +6768,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
+
+  /strip-bom@2.0.0:
+    resolution: {integrity: sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-utf8: 0.2.1
+    dev: false
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -6602,6 +6992,24 @@ packages:
     dependencies:
       nopt: 1.0.10
     dev: true
+
+  /tough-cookie@2.5.0:
+    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
+    engines: {node: '>=0.8'}
+    dependencies:
+      psl: 1.9.0
+      punycode: 2.3.0
+    dev: false
+
+  /tough-cookie@4.1.3:
+    resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
+    engines: {node: '>=6'}
+    dependencies:
+      psl: 1.9.0
+      punycode: 2.3.0
+      universalify: 0.2.0
+      url-parse: 1.5.10
+    dev: false
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -6862,6 +7270,16 @@ packages:
       yargs: 17.7.2
     dev: true
 
+  /tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
+  /tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+    dev: false
+
   /type-check@0.3.2:
     resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
     engines: {node: '>= 0.8.0'}
@@ -6969,6 +7387,11 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
+  /universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+    dev: false
+
   /unix-crypt-td-js@1.1.4:
     resolution: {integrity: sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==}
     dev: true
@@ -6991,6 +7414,12 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    dependencies:
+      punycode: 2.3.0
+    dev: false
+
   /urix@0.1.0:
     resolution: {integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==}
     deprecated: Please see https://github.com/lydell/urix#deprecated
@@ -6999,6 +7428,13 @@ packages:
   /url-join@5.0.0:
     resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
+
+  /url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
     dev: false
 
   /use@3.1.1:
@@ -7019,7 +7455,6 @@ packages:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
-    dev: true
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -7041,6 +7476,15 @@ packages:
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  /verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
+    dev: false
 
   /wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}


### PR DESCRIPTION
## Short Description

This PR adds options to "sanitise" output in the logger.

Which basically means: if someone tries to log state in a production environment, the logger should automatically remove or obfuscate it.

This PR adds three options: obfuscate, summarize, or remove. By default it will not attempt to sanitize objects (except for state, where we ALWAYS sanitize config), because the CLI is primarily developer tooling.

See the comment below for examples.

## Related issue

Fixes #314 (and I think #211  can be closed out now too)

## Implementation Details

The logger itself takes a `sanitize` argument with different "policies" for what to do when an object or array is logged.

The CLI accepts this as an input and feeds it through to the logger.

If you try and pass an unknown sanitize value, the CLI will abort in very dramatic circumstances (before running any of the job pipeline). That's because if you want to sanitize your output and you make a typo in the argument, it would be irresponsible to run. You're basically telling us you're trying to run in a sensitive production environment where you don't want to log anything.  In practice, of course, this will never happen because those environments are automated. And if you mis-spell "sanitize" I can't help you. But still, one day this might help someone out.

Note that this doesn't yet affect lightning at all - lightning will need to pass an extra flag to the CLI.

## QA Notes

The best way to test this is to create a job which logs some complex values, and see how the logger handles it with different sanitize options.

First install the dev build of openfn, called `openfnx`. From root, do:

`pnpm install && pnpm install:openfx`

(this will build for you and install a global command called `openfnx`)

Then you'll need a test job to run. Here's a simple one:

```
// job.js
fn((s) => {
  console.log({});
  return s;
});
```

Then run this from the CLI. You probably want to do this from a temp directory lest you accidentally check in stuff to the repo@
```
openfnx job.js -ia common --sanitize=summarize
```
Look out for the `[JOB]` log line - that's the bit emitted by your job code, and the bit that should be sanitized.

You can drop the `-i` flag after you've run the job for the first time (it'll run a bit quicker then)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added unit tests
- [ ] Changesets have been added (if there are production code changes)
