### PR TITLE
Deploy: fix typings

### DIFF
--- a/packages/cli/state.json
+++ b/packages/cli/state.json
@@ -1,9 +1,0 @@
-export default [fn((state) => {
-  console.log('multiplying by two');
-  state.data.value *= 2;
-  return state;
-}), fn((state) => {
-  console.log('multiplying by three');
-  state.data.value *= 3;
-  return state;
-})];

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "test": "pnpm ava",
     "test:watch": "pnpm ava -w",
-    "_test:types": "pnpm tsc --noEmit --project tsconfig.json --excludeDirectories test",
+    "test:types": "pnpm tsc --noEmit --project tsconfig.json --excludeDirectories test",
     "build": "tsup --config ../../tsup.config.js src/index.ts",
     "build:watch": "pnpm build --watch",
     "pack": "pnpm pack --pack-destination ../../dist"

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "test": "pnpm ava",
     "test:watch": "pnpm ava -w",
-    "test:types": "pnpm tsc --noEmit --project tsconfig.json --excludeDirectories test",
+    "test:types": "pnpm tsc --project tsconfig.test.json",
     "build": "tsup --config ../../tsup.config.js src/index.ts",
     "build:watch": "pnpm build --watch",
     "pack": "pnpm pack --pack-destination ../../dist"

--- a/packages/deploy/src/stateTransform.ts
+++ b/packages/deploy/src/stateTransform.ts
@@ -77,9 +77,12 @@ function pickValue(
   return defaultValue;
 }
 
-function mergeTriggers(stateTriggers, specTriggers): WorkflowState['triggers'] {
+function mergeTriggers(
+  stateTriggers: WorkflowState['triggers'],
+  specTriggers: WorkflowSpec['triggers']
+): WorkflowState['triggers'] {
   return Object.fromEntries(
-    splitZip(stateTriggers, specTriggers).map(
+    splitZip(stateTriggers, specTriggers!).map(
       ([triggerKey, stateTrigger, specTrigger]) => {
         if (specTrigger && !stateTrigger) {
           return [
@@ -95,21 +98,18 @@ function mergeTriggers(stateTriggers, specTriggers): WorkflowState['triggers'] {
         }
 
         if (!specTrigger && stateTrigger) {
-          return [
-            triggerKey,
-            { ...pickKeys(stateTrigger, ['id']), delete: true },
-          ];
+          return [triggerKey, { id: stateTrigger!.id, delete: true }];
         }
 
         // prefer spec, but use state if spec is missing, or default
         return [
           triggerKey,
           {
-            id: stateTrigger.id,
+            id: stateTrigger!.id,
             ...{
-              type: pickValue(specTrigger, stateTrigger, 'type', 'webhook'),
-              ...(specTrigger.type === 'cron'
-                ? { cron_expression: specTrigger.cron_expression }
+              type: pickValue(specTrigger!, stateTrigger!, 'type', 'webhook'),
+              ...(specTrigger!.type === 'cron'
+                ? { cron_expression: specTrigger!.cron_expression }
                 : {}),
             },
           },
@@ -131,19 +131,20 @@ function mergeEdges(
         function convertToStateEdge(
           jobs: WorkflowState['jobs'],
           triggers: WorkflowState['triggers'],
-          specEdge: SpecEdge
+          specEdge: SpecEdge,
+          id: string
         ): StateEdge {
-          let edge: StateEdge = {
-            condition: specEdge.condition || null,
-            source_job_id: specEdge.source_job
-              ? jobs[specEdge.source_job].id
-              : null,
-            source_trigger_id: specEdge.source_trigger
-              ? triggers[specEdge.source_trigger].id
-              : null,
-            target_job_id: specEdge.target_job
-              ? jobs[specEdge.target_job].id
-              : null,
+          const edge: StateEdge = {
+            id,
+            condition: specEdge.condition,
+            source_job_id:
+              (specEdge.source_job && jobs[specEdge.source_job].id) ?? null,
+            source_trigger_id:
+              (specEdge.source_trigger &&
+                triggers[specEdge.source_trigger].id) ??
+              null,
+            target_job_id:
+              (specEdge.target_job && jobs[specEdge.target_job].id) ?? '',
           };
 
           return edge;
@@ -152,23 +153,17 @@ function mergeEdges(
         if (specEdge && !stateEdge) {
           return [
             edgeKey,
-            {
-              ...convertToStateEdge(jobs, triggers, specEdge),
-              id: crypto.randomUUID(),
-            },
+            convertToStateEdge(jobs, triggers, specEdge, crypto.randomUUID()),
           ];
         }
 
         if (!specEdge && stateEdge) {
-          return [edgeKey, { ...pickKeys(stateEdge, ['id']), delete: true }];
+          return [edgeKey, { id: stateEdge.id, delete: true }];
         }
 
         return [
           edgeKey,
-          {
-            ...convertToStateEdge(jobs, triggers, specEdge!),
-            id: stateEdge!.id,
-          },
+          convertToStateEdge(jobs, triggers, specEdge!, stateEdge!.id),
         ];
       }
     )
@@ -183,25 +178,23 @@ export function mergeSpecIntoState(
   const nextWorkflows = Object.fromEntries(
     splitZip(oldState.workflows, spec.workflows).map(
       ([workflowKey, stateWorkflow, specWorkflow]) => {
-        stateWorkflow = stateWorkflow || {};
-
         const nextJobs = mergeJobs(
-          stateWorkflow.jobs || {},
+          stateWorkflow?.jobs || {},
           specWorkflow?.jobs || {}
         );
 
         const nextTriggers = mergeTriggers(
-          stateWorkflow.triggers || {},
+          stateWorkflow?.triggers || {},
           specWorkflow?.triggers || {}
         );
 
         const nextEdges = mergeEdges(
           deepClone({ jobs: nextJobs, triggers: nextTriggers }),
-          stateWorkflow.edges || {},
+          stateWorkflow?.edges || {},
           specWorkflow?.edges || {}
         );
 
-        if (specWorkflow && isEmpty(stateWorkflow)) {
+        if (specWorkflow && isEmpty(stateWorkflow || {})) {
           return [
             workflowKey,
             {
@@ -218,8 +211,8 @@ export function mergeSpecIntoState(
           workflowKey,
           {
             ...stateWorkflow,
-            id: stateWorkflow.id,
-            name: specWorkflow.name,
+            id: stateWorkflow!.id,
+            name: specWorkflow!.name,
             jobs: nextJobs,
             triggers: nextTriggers,
             edges: nextEdges,
@@ -251,25 +244,34 @@ export function mergeProjectPayloadIntoState(
   const nextWorkflows = Object.fromEntries(
     idKeyPairs(project.workflows, state.workflows).map(
       ([key, nextWorkflow, _state]) => {
-        nextWorkflow.jobs = Object.fromEntries(
+        const { id, name } = nextWorkflow;
+
+        const jobs = Object.fromEntries(
           idKeyPairs(nextWorkflow.jobs, state.workflows[key].jobs).map(
             ([key, nextJob, _state]) => [key, nextJob]
           )
         );
-
-        nextWorkflow.triggers = Object.fromEntries(
+        const triggers = Object.fromEntries(
           idKeyPairs(nextWorkflow.triggers, state.workflows[key].triggers).map(
             ([key, nextTrigger, _state]) => [key, nextTrigger]
           )
         );
-
-        nextWorkflow.edges = Object.fromEntries(
+        const edges = Object.fromEntries(
           idKeyPairs(nextWorkflow.edges, state.workflows[key].edges).map(
             ([key, nextEdge, _state]) => [key, nextEdge]
           )
         );
 
-        return [key, nextWorkflow];
+        return [
+          key,
+          {
+            id,
+            name,
+            jobs,
+            triggers,
+            edges,
+          },
+        ];
       }
     )
   );

--- a/packages/deploy/src/stateTransform.ts
+++ b/packages/deploy/src/stateTransform.ts
@@ -310,15 +310,9 @@ export function toProjectPayload(state: ProjectState): ProjectPayload {
 
     return {
       ...workflow,
-      jobs: Object.values(
-        workflow.jobs
-      ) as ProjectPayload['workflows'][0]['jobs'],
-      triggers: Object.values(
-        workflow.triggers
-      ) as ProjectPayload['workflows'][0]['triggers'],
-      edges: Object.values(
-        workflow.edges
-      ) as ProjectPayload['workflows'][0]['edges'],
+      jobs: Object.values(workflow.jobs),
+      triggers: Object.values(workflow.triggers),
+      edges: Object.values(workflow.edges),
     };
   });
 

--- a/packages/deploy/src/stateTransform.ts
+++ b/packages/deploy/src/stateTransform.ts
@@ -136,7 +136,7 @@ function mergeEdges(
         ): StateEdge {
           const edge: StateEdge = {
             id,
-            condition: specEdge.condition,
+            condition: specEdge.condition ?? null,
             source_job_id:
               (specEdge.source_job && jobs[specEdge.source_job].id) ?? null,
             source_trigger_id:

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -16,7 +16,7 @@ export type Trigger = {
 
 export type StateEdge = {
   id: string;
-  condition: string;
+  condition: string | null;
   source_job_id: string | null;
   source_trigger_id: string | null;
   target_job_id: string;
@@ -46,9 +46,9 @@ export interface ProjectSpec {
 export interface WorkflowState {
   id: string;
   name: string;
-  jobs: Record<string | symbol, Job>;
-  triggers: Record<string | symbol, Trigger>;
-  edges: Record<string | symbol, StateEdge>;
+  jobs: Record<string | symbol, Concrete<Job>>;
+  triggers: Record<string | symbol, Concrete<Trigger>>;
+  edges: Record<string | symbol, Concrete<StateEdge>>;
   delete?: boolean;
 }
 

--- a/packages/deploy/tsconfig.test.json
+++ b/packages/deploy/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.common",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "module": "esnext",
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
Fixes #355 

The deploy command starts failing when `mergeSpecIntoState` is exported from `deploy`. I think this is a result of extra rigidity on the type constraints we added recently, and maybe the typescript version bump.

This PR goes through  and addresses any type issues that get raised. A lot of them are bludgeoned over. I've had to make a few refactors for others. I've tried to not change any functionality but it's pretty complex in there and there will be diffs in the built JS.

I have no means of testing this so maybe someone can take a look before I merge?