### PR TITLE
Log levels can be specified anywhere in the command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -225,7 +225,7 @@ The CLI is actually a collection of packages, each of which will log with slight
 
 The CLI will log information at three different levels of verbosity: `default`, `info` and `debug` (`none` is also supported).
 
-To set the log level, pass `--log info` into your command. You can configure this for individual packages, ie `--log cmp=debug` will run the compiler with debug logging but leave everything else at default.
+To set the log level, pass `--log info` into your command. You can configure this for individual packages, ie `--log cmp=debug` will run the compiler with debug logging but leave everything else at default. To control multiple components, use comma-seperated values, ie, `--log debug,r/t=none,job=info`
 
 Note that, unless explicitly overriden, jobs will always report at debug verbosity (meaning job logging will always be shown).
 

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -233,7 +233,7 @@ export const log: CLIOption = {
   yargs: {
     alias: ['l'],
     description: 'Set the log level',
-    array: true,
+    string: true,
   },
   ensure: (opts: any) => {
     ensureLogOpts(opts);

--- a/packages/cli/src/util/ensure-log-opts.ts
+++ b/packages/cli/src/util/ensure-log-opts.ts
@@ -20,7 +20,7 @@ const componentShorthands: Record<string, string> = {
 
 type IncomingOpts = {
   command?: string;
-  log?: string[];
+  log?: string;
 };
 
 const ensureLogOpts = (opts: IncomingOpts) => {
@@ -36,9 +36,10 @@ const ensureLogOpts = (opts: IncomingOpts) => {
     return outgoingOpts;
   }
 
-  if (opts?.log) {
+  if (opts.log) {
     // Parse and validate each incoming log argument
-    opts.log!.forEach((l: string) => {
+    const parts = opts.log.split(',');
+    parts.forEach((l: string) => {
       let component = '';
       let level = '';
 

--- a/packages/cli/test/options/execute.test.ts
+++ b/packages/cli/test/options/execute.test.ts
@@ -48,8 +48,8 @@ test('execute: log debug', (t) => {
 });
 
 // These aren't supposed to be exhaustive, just testing the surface a but
-test('execute: compiler & runtime in debug', (t) => {
-  const options = parse('execute job.js --log compiler=debug runtime=debug');
+test.only('execute: compiler & runtime in debug', (t) => {
+  const options = parse('execute job.js --log compiler=debug,runtime=debug');
   t.deepEqual(options.log, {
     default: 'default',
     compiler: 'debug',
@@ -58,9 +58,15 @@ test('execute: compiler & runtime in debug', (t) => {
   });
 });
 
-test('execute: log debug by default but job none', (t) => {
-  const options = parse('execute job.js --log debug job=none');
+test.only('execute: log debug by default but job none', (t) => {
+  const options = parse('execute job.js --log debug,job=none');
   t.deepEqual(options.log, { default: 'debug', job: 'none' });
+});
+
+test.only("execute: log levels don't have to be at the end of a command", (t) => {
+  const options = parse('execute job.js --log debug,job=none --log-json');
+  t.deepEqual(options.log, { default: 'debug', job: 'none' });
+  t.true(options.logJson);
 });
 
 test('execute: throw for invalid log', (t) => {

--- a/packages/cli/test/options/execute.test.ts
+++ b/packages/cli/test/options/execute.test.ts
@@ -47,8 +47,8 @@ test('execute: log debug', (t) => {
   t.deepEqual(options.log, { default: 'debug', job: 'debug' });
 });
 
-// These aren't supposed to be exhaustive, just testing the surface a but
-test.only('execute: compiler & runtime in debug', (t) => {
+// These aren't supposed to be exhaustive, just testing the surface a bit
+test('execute: compiler & runtime in debug', (t) => {
   const options = parse('execute job.js --log compiler=debug,runtime=debug');
   t.deepEqual(options.log, {
     default: 'default',
@@ -58,12 +58,12 @@ test.only('execute: compiler & runtime in debug', (t) => {
   });
 });
 
-test.only('execute: log debug by default but job none', (t) => {
+test('execute: log debug by default but job none', (t) => {
   const options = parse('execute job.js --log debug,job=none');
   t.deepEqual(options.log, { default: 'debug', job: 'none' });
 });
 
-test.only("execute: log levels don't have to be at the end of a command", (t) => {
+test("execute: log levels don't have to be at the end of a command", (t) => {
   const options = parse('execute job.js --log debug,job=none --log-json');
   t.deepEqual(options.log, { default: 'debug', job: 'none' });
   t.true(options.logJson);

--- a/packages/cli/test/util/ensure-opts.test.ts
+++ b/packages/cli/test/util/ensure-opts.test.ts
@@ -1,5 +1,4 @@
 import test from 'ava';
-import { Opts } from '../../src/options';
 import ensureLogOpts, {
   defaultLoggerOptions,
   ERROR_MESSAGE_LOG_LEVEL,
@@ -18,7 +17,7 @@ test('log: add default options', (t) => {
 
 test('log: override default options', (t) => {
   const initialOpts = {
-    log: ['debug'],
+    log: 'debug',
   };
 
   const opts = ensureLogOpts(initialOpts);
@@ -28,7 +27,7 @@ test('log: override default options', (t) => {
 
 test('log: set a specific option', (t) => {
   const initialOpts = {
-    log: ['compiler=debug'],
+    log: 'compiler=debug',
   };
 
   const opts = ensureLogOpts(initialOpts);
@@ -38,7 +37,7 @@ test('log: set a specific option', (t) => {
 
 test('log: throw if an unknown log level is passed', (t) => {
   const initialOpts = {
-    log: ['foo'],
+    log: 'foo',
   };
 
   const error = t.throws(() => ensureLogOpts(initialOpts));
@@ -47,7 +46,7 @@ test('log: throw if an unknown log level is passed', (t) => {
 
 test('log: throw if an unknown log level is passed to a component', (t) => {
   const initialOpts = {
-    log: ['cli=foo'],
+    log: 'cli=foo',
   };
 
   const error = t.throws(() => ensureLogOpts(initialOpts));
@@ -56,7 +55,7 @@ test('log: throw if an unknown log level is passed to a component', (t) => {
 
 test('log: throw if an unknown log component is passed', (t) => {
   const initialOpts = {
-    log: ['foo=debug'],
+    log: 'foo=debug',
   };
 
   const error = t.throws(() => ensureLogOpts(initialOpts));
@@ -65,7 +64,7 @@ test('log: throw if an unknown log component is passed', (t) => {
 
 test('log: accept short component names', (t) => {
   const initialOpts = {
-    log: ['cmp=debug', 'r/t=debug'],
+    log: 'cmp=debug,r/t=debug',
   };
 
   const opts = ensureLogOpts(initialOpts);
@@ -76,7 +75,7 @@ test('log: accept short component names', (t) => {
 
 test('log: arguments are case insensitive', (t) => {
   const initialOpts = {
-    log: ['ClI=InFo'],
+    log: 'ClI=InFo',
   };
 
   const opts = ensureLogOpts(initialOpts);
@@ -86,7 +85,7 @@ test('log: arguments are case insensitive', (t) => {
 
 test('log: set default and a specific option', (t) => {
   const initialOpts = {
-    log: ['none', 'compiler=debug'],
+    log: 'none,compiler=debug',
   };
 
   const opts = ensureLogOpts(initialOpts);


### PR DESCRIPTION
## Short Description

This PR changes how log levels are parsed in the CLI's `--log` option, using commas rather than spaces to configure logs for multiple components.

## Related issue

Fixes #190

## Implementation Details

Until now, yargs has greedily parsed log levels as an array, so if you want to specify multiple log levels, you had to do it at the end of the command.
```
openfn job.js --log compiler=debug runtime=debug
```
This PR changes the yargs parser to treat log options as a string, and we split it by comma
```
openfn job.js --log compiler=debug,runtime=debug
```

This is much cleaner for users.

It's a nice simple change which breaks a satisfying number of tests.

## Lightning Note

Does this break anything in lightning? I don't think it's passing in multiple log levels right now, so it shouldn't do.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added unit tests
- [ ] Changesets have been added (if there are production code changes)
