### PR TITLE
Runtime: ensure state.data can be an array

### DIFF
--- a/.changeset/afraid-grapes-impress.md
+++ b/.changeset/afraid-grapes-impress.md
@@ -1,0 +1,6 @@
+---
+'@openfn/runtime': patch
+---
+
+Ensure data can be an array
+Fix an issue where string next links in a workflow could use the wrong prior state

--- a/packages/runtime/src/execute/compile-plan.ts
+++ b/packages/runtime/src/execute/compile-plan.ts
@@ -60,7 +60,7 @@ const findUpstream = (plan: ExecutionPlan, id: string) => {
     if (job.next)
       if (typeof job.next === 'string') {
         if (job.next === id) {
-          return job.next;
+          return job.id;
         }
       } else if (job.next[id]) {
         return job.id;

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -111,8 +111,6 @@ const assignKeys = (
 // TODO this is suboptimal and may be slow on large objects
 // (especially as the result get stringified again downstream)
 const prepareFinalState = (opts: Options, state: any) => {
-  // console.log('final state: ', state);
-  // console.log(opts.strict);
   if (state) {
     if (opts.strict) {
       state = assignKeys(state, {}, ['data', 'error', 'references']);

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -111,6 +111,8 @@ const assignKeys = (
 // TODO this is suboptimal and may be slow on large objects
 // (especially as the result get stringified again downstream)
 const prepareFinalState = (opts: Options, state: any) => {
+  // console.log('final state: ', state);
+  // console.log(opts.strict);
   if (state) {
     if (opts.strict) {
       state = assignKeys(state, {}, ['data', 'error', 'references']);

--- a/packages/runtime/src/execute/plan.ts
+++ b/packages/runtime/src/execute/plan.ts
@@ -64,7 +64,9 @@ const executePlan = async (
       job.state,
       ctx.opts.strict
     );
+    console.log(job.id, state);
     const result = await executeJob(ctx, job, state);
+    console.log('result >', result);
     stateHistory[next] = result.state;
 
     if (!result.next.length) {

--- a/packages/runtime/src/execute/plan.ts
+++ b/packages/runtime/src/execute/plan.ts
@@ -57,16 +57,14 @@ const executePlan = async (
     const job = compiledPlan.jobs[next];
 
     const prevState = stateHistory[job.previous || ''] ?? initialState;
-
     const state = assembleState(
       clone(prevState),
       job.configuration,
       job.state,
       ctx.opts.strict
     );
-    console.log(job.id, state);
+
     const result = await executeJob(ctx, job, state);
-    console.log('result >', result);
     stateHistory[next] = result.state;
 
     if (!result.next.length) {
@@ -77,6 +75,7 @@ const executePlan = async (
       queue.push(...result.next);
     }
   }
+
   // If there are multiple leaf results, return them
   if (Object.keys(leaves).length > 1) {
     return leaves;

--- a/packages/runtime/src/util/assemble-state.ts
+++ b/packages/runtime/src/util/assemble-state.ts
@@ -1,3 +1,14 @@
+const assembleData = (initialData: any, defaultData = {}) => {
+  if (
+    initialData &&
+    (Array.isArray(initialData) || typeof initialData !== 'object')
+  ) {
+    return initialData;
+  }
+
+  return Object.assign({}, defaultData, initialData);
+};
+
 // Function to assemble state in between jobs in a workflow
 const assembleState = (
   initialState: any = {}, // previous or initial state
@@ -11,20 +22,24 @@ const assembleState = (
         ...defaultState,
         ...initialState,
       };
+
   if (initialState.references) {
     obj.references = initialState.references;
   }
+
   if (initialState.errors) {
     obj.errors = initialState.errors;
   }
+
   Object.assign(obj, {
     configuration: Object.assign(
       {},
       initialState.configuration ?? {},
       configuration
     ),
-    data: Object.assign({}, defaultState.data, initialState.data),
+    data: assembleData(initialState.data, defaultState.data),
   });
+
   return obj;
 };
 

--- a/packages/runtime/test/execute/compile-plan.test.ts
+++ b/packages/runtime/test/execute/compile-plan.test.ts
@@ -26,6 +26,74 @@ test('should convert jobs to an object', (t) => {
   t.is(compiledPlan.jobs.b.expression, 'y');
 });
 
+test('should set previous job with 2 jobs', (t) => {
+  const plan: ExecutionPlan = {
+    start: 'a',
+    jobs: [
+      { id: 'a', expression: 'x', next: { b: true } },
+      { id: 'b', expression: 'y' },
+    ],
+  };
+  const compiledPlan = compilePlan(plan);
+  t.is(compiledPlan.jobs.a.previous, undefined);
+  t.is(compiledPlan.jobs.b.previous, 'a');
+});
+
+test('should set previous job with 2 jobs and shorthand syntax', (t) => {
+  const plan: ExecutionPlan = {
+    start: 'a',
+    jobs: [
+      { id: 'a', expression: 'x', next: 'b' },
+      { id: 'b', expression: 'y' },
+    ],
+  };
+  const compiledPlan = compilePlan(plan);
+  t.is(compiledPlan.jobs.a.previous, undefined);
+  t.is(compiledPlan.jobs.b.previous, 'a');
+});
+
+test('should set previous job with 2 jobs and no start', (t) => {
+  const plan: ExecutionPlan = {
+    jobs: [
+      { id: 'a', expression: 'x', next: { b: true } },
+      { id: 'b', expression: 'y' },
+    ],
+  };
+  const compiledPlan = compilePlan(plan);
+  t.is(compiledPlan.jobs.a.previous, undefined);
+  t.is(compiledPlan.jobs.b.previous, 'a');
+});
+
+test('should set previous job with 3 jobs', (t) => {
+  const plan: ExecutionPlan = {
+    start: 'a',
+    jobs: [
+      { id: 'a', expression: 'x', next: { b: true } },
+      { id: 'b', expression: 'y', next: { c: true } },
+      { id: 'c', expression: 'z' },
+    ],
+  };
+  const compiledPlan = compilePlan(plan);
+  t.is(compiledPlan.jobs.a.previous, undefined);
+  t.is(compiledPlan.jobs.b.previous, 'a');
+  t.is(compiledPlan.jobs.c.previous, 'b');
+});
+
+test('should set previous job with 3 jobs and shorthand syntax', (t) => {
+  const plan: ExecutionPlan = {
+    start: 'a',
+    jobs: [
+      { id: 'c', expression: 'z' },
+      { id: 'a', expression: 'x', next: 'b' },
+      { id: 'b', expression: 'y', next: 'c' },
+    ],
+  };
+  const compiledPlan = compilePlan(plan);
+  t.is(compiledPlan.jobs.a.previous, undefined);
+  t.is(compiledPlan.jobs.b.previous, 'a');
+  t.is(compiledPlan.jobs.c.previous, 'b');
+});
+
 test('should auto generate ids for jobs', (t) => {
   const plan = {
     start: 'a',

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -295,5 +295,5 @@ test('data can be an array (workflow)', async (t) => {
   };
 
   const result: any = await run(plan, {}, { strict: false });
-  t.deepEqual(result, [1, 2, 3]);
+  t.deepEqual(result.data, [1, 2, 3]);
 });

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -279,7 +279,7 @@ test('data can be an array (expression)', async (t) => {
   t.deepEqual(result.data, [1, 2, 3]);
 });
 
-test.only('data can be an array (workflow)', async (t) => {
+test('data can be an array (workflow)', async (t) => {
   const plan: ExecutionPlan = {
     jobs: [
       {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -271,3 +271,29 @@ test('stuff written to state before an error is preserved', async (t) => {
 
   t.is(result.x, 1);
 });
+
+test('data can be an array (expression)', async (t) => {
+  const expression = 'export default [() => ({ data: [1,2,3] })]';
+
+  const result: any = await run(expression, {}, { strict: false });
+  t.deepEqual(result.data, [1, 2, 3]);
+});
+
+test.only('data can be an array (workflow)', async (t) => {
+  const plan: ExecutionPlan = {
+    jobs: [
+      {
+        id: 'a',
+        expression: 'export default [() => ({ data: [1,2,3] })]',
+        next: 'b',
+      },
+      {
+        id: 'b',
+        expression: 'export default [(s) => s]',
+      },
+    ],
+  };
+
+  const result: any = await run(plan, {}, { strict: false });
+  t.deepEqual(result, [1, 2, 3]);
+});

--- a/packages/runtime/test/util/assemble-state.test.ts
+++ b/packages/runtime/test/util/assemble-state.test.ts
@@ -86,6 +86,23 @@ test('Initial data is prioritised over default data', (t) => {
   t.deepEqual(strict, nonStrict);
 });
 
+test('Initial data does not have to be an object', (t) => {
+  const initial = { data: [1] };
+  const defaultState = { data: {} };
+  const config = undefined;
+
+  const strict = assembleState(initial, config, defaultState, true);
+  t.deepEqual(strict, {
+    configuration: {},
+    data: [1],
+  });
+
+  // At this point I don't want any special handling for strict mode,
+  // see https://github.com/OpenFn/kit/issues/233
+  const nonStrict = assembleState(initial, config, defaultState, false);
+  t.deepEqual(strict, nonStrict);
+});
+
 test('merges default and initial config objects', (t) => {
   const initial = { configuration: { x: 1 } };
   const defaultState = undefined;


### PR DESCRIPTION
## Short Description

When running a workflow, if state.data is an array, it gets blatted to an object. See unit tests in runtime.test.ts

## Related issue

Fixes #377

## Implementation Details

There are two really important little fixes here.

First off, when assembling state for a job, we need to be a bit mindful that state.data might not be an object (it could easily be array).

Secondly, if your workflow edges look like `{ next: "job-1" }`, there's a nasty bug where the runtime would load previous state from the wrong job.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added unit tests
- [ ] Changesets have been added (if there are production code changes)
