### PR TITLE
Fix auto publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,8 @@ jobs:
       - run: pnpm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: pnpm changeset publish -r --report-summary --publish-branch main
+      - run: pnpm publish -r --report-summary --publish-branch main
+      - run: pnpm changeset tag
       - run: git push --tags
       - run: pnpm run generate-slack-report
         env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
       - run: pnpm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: pnpm publish -r --report-summary --publish-branch main
+      - run: pnpm changeset publish -r --report-summary --publish-branch main
       - run: git push --tags
       - run: pnpm run generate-slack-report
         env:

--- a/packages/runtime-manager/CHANGELOG.md
+++ b/packages/runtime-manager/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.0.41
 
-Testing auto-deplot, no changes
+Testing auto-deploy, no changes
 
 ## 0.0.40
 

--- a/packages/runtime-manager/CHANGELOG.md
+++ b/packages/runtime-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # runtime-manager
 
+## 0.0.41
+
+Testing auto-deplot, no changes
+
 ## 0.0.40
 
 ### Patch Changes

--- a/packages/runtime-manager/package.json
+++ b/packages/runtime-manager/package.json
@@ -1,10 +1,9 @@
 {
   "name": "@openfn/runtime-manager",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "An example runtime manager service.",
   "main": "index.js",
   "type": "module",
-  "private": true,
   "scripts": {
     "test": "pnpm ava",
     "test:types": "pnpm tsc --noEmit --project tsconfig.json",


### PR DESCRIPTION
* Fix auto publish
* Bump runtime manager version just to test

I am not sure whether `pnpm changeset publish` gives me the same report summary as `pnpn publish`. It's hard to test and it doesn't matter - I'm just going to manually generate and push tags. It's all the same.