### PR TITLE
CLI: Simplify handling of imports

### DIFF
--- a/.changeset/thirty-eels-cover.md
+++ b/.changeset/thirty-eels-cover.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': minor
+---
+
+Compile jobs with dumb imports by default

--- a/packages/cli/src/compile/command.ts
+++ b/packages/cli/src/compile/command.ts
@@ -7,6 +7,7 @@ export type CompileOptions = Pick<
   Opts,
   | 'adaptors'
   | 'command'
+  | 'dumbImports'
   | 'expandAdaptors'
   | 'ignoreImports'
   | 'jobPath'
@@ -26,6 +27,7 @@ export type CompileOptions = Pick<
 const options = [
   o.expandAdaptors, // order important
   o.adaptors,
+  o.dumbImports,
   o.ignoreImports,
   o.inputPath,
   o.log,

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -9,6 +9,7 @@ export type ExecuteOptions = Required<
     Opts,
     | 'adaptors'
     | 'autoinstall'
+    | 'dumbImports'
     | 'command'
     | 'compile'
     | 'expandAdaptors'
@@ -41,6 +42,7 @@ const options = [
   o.adaptors,
   o.autoinstall,
   o.compile,
+  o.dumbImports,
   o.immutable,
   o.ignoreImports,
   o.inputPath,

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -20,6 +20,7 @@ export type Opts = {
   adaptor?: boolean | string;
   adaptors?: string[];
   autoinstall?: boolean;
+  dumbImports?: boolean;
   compile?: boolean;
   confirm?: boolean;
   describe?: string;
@@ -114,6 +115,16 @@ export const autoinstall: CLIOption = {
     boolean: true,
     description: 'Auto-install the language adaptor',
     default: false,
+  },
+};
+
+export const dumbImports: CLIOption = {
+  name: 'dumb-imports',
+  yargs: {
+    boolean: true,
+    description:
+      'Use simple imports when compiling (assumes dangling identifiers come from the adaptor)',
+    default: true,
   },
 };
 
@@ -218,13 +229,11 @@ export const projectId: CLIOption = {
     hidden: true,
   },
   ensure: (opts) => {
-      const projectId = opts.projectId;
-      //check that this is a uuid
-      return projectId;
-    },
+    const projectId = opts.projectId;
+    //check that this is a uuid
+    return projectId;
+  },
 };
-
-
 
 // Input path covers jobPath and workflowPath
 export const inputPath: CLIOption = {

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -549,7 +549,7 @@ test.serial(
   }
 );
 
-test.serial('compile a job: openfn compile job.js to stdout', async (t) => {
+test.serial('compile a job to stdout: openfn compile job.js', async (t) => {
   const options = {};
   await run('compile job.js', 'fn(42);', options);
 
@@ -557,7 +557,22 @@ test.serial('compile a job: openfn compile job.js to stdout', async (t) => {
   t.regex(message, /export default/);
 });
 
-test.serial('compile a job: openfn compile job.js to file', async (t) => {
+test.serial(
+  'compile a job with dumb imports: openfn compile job.js -a common',
+  async (t) => {
+    const options = {};
+    await run(
+      'compile job.js -a common --dumb-imports',
+      'wibble(42);',
+      options
+    );
+
+    const { message } = logger._parse(logger._last);
+    t.regex(message, /import { wibble } from "@openfn\/language-common";/);
+  }
+);
+
+test.serial('compile a job to file: openfn compile job.js', async (t) => {
   const options = {
     outputPath: 'out.js',
   };
@@ -567,23 +582,26 @@ test.serial('compile a job: openfn compile job.js to file', async (t) => {
   t.is(output, 'export default [fn(42)];');
 });
 
-test.serial('compile a workflow: openfn compile wf.json to file', async (t) => {
-  const options = {
-    outputPath: 'out.json',
-    jobPath: 'wf.json', // just to fool the test
-  };
+test.serial(
+  'compile a workflow to fikle: openfn compile wf.json',
+  async (t) => {
+    const options = {
+      outputPath: 'out.json',
+      jobPath: 'wf.json', // just to fool the test
+    };
 
-  const wf = JSON.stringify({
-    start: 'a',
-    jobs: [{ expression: 'x()' }],
-  });
-  await run('compile wf.json -o out.json', wf, options);
+    const wf = JSON.stringify({
+      start: 'a',
+      jobs: [{ expression: 'x()' }],
+    });
+    await run('compile wf.json -o out.json', wf, options);
 
-  const output = await fs.readFile('out.json', 'utf8');
-  const result = JSON.parse(output);
-  t.truthy(result);
-  t.is(result.jobs[0].expression, 'export default [x()];');
-});
+    const output = await fs.readFile('out.json', 'utf8');
+    const result = JSON.parse(output);
+    t.truthy(result);
+    t.is(result.jobs[0].expression, 'export default [x()];');
+  }
+);
 
 test.serial('docs should print documentation with full names', async (t) => {
   mock({


### PR DESCRIPTION
## Short Description

Adds a `dumb-imports` option to the CLI by default.

This should enable nested imports like `common.http`, `common.beta` and `mailchimp.md5` to work.

## Related issue

This is a workaround to #238, but closes #363 and the mailchimp md5 issue over in adaptors

## Implementation Details

The CLI currently fails for jobs which reference any re-exported module from an adaptor. For example common exports `http`, `beta`, `dateFns`. All of these aliased exports (or nested namespaces?) will result in a Reference Error in the new CLI.

For any job, we generate an import statement - eg, `import { fn, http } from '@openfn/language-common'`. To ensure this import statement is accurate, we look at the actual exports of the adaptor and try to only import what we need.

The problem, which is broadly captured in #238, is that we are failing to get an accurate list of an adaptors exports. This mean that for `http` and other exports, no export is reported and so no import is generated. This results in a runtime exception because we're referencing an undefined symbol.

To fix this properly we need to dig  deeply into `describe-package`. Actually, we need to basically re-write it - see #197.

This fix basically say: don't bother to look up the adaptor's actual imports, just assume that all undeclared variables are imported from the adaptor (apart from globals).

The risks of this change are:
* If you don't declare a variable properly in job code (ie, `x = 10`), the compiler will and import that variable from the adaptor. This will result in a runtime error. This is probably quite likely to happen.
* If you reference a global variable that isn't on our list, we'll try and import it from the adaptor, resulting in an error. This is unlikely (and easy to fix)

## QA Notes

It would be helpful to re-test these issues (and close them, if they're not already)

* https://github.com/OpenFn/kit/issues/363
* https://github.com/OpenFn/adaptors/issues/383
* https://github.com/OpenFn/kit/issues/80 (see the beta stuff)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added unit tests
- [x] Changesets have been added (if there are production code changes)

