### PR TITLE
Worker: Fix attempts log

### DIFF
--- a/.changeset/early-olives-camp.md
+++ b/.changeset/early-olives-camp.md
@@ -1,5 +1,0 @@
----
-'@openfn/lightning-mock': patch
----
-
-Acknowledge attempt start

--- a/.changeset/early-olives-camp.md
+++ b/.changeset/early-olives-camp.md
@@ -1,0 +1,5 @@
+---
+'@openfn/lightning-mock': patch
+---
+
+Acknowledge attempt start

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @openfn/integration-tests-worker
 
+## 1.0.4
+
+### Patch Changes
+
+- Updated dependencies [06f2f75]
+- Updated dependencies
+- Updated dependencies
+  - @openfn/lightning-mock@1.0.4
+  - @openfn/engine-multi@0.1.3
+  - @openfn/ws-worker@0.1.3
+
 ## 1.0.3
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # engine-multi
 
+## 0.1.3
+
+### Patch Changes
+
+- Export event types
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/engine-multi/src/index.ts
+++ b/packages/engine-multi/src/index.ts
@@ -3,3 +3,4 @@ import createEngine from './api';
 export default createEngine;
 
 export * from './types';
+export * from './events';

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/lightning-mock
 
+## 1.0.4
+
+### Patch Changes
+
+- 06f2f75: Acknowledge attempt start
+- Updated dependencies
+  - @openfn/engine-multi@0.1.3
+
 ## 1.0.3
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/lightning-mock/src/api-sockets.ts
+++ b/packages/lightning-mock/src/api-sockets.ts
@@ -205,7 +205,7 @@ const createSocketAPI = (
     ws: DevSocket,
     evt: PhoenixEvent<GetCredentialPayload>
   ) {
-    const { ref, join_ref, topic, payload } = evt;
+    const { ref, join_ref, topic } = evt;
     ws.reply<GetCredentialReply>({
       ref,
       join_ref,

--- a/packages/lightning-mock/src/api-sockets.ts
+++ b/packages/lightning-mock/src/api-sockets.ts
@@ -35,6 +35,7 @@ import {
   RunStart,
   RunStartReply,
   RunCompleteReply,
+  ATTEMPT_START,
 } from './events';
 
 import type { Server } from 'http';
@@ -119,6 +120,7 @@ const createSocketAPI = (
 
     const { unsubscribe } = wss.registerEvents(`attempt:${attemptId}`, {
       [GET_ATTEMPT]: wrap(getAttempt),
+      [ATTEMPT_START]: wrap(handleStartAttempt),
       [GET_CREDENTIAL]: wrap(getCredential),
       [GET_DATACLIP]: wrap(getDataclip),
       [RUN_START]: wrap(handleRunStart),
@@ -194,6 +196,22 @@ const createSocketAPI = (
       payload: {
         status: 'ok',
         response,
+      },
+    });
+  }
+
+  function handleStartAttempt(
+    _state: ServerState,
+    ws: DevSocket,
+    evt: PhoenixEvent<GetCredentialPayload>
+  ) {
+    const { ref, join_ref, topic, payload } = evt;
+    ws.reply<GetCredentialReply>({
+      ref,
+      join_ref,
+      topic,
+      payload: {
+        status: 'ok',
       },
     });
   }

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ws-worker
 
+## 0.1.3
+
+### Patch Changes
+
+- Fix log event mapping
+- Updated dependencies
+  - @openfn/engine-multi@0.1.3
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/ws-worker/src/api/execute.ts
+++ b/packages/ws-worker/src/api/execute.ts
@@ -118,7 +118,7 @@ export function execute(
       addEvent('workflow-start', onWorkflowStart),
       addEvent('job-start', onJobStart),
       addEvent('job-complete', onJobComplete),
-      addEvent('log', onJobLog),
+      addEvent('workflow-log', onJobLog),
       // This will also resolve the promise
       addEvent('workflow-complete', onWorkflowComplete),
 

--- a/packages/ws-worker/src/mock/runtime-engine.ts
+++ b/packages/ws-worker/src/mock/runtime-engine.ts
@@ -1,17 +1,17 @@
 import crypto from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import type { ExecutionPlan, JobNode } from '@openfn/runtime';
-import type { Resolvers } from '@openfn/engine-multi';
+import * as engine from '@openfn/engine-multi';
 import type { State } from '../types';
 import mockResolvers from './resolvers';
 
 export type EngineEvent =
-  | 'job-start'
-  | 'job-complete'
-  | 'log' // this is a log from inside the VM
-  | 'workflow-start' // before compile
-  | 'workflow-complete' // after everything has run
-  | 'workflow-error'; // ?
+  | typeof engine.JOB_COMPLETE
+  | typeof engine.JOB_START
+  | typeof engine.WORKFLOW_COMPLETE
+  | typeof engine.WORKFLOW_ERROR
+  | typeof engine.WORKFLOW_LOG
+  | typeof engine.WORKFLOW_START;
 
 export type JobStartEvent = {
   workflowId: string;
@@ -72,7 +72,7 @@ async function createMock() {
     workflowId: string,
     job: JobNode,
     initialState = {},
-    resolvers: Resolvers = mockResolvers
+    resolvers: engine.Resolvers = mockResolvers
   ) => {
     const { id, expression, configuration, adaptor } = job;
 
@@ -92,7 +92,7 @@ async function createMock() {
     }
 
     const info = (...message: any[]) => {
-      dispatch('log', {
+      dispatch('workflow-log', {
         workflowId,
         message: message,
         level: 'info',
@@ -127,7 +127,7 @@ async function createMock() {
   // The mock uses lots of timeouts to make testing a bit easier and simulate asynchronicity
   const execute = (
     xplan: ExecutionPlan,
-    options: { resolvers?: Resolvers; throw?: boolean } = {
+    options: { resolvers?: engine.Resolvers; throw?: boolean } = {
       resolvers: mockResolvers,
     }
   ) => {

--- a/packages/ws-worker/test/mock/runtime-engine.test.ts
+++ b/packages/ws-worker/test/mock/runtime-engine.test.ts
@@ -124,7 +124,7 @@ test('mock should dispatch log events when evaluating JSON', async (t) => {
   const engine = await create();
 
   const logs = [];
-  engine.on('log', (l) => {
+  engine.on('workflow-log', (l) => {
     logs.push(l);
   });
 
@@ -139,7 +139,7 @@ test('mock should throw if the magic option is passed', async (t) => {
   const engine = await create();
 
   const logs = [];
-  engine.on('log', (l) => {
+  engine.on('workflow-log', (l) => {
     logs.push(l);
   });
 
@@ -175,7 +175,7 @@ test('listen to events', async (t) => {
   const called = {
     'job-start': false,
     'job-complete': false,
-    log: false,
+    'workflow-log': false,
     'workflow-start': false,
     'workflow-complete': false,
   };
@@ -192,8 +192,8 @@ test('listen to events', async (t) => {
       t.is(jobId, sampleWorkflow.jobs[0].id);
       // TODO includes state?
     },
-    log: ({ workflowId, message }) => {
-      called['log'] = true;
+    'workflow-log': ({ workflowId, message }) => {
+      called['workflow-log'] = true;
       t.is(workflowId, sampleWorkflow.id);
       t.truthy(message);
     },
@@ -247,14 +247,14 @@ test('do nothing for a job if no expression and adaptor (trigger node)', async (
     'job-complete': () => {
       didCallEvent = true;
     },
-    log: () => {
-      didCallEvent = true;
-    },
-    'workflow-start': () => {
+    'workflow-log': () => {
       // this can be called
     },
+    'workflow-start': () => {
+      // ditto
+    },
     'workflow-complete': () => {
-      // and this
+      // ditto
     },
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@openfn/language-common_1.11.1':
         specifier: npm:@openfn/language-common@^1.11.1
         version: /@openfn/language-common@1.11.1
+      is-array_1.0.1:
+        specifier: npm:is-array@^1.0.1
+        version: /is-array@1.0.1
 
   integration-tests/worker:
     dependencies:
@@ -4944,6 +4947,10 @@ packages:
     dependencies:
       kind-of: 6.0.3
     dev: true
+
+  /is-array@1.0.1:
+    resolution: {integrity: sha512-gxiZ+y/u67AzpeFmAmo4CbtME/bs7J2C++su5zQzvQyaxUqVzkh69DI+jN+KZuSO6JaH6TIIU6M6LhqxMjxEpw==}
+    dev: false
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}

--- a/scripts/slack-publish-message.js
+++ b/scripts/slack-publish-message.js
@@ -17,13 +17,6 @@ const getEngineeringMessage = (changes) => {
         text: `🚀 *New Releases in kit*`,
       },
     },
-    {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: 'Update the CLI with with `npm -g install @openfn/cli`',
-      },
-    },
     // TODO I'd like to link to a full changelog but we don't really have one
   ];
 


### PR DESCRIPTION
Whoops - turns out I was using the wrong attempt name to map log events.

Closes #434 

This PR fixes it, adds a wee fix to the lightning mock, and updates typings.

We did have some unit tests around this but they were also using the wrong name. 