### PR TITLE
Hrtime: send nanoseconds to lightning

### DIFF
--- a/packages/ws-worker/src/api/execute.ts
+++ b/packages/ws-worker/src/api/execute.ts
@@ -246,15 +246,13 @@ export async function onWorkflowError(
 }
 
 export function onJobLog({ channel, state }: Context, event: JSONLog) {
-  const timeInMicroseconds = BigInt(event.time) / BigInt(1e3);
-
   // lightning-friendly log object
   const log: ATTEMPT_LOG_PAYLOAD = {
     attempt_id: state.plan.id!,
     message: event.message,
     source: event.name,
     level: event.level,
-    timestamp: timeInMicroseconds.toString(),
+    timestamp: event.time,
   };
 
   if (state.activeRun) {

--- a/packages/ws-worker/src/mock/runtime-engine.ts
+++ b/packages/ws-worker/src/mock/runtime-engine.ts
@@ -2,6 +2,8 @@ import crypto from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import type { ExecutionPlan, JobNode } from '@openfn/runtime';
 import * as engine from '@openfn/engine-multi';
+import { timestamp } from '@openfn/logger';
+
 import type { State } from '../types';
 import mockResolvers from './resolvers';
 
@@ -95,7 +97,7 @@ async function createMock() {
         workflowId,
         message: message,
         level: 'info',
-        time: (BigInt(Date.now()) * BigInt(1e3)).toString(),
+        time: timestamp().toString(),
         name: 'mck',
       });
     };

--- a/packages/ws-worker/test/api/execute.test.ts
+++ b/packages/ws-worker/test/api/execute.test.ts
@@ -189,9 +189,7 @@ test('jobLog should should send a log event outside a run', async (t) => {
   const result = {
     attempt_id: plan.id,
     message: log.message,
-    // Conveniently this won't have rounding errors because the last
-    // 3 digits are always 000, because of how we generate the stamp above
-    timestamp: log.time.substring(0, 16),
+    timestamp: log.time,
     level: log.level,
     source: log.name,
   };
@@ -236,7 +234,7 @@ test('jobLog should should send a log event inside a run', async (t) => {
       t.deepEqual(evt.message, log.message);
       t.is(evt.level, log.level);
       t.is(evt.source, log.name);
-      t.is(evt.timestamp, log.time.substring(0, 16));
+      t.is(evt.timestamp, log.time);
     },
   });
 

--- a/packages/ws-worker/test/integration.test.ts
+++ b/packages/ws-worker/test/integration.test.ts
@@ -302,21 +302,8 @@ test.serial(
         t.log(history)
         let last = BigInt(0);
 
-
-        // There is a significant chance that some logs will come out with
-        // the same timestamp
-        // So we add some leniency
-        let lives = 3;
-
         history.forEach(time => {
-          if (time === last) {
-            lives -=1
-            t.true(lives > 0);
-            // skip
-            return
-          }
           t.true(time > last)
-          lives = 2
           last = time;
         })
 


### PR DESCRIPTION
Keeping this open for a little while in case we want it.

This sends full nanosecond log timings to lightning. We can then restore the flaky worker integration test