### PR TITLE
Worker: better server connectivity

### DIFF
--- a/packages/ws-worker/src/api/claim.ts
+++ b/packages/ws-worker/src/api/claim.ts
@@ -31,15 +31,16 @@ const claim = (app: ServerApp, logger: Logger = mockLogger, maxWorkers = 5) => {
           app.execute(attempt);
           resolve();
         });
+      })
+      // // TODO need implementations for both of these really
+      // // What do we do if we fail to join the worker channel?
+      .receive('error', () => {
+        logger.debug('pull err');
+      })
+      .receive('timeout', () => {
+        logger.debug('pull timeout');
+        reject(new Error('timeout'));
       });
-    // // TODO need implementations for both of these really
-    // // What do we do if we fail to join the worker channel?
-    // .receive('error', () => {
-    //   logger.debug('pull err');
-    // })
-    // .receive('timeout', () => {
-    //   logger.debug('pull timeout');
-    // });
   });
 };
 

--- a/packages/ws-worker/src/mock/sockets.ts
+++ b/packages/ws-worker/src/mock/sockets.ts
@@ -82,6 +82,10 @@ export const mockSocket = (
     onError: (callback: EventHandler) => {
       callbacks.onError = callback;
     },
+    onClose: (callback: EventHandler) => {
+      // TODO this isn't actually hooked up right now
+      callbacks.onClose = callback;
+    },
     connect: () => {
       connect()
         .then(() => {

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -47,63 +47,66 @@ const MIN_BACKOFF = 1000;
 const MAX_BACKOFF = 1000 * 30;
 
 // TODO move out into another file, make testable, test in isolation
-function connect(
-  app: ServerApp,
-  engine: RuntimeEngine,
-  logger: Logger,
-  options: ServerOptions = {}
-) {
+function connect(app: ServerApp, logger: Logger, options: ServerOptions = {}) {
   logger.debug('Connecting to Lightning at', options.lightning);
 
-  connectToWorkerQueue(options.lightning!, app.id, options.secret!)
-    .then(({ socket, channel }) => {
-      logger.success('Connected to Lightning at', options.lightning);
+  // A new connection made to the queue
+  const onConnect = ({ socket, channel }) => {
+    logger.success('Connected to Lightning at', options.lightning);
 
-      // save the channel and socket
-      app.socket = socket;
-      app.channel = channel;
+    // save the channel and socket
+    app.socket = socket;
+    app.channel = channel;
 
-      // trigger the workloop
-      if (!options.noLoop) {
-        if (app.killWorkloop) {
-          logger.info('Terminating old workloop');
-          app.killWorkloop();
-        }
-
-        logger.info('Starting workloop');
-        // TODO maybe namespace the workloop logger differently? It's a bit annoying
-        app.killWorkloop = startWorkloop(
-          app,
-          logger,
-          options.backoff?.min || MIN_BACKOFF,
-          options.backoff?.max || MAX_BACKOFF,
-          options.maxWorkflows
-        );
-      } else {
-        logger.break();
-        logger.warn('Workloop not starting');
-        logger.info('This server will not auto-pull work from lightning.');
-        logger.info('You can manually claim by posting to /claim, eg:');
-        logger.info(
-          `  curl -X POST http://locahost:${options.port || DEFAULT_PORT}/claim`
-        );
-        logger.break();
-      }
-    })
-    .catch((e) => {
-      logger.error(
-        'CRITICAL ERROR: could not connect to lightning at',
-        options.lightning
+    // trigger the workloop
+    if (!options.noLoop) {
+      logger.info('Starting workloop');
+      // TODO maybe namespace the workloop logger differently? It's a bit annoying
+      app.killWorkloop = startWorkloop(
+        app,
+        logger,
+        options.backoff?.min || MIN_BACKOFF,
+        options.backoff?.max || MAX_BACKOFF,
+        options.maxWorkflows
       );
-      logger.debug(e);
+    } else {
+      logger.break();
+      logger.warn('Workloop not starting');
+      logger.info('This server will not auto-pull work from lightning.');
+      logger.info('You can manually claim by posting to /claim, eg:');
+      logger.info(
+        `  curl -X POST http://locahost:${options.port || DEFAULT_PORT}/claim`
+      );
+      logger.break();
+    }
+  };
 
-      app.killWorkloop?.();
+  // We were disconnected from the queue
+  const onDisconnect = () => {
+    if (app.killWorkloop) {
+      app.killWorkloop();
+      delete app.killWorkloop;
+      logger.info('Connection to lightning lost.');
+      logger.info(
+        'Worker will automatically reconnect when lightning is back online.'
+      );
+      // So far as I know, the socket will try and reconnect in the background forever
+    }
+  };
 
-      // Try to Reconnect after 10 seconds
-      setTimeout(() => {
-        connect(app, engine, logger, options);
-      }, 1e4);
-    });
+  // We failed to connect to the queue
+  const onError = (e) => {
+    logger.error(
+      'CRITICAL ERROR: could not connect to lightning at',
+      options.lightning
+    );
+    logger.debug(e);
+  };
+
+  connectToWorkerQueue(options.lightning!, app.id, options.secret!)
+    .on('connect', onConnect)
+    .on('disconnect', onDisconnect)
+    .on('error', onError);
 }
 
 function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
@@ -187,7 +190,7 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
   app.use(router.routes());
 
   if (options.lightning) {
-    connect(app, engine, logger, options);
+    connect(app, logger, options);
   } else {
     logger.warn('No lightning URL provided');
   }

--- a/packages/ws-worker/test/channels/worker-queue.test.ts
+++ b/packages/ws-worker/test/channels/worker-queue.test.ts
@@ -4,72 +4,80 @@ import connectToWorkerQueue from '../../src/channels/worker-queue';
 import { mockSocket } from '../../src/mock/sockets';
 
 test('should connect', async (t) => {
-  const { socket, channel } = await connectToWorkerQueue(
-    'www',
-    'a',
-    'secret',
-    mockSocket
-  );
-
-  t.truthy(socket);
-  t.truthy(socket.connect);
-  t.truthy(channel);
-  t.truthy(channel.join);
+  return new Promise((done) => {
+    connectToWorkerQueue('www', 'a', 'secret', mockSocket).on(
+      'connect',
+      ({ socket, channel }) => {
+        t.truthy(socket);
+        t.truthy(socket.connect);
+        t.truthy(channel);
+        t.truthy(channel.join);
+        t.pass('connected');
+        done();
+      }
+    );
+  });
 });
 
 test('should connect with an auth token', async (t) => {
-  const workerId = 'x';
-  const secret = 'xyz';
-  const encodedSecret = new TextEncoder().encode(secret);
+  return new Promise((done) => {
+    const workerId = 'x';
+    const secret = 'xyz';
+    const encodedSecret = new TextEncoder().encode(secret);
 
-  function createSocket(endpoint, options) {
-    const socket = mockSocket(endpoint, {}, async () => {
-      const { token } = options.params;
+    function createSocket(endpoint, options) {
+      const socket = mockSocket(endpoint, {}, async () => {
+        const { token } = options.params;
 
-      const { payload } = await jose.jwtVerify(token, encodedSecret);
-      t.is(payload.worker_id, workerId);
-    });
+        const { payload } = await jose.jwtVerify(token, encodedSecret);
+        t.is(payload.worker_id, workerId);
+      });
 
-    return socket;
-  }
-  const { socket, channel } = await connectToWorkerQueue(
-    'www',
-    workerId,
-    secret,
-    createSocket
-  );
-
-  t.truthy(socket);
-  t.truthy(socket.connect);
-  t.truthy(channel);
-  t.truthy(channel.join);
+      return socket;
+    }
+    connectToWorkerQueue('www', workerId, secret, createSocket).on(
+      'connect',
+      ({ socket, channel }) => {
+        t.truthy(socket);
+        t.truthy(socket.connect);
+        t.truthy(channel);
+        t.truthy(channel.join);
+        t.pass('connected');
+        done();
+      }
+    );
+  });
 });
 
 test('should fail to connect with an invalid auth token', async (t) => {
-  const workerId = 'x';
-  const secret = 'xyz';
-  const encodedSecret = new TextEncoder().encode(secret);
+  return new Promise((done) => {
+    const workerId = 'x';
+    const secret = 'xyz';
+    const encodedSecret = new TextEncoder().encode(secret);
 
-  function createSocket(endpoint, options) {
-    const socket = mockSocket(endpoint, {}, async () => {
-      const { token } = options.params;
+    function createSocket(endpoint, options) {
+      const socket = mockSocket(endpoint, {}, async () => {
+        const { token } = options.params;
 
-      try {
-        await jose.jwtVerify(token, encodedSecret);
-      } catch (_e) {
-        throw new Error('auth_fail');
-      }
-    });
+        try {
+          await jose.jwtVerify(token, encodedSecret);
+        } catch (_e) {
+          throw new Error('auth_fail');
+        }
+      });
 
-    return socket;
-  }
-
-  await t.throwsAsync(
-    connectToWorkerQueue('www', workerId, 'wrong-secret!', createSocket),
-    {
-      message: 'auth_fail',
+      return socket;
     }
-  );
+
+    connectToWorkerQueue('www', workerId, 'wrong-secret!', createSocket).on(
+      'error',
+      (e) => {
+        t.is(e, 'auth_fail');
+        t.pass('error thrown');
+        done();
+      }
+    );
+  });
 });
 
 // TODO maybe?


### PR DESCRIPTION
This PR refactors socket connections to be more robust.

We used to use a promise to connect to the worker queue, which would resolve or throw. The problem is that once its resolved or thrown, the promise kinda goes stale. Meaning that after it's been connected it doesn't really reconnect properly.

I've made the connect function more robust by making it an event emitter. It'll now emit `connect`, `disconnect` and `error `messages which the sever deals with appropriately. The socket does most of the work actually, I'm just taking care to  stop and restart the workloop when the connection comes and goes.

Over lunch I ran this test:
* Do not start lightning
* Start the worker
* The worker loops an error message
* Start lightning
* The worker connects to the queue channel
* Kill lighting
* The worker stops the workloop and sits idle (with a nice log message)
* Wait for literally an hour
* Start lightning
* The worker happily reconnects, no biggie

Quick note here that the attempt channel has none of this stuff - I'm 100% reliant on the pheonix socket to reconnect and aysnchronise with itself.