### PR TITLE
Worker: fix initial state handling

### DIFF
--- a/.changeset/sour-bees-jam.md
+++ b/.changeset/sour-bees-jam.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': patch
+---
+
+Use the runtime in non-strict mode

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -221,6 +221,46 @@ test('run a job with initial state', (t) => {
   });
 });
 
+test.only('run a job with initial state #2', (t) => {
+  return new Promise(async (done) => {
+    const attempt = {
+      id: crypto.randomUUID(),
+      dataclip_id: 's1',
+      jobs: [
+        {
+          adaptor: '@openfn/language-common@latest',
+          body: 'fn((s) => s)',
+        },
+      ],
+    };
+
+    initLightning();
+
+    const initialState = { name: 'Professor X' };
+
+    lightning.addDataclip('s1', initialState);
+
+    lightning.on('attempt:complete', () => {
+      const result = lightning.getResult(attempt.id);
+      console.log(result);
+      t.deepEqual(result, {
+        ...initialState,
+        configuration: {},
+      });
+      done();
+    });
+
+    await initWorker();
+
+    // TODO: is there any way I can test the worker behaviour here?
+    // I think I can listen to load-state right?
+    // well, not really, not yet, not from the worker
+    // see https://github.com/OpenFn/kit/issues/402
+
+    lightning.enqueueAttempt(attempt);
+  });
+});
+
 // TODO this sort of works but the server side of it does not
 // Will work on it more
 test('run a job with credentials', (t) => {

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -182,7 +182,7 @@ test('run a job which does NOT autoinstall common', (t) => {
   });
 });
 
-test('run a job with initial state', (t) => {
+test('run a job with initial state (with data)', (t) => {
   return new Promise(async (done) => {
     const attempt = {
       id: crypto.randomUUID(),
@@ -221,7 +221,7 @@ test('run a job with initial state', (t) => {
   });
 });
 
-test.only('run a job with initial state #2', (t) => {
+test('run a job with initial state (no top level keys)', (t) => {
   return new Promise(async (done) => {
     const attempt = {
       id: crypto.randomUUID(),
@@ -242,9 +242,9 @@ test.only('run a job with initial state #2', (t) => {
 
     lightning.on('attempt:complete', () => {
       const result = lightning.getResult(attempt.id);
-      console.log(result);
       t.deepEqual(result, {
         ...initialState,
+        data: {},
         configuration: {},
       });
       done();

--- a/packages/engine-multi/src/worker/worker.ts
+++ b/packages/engine-multi/src/worker/worker.ts
@@ -32,6 +32,7 @@ workerpool.worker({
     const { adaptorPaths, whitelist, sanitize } = runOptions;
     const { logger, jobLogger } = createLoggers(plan.id!, sanitize);
     const options = {
+      strict: false,
       logger,
       jobLogger,
       linker: {

--- a/packages/engine-multi/test/integration.test.ts
+++ b/packages/engine-multi/test/integration.test.ts
@@ -7,9 +7,8 @@ let api;
 
 test.afterEach(() => {
   logger._reset();
-  api.destroy()
+  api.destroy();
 });
-
 
 // this tests the full API with the actual runtime
 // note that it won't test autoinstall
@@ -222,8 +221,28 @@ test.serial('preload credentials', (t) => {
 
     const plan = createPlan(jobs);
 
-    api.execute(plan, options).on('workflow-complete', ({ state }) => {
+    api.execute(plan, options).on('workflow-complete', () => {
       t.true(didCallLoader);
+      done();
+    });
+  });
+});
+
+test.serial('accept initial state', (t) => {
+  return new Promise((done) => {
+    const plan = createPlan();
+
+    // important!  The runtime  must use both x and y as initial state
+    // if we run the runtime in strict mode, x will be ignored
+    plan.initialState = {
+      x: 1,
+      data: {
+        y: 1,
+      },
+    };
+
+    api.execute(plan).on('workflow-complete', ({ state }) => {
+      t.deepEqual(state, plan.initialState);
       done();
     });
   });

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -260,7 +260,7 @@ test('run a workflow with state and conditional branching', async (t) => {
   t.is(result2.data.count, 0);
 });
 
-test('run a workflow with initial state and optional start', async (t) => {
+test('run a workflow with initial state (data key) and optional start', async (t) => {
   const plan: ExecutionPlan = {
     jobs: [
       {


### PR DESCRIPTION
Right now if you pass initial state into an execution plan, only the data key will actually be passed into the runtime job.

This is a strict mode issue (which is annoying because while the idea of strict mode is sort of sound the current implementation of it is totally bogus).

The fix is simply to disable strict mode in the engine.

Proof of the pudding is the new unit and integration tests.