### PR TITLE
Worker: fix credential handling

### DIFF
--- a/.changeset/warm-elephants-flow.md
+++ b/.changeset/warm-elephants-flow.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Fix credential mapping from Lightning

--- a/packages/ws-worker/test/integration.test.ts
+++ b/packages/ws-worker/test/integration.test.ts
@@ -171,7 +171,7 @@ test.serial(
       const attempt = getAttempt({}, [
         {
           id: 'some-job',
-          credential: 'a',
+          credential_id: 'a',
           adaptor: '@openfn/language-common@1.0.0',
           body: JSON.stringify({ answer: 42 }),
         },

--- a/packages/ws-worker/test/mock/data.ts
+++ b/packages/ws-worker/test/mock/data.ts
@@ -25,7 +25,7 @@ export const attempts = {
         id: 'job-1',
         adaptor: '@openfn/language-common@1.0.0',
         body: 'fn(a => a)',
-        credential: 'a',
+        credential_id: 'a',
       },
     ],
   },

--- a/packages/ws-worker/test/util/convert-attempt.test.ts
+++ b/packages/ws-worker/test/util/convert-attempt.test.ts
@@ -8,7 +8,7 @@ const createNode = (props = {}) =>
     id: 'a',
     body: 'x',
     adaptor: 'common',
-    credential: 'y',
+    credential_id: 'y',
     ...props,
   } as Node);
 


### PR DESCRIPTION
This branch fixes credential mapping in the worker. Which is broken.

Closes #465

TODO:

* [x] Typings
* [x] Tests
* [x] Changesets