### PR TITLE
Worker: only count leaf nodes when working out fail reasons

### DIFF
--- a/.changeset/unlucky-tips-crash.md
+++ b/.changeset/unlucky-tips-crash.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Only consider leaf nodes when calculating attempt fail reasons

--- a/.changeset/unlucky-tips-crash.md
+++ b/.changeset/unlucky-tips-crash.md
@@ -1,5 +1,0 @@
----
-'@openfn/ws-worker': patch
----
-
-Only consider leaf nodes when calculating attempt fail reasons

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/integration-tests-worker
 
+## 1.0.13
+
+### Patch Changes
+
+- Updated dependencies [7d350d9]
+  - @openfn/ws-worker@0.2.3
+
 ## 1.0.12
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ws-worker
 
+## 0.2.3
+
+### Patch Changes
+
+- 7d350d9: Only consider leaf nodes when calculating attempt fail reasons
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/ws-worker/src/api/execute.ts
+++ b/packages/ws-worker/src/api/execute.ts
@@ -237,23 +237,27 @@ export function onJobComplete(
 
   delete state.activeRun;
   delete state.activeJob;
-  const { reason, error_message, error_type } = calculateJobExitReason(
-    job_id,
-    event.state,
-    error
-  );
-  state.reasons[job_id] = { reason, error_message, error_type };
+  try {
+    const { reason, error_message, error_type } = calculateJobExitReason(
+      job_id,
+      event.state,
+      error
+    );
+    state.reasons[job_id] = { reason, error_message, error_type };
 
-  return sendEvent<RUN_COMPLETE_PAYLOAD>(channel, RUN_COMPLETE, {
-    run_id,
-    job_id,
-    output_dataclip_id: dataclipId,
-    output_dataclip: stringify(event.state),
+    return sendEvent<RUN_COMPLETE_PAYLOAD>(channel, RUN_COMPLETE, {
+      run_id,
+      job_id,
+      output_dataclip_id: dataclipId,
+      output_dataclip: stringify(event.state),
 
-    reason,
-    error_message,
-    error_type,
-  });
+      reason,
+      error_message,
+      error_type,
+    });
+  } catch (e) {
+    console.log(e);
+  }
 }
 
 export function onWorkflowStart(

--- a/packages/ws-worker/test/api/reasons.test.ts
+++ b/packages/ws-worker/test/api/reasons.test.ts
@@ -77,3 +77,28 @@ test('crash has priority over fail', (t) => {
 
   t.is(r.reason, 'crash');
 });
+
+// This means a job didn't return state, which isn't great
+// (and actually soon may be a fail)
+// But it should not stop us calculating a reason
+test('success if no state is passed', (t) => {
+  const jobId = 'a';
+  const state = undefined;
+  const error = undefined;
+  const r = calculateJobExitReason(jobId, state, error);
+
+  t.is(r.reason, 'success');
+  t.is(r.error_type, null);
+  t.is(r.error_message, null);
+});
+
+test('success if boolean state is passed', (t) => {
+  const jobId = 'a';
+  const state = true;
+  const error = undefined;
+  const r = calculateJobExitReason(jobId, state, error);
+
+  t.is(r.reason, 'success');
+  t.is(r.error_type, null);
+  t.is(r.error_message, null);
+});


### PR DESCRIPTION
When calculating the exit reason on a failed run, we should only consider leaf nodes. It doesn't matter if a non-leaf node errors if the final leaf node succeeds.

Closes #468

In the case of multiple fails on multiple leaves, right now the first fail will be reported (where "first" is a bit arbitrary). This is something we might want to look at again a bit later.

Note that a crash, kill or exception on ANY node will still report that error as the fail reason. This PR only affects attempts which complete the run.

I will later add more integration tests to  cover these cases - I don't really have the infrastructure in place yet