### PR TITLE
Runtime: clean state after fail

### DIFF
--- a/.changeset/empty-pugs-fetch.md
+++ b/.changeset/empty-pugs-fetch.md
@@ -1,5 +1,0 @@
----
-'@openfn/runtime': patch
----
-
-Clean state after error

--- a/.changeset/empty-pugs-fetch.md
+++ b/.changeset/empty-pugs-fetch.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+Clean state after error

--- a/.changeset/tasty-doors-rush.md
+++ b/.changeset/tasty-doors-rush.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+Rename UserError to JobError

--- a/.changeset/tasty-doors-rush.md
+++ b/.changeset/tasty-doors-rush.md
@@ -1,5 +1,0 @@
----
-'@openfn/runtime': patch
----
-
-Rename UserError to JobError

--- a/integration-tests/cli/test/execute-workflow.test.ts
+++ b/integration-tests/cli/test/execute-workflow.test.ts
@@ -184,14 +184,14 @@ test.serial(
         start: {
           error: {
             message: 'abort',
-            type: 'UserError',
-            name: 'UserError',
+            type: 'JobError',
+            name: 'JobError',
             severity: 'fail',
             source: 'runtime',
           },
           jobId: 'start',
           message: 'abort',
-          type: 'UserError',
+          type: 'JobError',
         },
       },
     });

--- a/integration-tests/cli/test/execute-workflow.test.ts
+++ b/integration-tests/cli/test/execute-workflow.test.ts
@@ -183,7 +183,6 @@ test.serial(
       errors: {
         start: {
           error: {
-            includeStackTrace: false,
             message: 'abort',
             type: 'UserError',
             name: 'UserError',

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/integration-tests-worker
 
+## 1.0.14
+
+### Patch Changes
+
+- @openfn/engine-multi@0.1.9
+- @openfn/lightning-mock@1.0.10
+- @openfn/ws-worker@0.2.4
+
 ## 1.0.13
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 0.4.6
+
+### Patch Changes
+
+- Updated dependencies [419f276]
+- Updated dependencies [0e66f5a]
+  - @openfn/runtime@0.1.2
+
 ## 0.4.5
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,13 @@
 # engine-multi
 
+## 0.1.9
+
+### Patch Changes
+
+- Updated dependencies [419f276]
+- Updated dependencies [0e66f5a]
+  - @openfn/runtime@0.1.2
+
 ## 0.1.8
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openfn/lightning-mock
 
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [419f276]
+- Updated dependencies [0e66f5a]
+  - @openfn/runtime@0.1.2
+  - @openfn/engine-multi@0.1.9
+
 ## 1.0.9
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/runtime
 
+## 0.1.2
+
+### Patch Changes
+
+- 419f276: Clean state after error
+- 0e66f5a: Rename JobError to JobError
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Job processing runtime.",
   "type": "module",
   "exports": {

--- a/packages/runtime/src/errors.ts
+++ b/packages/runtime/src/errors.ts
@@ -62,7 +62,6 @@ export function assertAdaptorError(e: any) {
 // Abstract error supertype
 export class RTError extends Error {
   source = 'runtime';
-  includeStackTrace = false;
   type: string = '-';
 
   constructor() {

--- a/packages/runtime/src/errors.ts
+++ b/packages/runtime/src/errors.ts
@@ -178,9 +178,9 @@ export class AdaptorError extends RTError {
 
 // custom user error trow new Error() or throw {}
 // Maybe JobError or Expression Error?
-export class UserError extends RTError {
-  type = 'UserError';
-  name = 'UserError';
+export class JobError extends RTError {
+  type = 'JobError';
+  name = 'JobError';
   severity = 'fail';
   message: string = '';
   constructor(error: any) {

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -18,6 +18,11 @@ import {
 } from '../errors';
 import { NOTIFY_JOB_COMPLETE, NOTIFY_JOB_START } from '../events';
 
+export type ExecutionErrorWrapper = {
+  state: any;
+  error: any;
+};
+
 export default (
   ctx: ExecutionContext,
   expression: string | Operation[],
@@ -77,6 +82,8 @@ export default (
       // return the final state
       resolve(finalState);
     } catch (e: any) {
+      // whatever initial state looks like now, clean it and report it back
+      const finalState = prepareFinalState(opts, initialState);
       duration = Date.now() - duration;
       let finalError;
       try {
@@ -90,7 +97,7 @@ export default (
         finalError = e;
       }
 
-      reject(finalError);
+      reject({ state: finalState, error: finalError } as ExecutionErrorWrapper);
     }
   });
 

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -9,7 +9,7 @@ import clone from '../util/clone';
 import {
   InputError,
   TimeoutError,
-  UserError,
+  JobError,
   assertAdaptorError,
   assertImportError,
   assertRuntimeCrash,
@@ -92,7 +92,7 @@ export default (
         assertRuntimeCrash(e);
         assertSecurityKill(e);
         assertAdaptorError(e);
-        finalError = new UserError(e);
+        finalError = new JobError(e);
       } catch (e) {
         finalError = e;
       }

--- a/packages/runtime/test/errors.test.ts
+++ b/packages/runtime/test/errors.test.ts
@@ -182,7 +182,7 @@ test('fail on user error with new Error()', async (t) => {
 
   const error = result.errors['job-1'];
 
-  t.is(error.type, 'UserError');
+  t.is(error.type, 'JobError');
   t.is(error.message, 'abort');
 });
 
@@ -193,7 +193,7 @@ test('fail on user error with throw "abort"', async (t) => {
 
   const error = result.errors['job-1'];
 
-  t.is(error.type, 'UserError');
+  t.is(error.type, 'JobError');
   t.is(error.message, 'abort');
 });
 
@@ -240,6 +240,6 @@ test('adaptor error with no stack trace will be a user error', async (t) => {
   );
 
   const error = result.errors['job-1'];
-  t.is(error.type, 'UserError');
+  t.is(error.type, 'JobError');
   t.is(error.message, 'adaptor err');
 });

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -663,7 +663,7 @@ test('handle non-standard error objects', async (t) => {
   const result = await execute(plan, {}, mockLogger);
   t.truthy(result.errors);
   const err = result.errors.a;
-  t.is(err.type, 'UserError');
+  t.is(err.type, 'JobError');
   t.is(err.message, 'wibble');
 });
 
@@ -734,7 +734,7 @@ test('log appopriately on error', async (t) => {
   t.truthy(err);
   t.regex(err!.message as string, /Failed job job1 after \d+ms/i);
 
-  t.truthy(logger._find('error', /UserError: e/));
+  t.truthy(logger._find('error', /JobError: e/));
   t.truthy(logger._find('error', /Check state.errors.job1 for details/i));
 });
 

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -383,7 +383,7 @@ test('log errors, write to state, and continue', async (t) => {
 
   t.truthy(result.errors);
   t.is(result.errors.a.message, 'test');
-  t.is(result.errors.a.type, 'UserError');
+  t.is(result.errors.a.type, 'JobError');
 
   t.truthy(logger._find('error', /failed job a/i));
 });

--- a/packages/runtime/test/security.test.ts
+++ b/packages/runtime/test/security.test.ts
@@ -4,8 +4,6 @@ import doRun from '../src/runtime';
 
 import { createMockLogger } from '@openfn/logger';
 import { ExecutionPlan } from '../src/types';
-import { RuntimeError } from '../src/errors';
-import { platform } from 'os';
 
 // Disable strict mode for all these tests
 const run = (job: any, state?: any, options: any = {}) =>
@@ -16,6 +14,75 @@ const logger = createMockLogger(undefined, { level: 'default' });
 test.afterEach(() => {
   logger._reset();
 });
+
+test.serial.only(
+  'config should be scrubbed from the result state by default',
+  async (t) => {
+    const src = 'export default [(s) => s]';
+
+    const state = {
+      data: true,
+      configuration: {
+        password: 'secret',
+      },
+    };
+    const result: any = await run(src, state);
+    t.is(result.data, true);
+    t.is(result.configuration, undefined);
+  }
+);
+
+test.serial.only(
+  'config should be scrubbed from the result state in strict mode',
+  async (t) => {
+    const src = 'export default [(s) => s]';
+
+    const state = {
+      data: true,
+      configuration: {
+        password: 'secret',
+      },
+    };
+    const result: any = await run(src, state, { strict: true });
+    t.is(result.data, true);
+    t.is(result.configuration, undefined);
+  }
+);
+
+test.serial.only(
+  'config should be scrubbed from the result state in non-strict mode',
+  async (t) => {
+    const src = 'export default [(s) => s]';
+
+    const state = {
+      data: true,
+      configuration: {
+        password: 'secret',
+      },
+    };
+    const result: any = await run(src, state, { strict: false });
+    t.is(result.data, true);
+    t.is(result.configuration, undefined);
+  }
+);
+
+test.serial.only(
+  'config should be scrubbed from the result state after error',
+  async (t) => {
+    const src = 'export default [(s) => { throw "err" }]';
+
+    const state = {
+      data: true,
+      configuration: {
+        password: 'secret',
+      },
+    };
+    const result: any = await run(src, state, { strict: false });
+    t.truthy(result.errors);
+    t.is(result.data, true);
+    t.is(result.configuration, undefined);
+  }
+);
 
 test.serial('jobs should not have access to global scope', async (t) => {
   const src = 'export default [() => globalThis.x]';

--- a/packages/runtime/test/security.test.ts
+++ b/packages/runtime/test/security.test.ts
@@ -15,7 +15,7 @@ test.afterEach(() => {
   logger._reset();
 });
 
-test.serial.only(
+test.serial(
   'config should be scrubbed from the result state by default',
   async (t) => {
     const src = 'export default [(s) => s]';
@@ -32,7 +32,7 @@ test.serial.only(
   }
 );
 
-test.serial.only(
+test.serial(
   'config should be scrubbed from the result state in strict mode',
   async (t) => {
     const src = 'export default [(s) => s]';
@@ -49,7 +49,7 @@ test.serial.only(
   }
 );
 
-test.serial.only(
+test.serial(
   'config should be scrubbed from the result state in non-strict mode',
   async (t) => {
     const src = 'export default [(s) => s]';
@@ -66,7 +66,7 @@ test.serial.only(
   }
 );
 
-test.serial.only(
+test.serial(
   'config should be scrubbed from the result state after error',
   async (t) => {
     const src = 'export default [(s) => { throw "err" }]';

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # ws-worker
 
+## 0.2.4
+
+### Patch Changes
+
+- Updated dependencies [419f276]
+- Updated dependencies [0e66f5a]
+  - @openfn/runtime@0.1.2
+  - @openfn/engine-multi@0.1.9
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/ws-worker/test/reasons.test.ts
+++ b/packages/ws-worker/test/reasons.test.ts
@@ -105,7 +105,7 @@ test('fail: user error', async (t) => {
   const { reason } = await execute(plan);
   t.is(reason.reason, 'fail');
   t.is(reason.error_message, 'abort!');
-  t.is(reason.error_type, 'UserError');
+  t.is(reason.error_type, 'JobError');
 });
 
 test('fail: user error in the third job', async (t) => {
@@ -129,7 +129,7 @@ test('fail: user error in the third job', async (t) => {
   const { reason } = await execute(plan);
   t.is(reason.reason, 'fail');
   t.is(reason.error_message, 'abort!');
-  t.is(reason.error_type, 'UserError');
+  t.is(reason.error_type, 'JobError');
 });
 
 // We should ignore fails on non-leaf nodes (because a downstream leaf may anticipate and correct the error)


### PR DESCRIPTION
The runtime, after executing an expression (job), should remove the configuration property from state before returning.

But,  if there was an error during execution, it does not do this!

![image](https://github.com/OpenFn/kit/assets/7052509/75412259-6a4e-4d87-823d-2437f44f509c)

After the runtime finishes executing it calls out to a function to sanitize the state and ensure that it is safely serialisable. This cleaned state then gets pushed downstream (or back to the user).

But in the event of an error, it'll continue executing the workflow without this cleaning step.

If this is a non-leaf node, the next job will run with a clean state and config and it doesn't really matter. But if it's a leaf node, we would return the state object as it appears at the point of error.

This PR ensures we sanitize state even after error, and pass the sanitised state downstream.

![image](https://github.com/OpenFn/kit/assets/7052509/b661decb-e075-435c-bae5-4ee8b5562b33)

## Question

Now, here's a question.

After an error, do we pass downstream/return the state as it was at the point of error, OR the pristine initial state at the start of the job?

Do keep the incomplete state from the job or do we reset it?

At the moment we keep the incomplete state. This seems fine. I do not know the correct answer.

## Bonus Fix

Two things have been annoying me about errors so I've rushed in some quick fixes here:
* Remove the includeStackTrace key from errors, which I am not using
* Rename UserError to JobError (which feels like less of a personal attack)