### PR TITLE
Fix input_data_clip id

### DIFF
--- a/.changeset/shaggy-cups-reply.md
+++ b/.changeset/shaggy-cups-reply.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+Broadcast next steps with job-complete and error events

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -16,7 +16,6 @@ import {
   assertRuntimeError,
   assertSecurityKill,
 } from '../errors';
-import { NOTIFY_JOB_COMPLETE, NOTIFY_JOB_START } from '../events';
 
 export type ExecutionErrorWrapper = {
   state: any;
@@ -26,12 +25,11 @@ export type ExecutionErrorWrapper = {
 export default (
   ctx: ExecutionContext,
   expression: string | Operation[],
-  initialState: State,
-  id?: string
+  initialState: State
 ) =>
   new Promise(async (resolve, reject) => {
     let duration = Date.now();
-    const { logger, notify = () => {}, opts = {} } = ctx;
+    const { logger, opts = {} } = ctx;
     try {
       const timeout = opts.timeout || TIMEOUT;
 
@@ -55,7 +53,6 @@ export default (
 
       // Run the pipeline
       logger.debug(`Executing expression (${operations.length} operations)`);
-      notify(NOTIFY_JOB_START, { jobId: id });
 
       const tid = setTimeout(() => {
         logger.error(`Error: Timeout (${timeout}ms) expired!`);
@@ -72,12 +69,6 @@ export default (
       duration = Date.now() - duration;
 
       const finalState = prepareFinalState(opts, result);
-
-      notify(NOTIFY_JOB_COMPLETE, {
-        duration,
-        state: finalState,
-        jobId: id,
-      });
 
       // return the final state
       resolve(finalState);

--- a/packages/runtime/src/execute/job.ts
+++ b/packages/runtime/src/execute/job.ts
@@ -43,94 +43,8 @@ const loadState = async (
   return job.state;
 };
 
-// The job handler is responsible for preparing the job
-// and working out where to go next
-// it'll resolve credentials and state and notify how long init took
-const executeJob = async (
-  ctx: ExecutionContext,
-  job: CompiledJobNode,
-  initialState: State = {}
-): Promise<{ next: JobNodeID[]; state: any }> => {
+const calculateNext = (job: CompiledJobNode, result: any) => {
   const next: string[] = [];
-
-  const { opts, notify, logger, report } = ctx;
-
-  const duration = Date.now();
-
-  notify(NOTIFY_INIT_START);
-
-  // lazy load config and state
-  const configuration = await loadCredentials(
-    job,
-    opts.callbacks?.resolveCredential! // cheat - we need to handle the error case here
-  );
-
-  const globals = await loadState(
-    job,
-    opts.callbacks?.resolveState! // and here
-  );
-
-  const state = assembleState(
-    clone(initialState),
-    configuration,
-    globals,
-    opts.strict
-  );
-
-  notify(NOTIFY_INIT_COMPLETE, { duration: Date.now() - duration });
-
-  // We should by this point have validated the plan, so the job MUST exist
-
-  logger.timer('job');
-  logger.always('Starting job', job.id);
-
-  // The expression SHOULD return state, but COULD return anything
-  let result: any = state;
-  if (job.expression) {
-    const startTime = Date.now();
-    try {
-      // TODO include the upstream job
-      notify(NOTIFY_JOB_START, { jobId: job.id });
-      result = await executeExpression(ctx, job.expression, state);
-      const humanDuration = logger.timer('job');
-      logger.success(`Completed job ${job.id} in ${humanDuration}`);
-
-      // TODO should we also include the downstream jobs here?
-      // That's a little bit more complicated to work out
-      notify(NOTIFY_JOB_COMPLETE, {
-        duration,
-        state: result,
-        jobId: job.id,
-      });
-    } catch (e: any) {
-      if (e.hasOwnProperty('error') && e.hasOwnProperty('state')) {
-        const { error, state } = e as ExecutionErrorWrapper;
-
-        // Whatever the final state was, save that as the intial state to the next thing
-        result = state;
-
-        const duration = logger.timer('job');
-        logger.error(`Failed job ${job.id} after ${duration}`);
-        report(state, job.id, error);
-
-        notify(NOTIFY_JOB_ERROR, {
-          duration: Date.now() - startTime,
-          error,
-          state,
-          jobId: job.id,
-        });
-
-        // Stop executing if the error is sufficiently severe
-        if (error.severity === 'crash' || error.severity === 'kill') {
-          throw error;
-        }
-      } else {
-        // It should be impossible to get here
-        throw e;
-      }
-    }
-  }
-
   if (job.next) {
     for (const nextJobId in job.next) {
       const edge = job.next[nextJobId];
@@ -155,6 +69,105 @@ const executeJob = async (
       // TODO errors
     }
   }
+  return next;
+};
+
+// The job handler is responsible for preparing the job
+// and working out where to go next
+// it'll resolve credentials and state and notify how long init took
+const executeJob = async (
+  ctx: ExecutionContext,
+  job: CompiledJobNode,
+  initialState: State = {}
+): Promise<{ next: JobNodeID[]; state: any }> => {
+  const { opts, notify, logger, report } = ctx;
+
+  const duration = Date.now();
+
+  const jobId = job.id;
+
+  notify(NOTIFY_INIT_START, { jobId });
+
+  // lazy load config and state
+  const configuration = await loadCredentials(
+    job,
+    opts.callbacks?.resolveCredential! // cheat - we need to handle the error case here
+  );
+
+  const globals = await loadState(
+    job,
+    opts.callbacks?.resolveState! // and here
+  );
+
+  const state = assembleState(
+    clone(initialState),
+    configuration,
+    globals,
+    opts.strict
+  );
+
+  notify(NOTIFY_INIT_COMPLETE, { jobId, duration: Date.now() - duration });
+
+  // We should by this point have validated the plan, so the job MUST exist
+
+  logger.timer('job');
+  logger.always('Starting job', jobId);
+
+  // The expression SHOULD return state, but COULD return anything
+  let result: any = state;
+  let next: string[] = [];
+  let didError = false;
+  if (job.expression) {
+    const startTime = Date.now();
+    try {
+      // TODO include the upstream job
+      notify(NOTIFY_JOB_START, { jobId });
+      result = await executeExpression(ctx, job.expression, state);
+      const humanDuration = logger.timer('job');
+      logger.success(`Completed job ${jobId} in ${humanDuration}`);
+    } catch (e: any) {
+      didError = true;
+      if (e.hasOwnProperty('error') && e.hasOwnProperty('state')) {
+        const { error, state } = e as ExecutionErrorWrapper;
+
+        // Whatever the final state was, save that as the intial state to the next thing
+        result = state;
+
+        const duration = logger.timer('job');
+        logger.error(`Failed job ${jobId} after ${duration}`);
+        report(state, jobId, error);
+
+        next = calculateNext(job, result);
+
+        notify(NOTIFY_JOB_ERROR, {
+          duration: Date.now() - startTime,
+          error,
+          state,
+          jobId,
+          next,
+        });
+
+        // Stop executing if the error is sufficiently severe
+        if (error.severity === 'crash' || error.severity === 'kill') {
+          throw error;
+        }
+      } else {
+        // It should be impossible to get here
+        throw e;
+      }
+    }
+  }
+
+  if (!didError) {
+    next = calculateNext(job, result);
+    notify(NOTIFY_JOB_COMPLETE, {
+      duration: Date.now() - duration,
+      state: result,
+      jobId,
+      next,
+    });
+  }
+
   return { next, state: result };
 };
 

--- a/packages/runtime/src/execute/plan.ts
+++ b/packages/runtime/src/execute/plan.ts
@@ -49,7 +49,7 @@ const executePlan = async (
     initialState = await opts.callbacks?.resolveState?.(id);
 
     const duration = Date.now() - startTime;
-    opts.callbacks?.notify?.(NOTIFY_STATE_LOAD, { duration, id });
+    opts.callbacks?.notify?.(NOTIFY_STATE_LOAD, { duration, jobId: id });
     logger.success(`loaded state for ${id} in ${duration}ms`);
 
     // TODO catch and re-throw

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -114,13 +114,18 @@ export type JobModule = {
   // TODO lifecycle hooks
 };
 
+type NotifyHandler = (
+  event: NotifyEvents,
+  payload: NotifyEventsLookup[typeof event]
+) => void;
+
 // TODO difficulty: this is not the same as a vm execution context
 export type ExecutionContext = {
   plan: CompiledExecutionPlan;
   logger: Logger;
   opts: Options;
   report: ErrorReporter;
-  notify: (evt: NotifyEvents, payload?: any) => void;
+  notify: NotifyHandler;
 };
 
 export type NotifyEvents =
@@ -131,8 +136,50 @@ export type NotifyEvents =
   | typeof NOTIFY_JOB_ERROR
   | typeof NOTIFY_STATE_LOAD;
 
+export type NotifyJobInitStartPayload = {
+  jobId: string;
+};
+
+export type NotifyJobInitCompletePayload = {
+  duration: number;
+  jobId: string;
+};
+
+export type NotifyJobCompletePayload = {
+  duration: number;
+  state: any;
+  jobId: string;
+  next: string[];
+};
+
+export type NotifyJobErrorPayload = {
+  duration: number;
+  error?: any; // TODO I should be able to do better than this because I have a standard error interface
+  state: any;
+  jobId: string;
+  next: string[];
+};
+
+export type NotifyJobStartPayload = {
+  jobId: string;
+};
+
+export type NotifyStateLoadPayload = {
+  jobId: string;
+  duration: number;
+};
+
+export type NotifyEventsLookup = {
+  [NOTIFY_INIT_START]: NotifyJobInitStartPayload;
+  [NOTIFY_INIT_COMPLETE]: NotifyJobInitCompletePayload;
+  [NOTIFY_JOB_START]: NotifyJobStartPayload;
+  [NOTIFY_JOB_COMPLETE]: NotifyJobCompletePayload;
+  [NOTIFY_JOB_ERROR]: NotifyJobErrorPayload;
+  [NOTIFY_STATE_LOAD]: NotifyStateLoadPayload;
+};
+
 export type ExecutionCallbacks = {
-  notify?(event: NotifyEvents, payload: any): void;
+  notify: NotifyHandler;
   resolveState?: (stateId: string) => Promise<any>;
   resolveCredential?: (credentialId: string) => Promise<any>;
 };

--- a/packages/runtime/test/execute/expression.test.ts
+++ b/packages/runtime/test/execute/expression.test.ts
@@ -1,9 +1,8 @@
 import test from 'ava';
 import { fn } from '@openfn/language-common';
-import type { State, Operation, ExecutionContext } from '../../src/types';
 import { createMockLogger } from '@openfn/logger';
 import execute from '../../src/execute/expression';
-import { NOTIFY_JOB_COMPLETE, NOTIFY_JOB_START } from '../../src';
+import type { State, Operation, ExecutionContext } from '../../src/types';
 
 type TestState = State & {
   data: {
@@ -65,69 +64,6 @@ test('run a live no-op job with @openfn/language-common.fn', async (t) => {
   const result = await execute(context, job, state);
 
   t.deepEqual(state, result);
-});
-
-test(`notify ${NOTIFY_JOB_START}`, async (t) => {
-  let didCallCallback = false;
-
-  const expression = [(s: State) => s];
-  const state = createState();
-
-  const notify = (event: string, payload?: any) => {
-    if (event === NOTIFY_JOB_START) {
-      didCallCallback = true;
-    }
-    t.is(payload.jobId, 'j');
-  };
-
-  const context = createContext({ notify });
-
-  await execute(context, expression, state, 'j');
-  t.true(didCallCallback);
-});
-
-test(`notify ${NOTIFY_JOB_COMPLETE}`, async (t) => {
-  let didCallCallback = false;
-
-  const expression = [(s: State) => s];
-  const state = createState();
-
-  const notify = (event: string, payload: any) => {
-    if (event === NOTIFY_JOB_COMPLETE) {
-      const { state, duration, jobId } = payload;
-      didCallCallback = true;
-      t.truthy(state);
-      t.deepEqual(state, state);
-      t.assert(!isNaN(duration));
-      t.is(jobId, 'j');
-    }
-  };
-
-  const context = createContext({ notify });
-
-  await execute(context, expression, state, 'j');
-  t.true(didCallCallback);
-});
-
-test(`notify ${NOTIFY_JOB_COMPLETE} should publish serializable state`, async (t) => {
-  // Promises will trigger an exception if you try to serialize them
-  // If we don't return finalState in  execute/expression, this test will fail
-  const resultState = { x: new Promise((r) => r), y: 22 };
-  const expression = [(s: State) => resultState];
-  const state = createState();
-
-  const notify = (event: string, payload: any) => {
-    if (event === NOTIFY_JOB_COMPLETE) {
-      const { state, duration, jobId } = payload;
-      t.truthy(state);
-      t.assert(!isNaN(duration));
-      t.is(jobId, 'j');
-    }
-  };
-
-  const context = createContext({ notify });
-
-  await execute(context, expression, state, 'j');
 });
 
 test('jobs can handle a promise', async (t) => {

--- a/packages/runtime/test/execute/job.test.ts
+++ b/packages/runtime/test/execute/job.test.ts
@@ -1,0 +1,93 @@
+import test from 'ava';
+import { createMockLogger } from '@openfn/logger';
+
+import { NOTIFY_JOB_COMPLETE, NOTIFY_JOB_START } from '../../src';
+import execute from '../../src/execute/job';
+
+import type { ExecutionContext, State } from '../../src/types';
+
+const createState = (data = {}) => ({
+  data: data,
+  configuration: {},
+});
+
+const logger = createMockLogger(undefined, { level: 'debug' });
+
+const createContext = (args = {}) =>
+  ({
+    logger,
+    plan: {},
+    opts: {},
+    notify: () => {},
+    report: () => {},
+    ...args,
+  } as unknown as ExecutionContext);
+
+test.afterEach(() => {
+  logger._reset();
+});
+
+test(`notify ${NOTIFY_JOB_START}`, async (t) => {
+  const job = {
+    id: 'j',
+    expression: [(s: State) => s],
+  };
+  const state = createState();
+
+  const notify = (event: string, payload?: any) => {
+    if (event === NOTIFY_JOB_START) {
+      t.is(payload.jobId, 'j');
+    }
+  };
+
+  const context = createContext({ notify });
+
+  await execute(context, job, state);
+});
+
+test(`notify ${NOTIFY_JOB_COMPLETE}`, async (t) => {
+  const job = {
+    id: 'j',
+    expression: [(s: State) => s],
+  };
+
+  const state = createState();
+
+  const notify = (event: string, payload: any) => {
+    if (event === NOTIFY_JOB_COMPLETE) {
+      const { state, duration, jobId } = payload;
+      t.truthy(state);
+      t.deepEqual(state, state);
+      t.assert(!isNaN(duration));
+      t.is(jobId, 'j');
+    }
+  };
+
+  const context = createContext({ notify });
+
+  await execute(context, job, state);
+});
+
+test(`notify ${NOTIFY_JOB_COMPLETE} should publish serializable state`, async (t) => {
+  // Promises will trigger an exception if you try to serialize them
+  // If we don't return finalState in  execute/expression, this test will fail
+  const resultState = { x: new Promise((r) => r), y: 22 };
+  const job = {
+    id: 'j',
+    expression: [() => resultState],
+  };
+  const state = createState();
+
+  const notify = (event: string, payload: any) => {
+    if (event === NOTIFY_JOB_COMPLETE) {
+      const { state, duration, jobId } = payload;
+      t.truthy(state);
+      t.assert(!isNaN(duration));
+      t.is(jobId, 'j');
+    }
+  };
+
+  const context = createContext({ notify });
+
+  await execute(context, job, state);
+});

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -801,7 +801,7 @@ test('keep executing after an error', async (t) => {
   t.falsy(result.x);
 });
 
-test('simple on-error handler', async (t) => {
+test.only('simple on-error handler', async (t) => {
   const plan: ExecutionPlan = {
     jobs: [
       {

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -634,6 +634,75 @@ test('execute multiple steps in "parallel"', async (t) => {
   });
 });
 
+test('isolate state in "parallel" execution', async (t) => {
+  const plan: ExecutionPlan = {
+    start: 'start',
+    initialState: { data: { x: 0 } },
+    jobs: [
+      {
+        id: 'start',
+        expression: 'export default [s => s]',
+        next: {
+          b: true,
+          c: true,
+        },
+      },
+      {
+        id: 'b',
+        expression:
+          'export default [s => { if (s.data.c) { throw "e" }; s.data.b = true; return s }]',
+      },
+      {
+        id: 'c',
+        expression:
+          'export default [s => { if (s.data.b) { throw "e" }; s.data.c = true; return s }]',
+      },
+    ],
+  };
+
+  const result = await execute(plan, {}, mockLogger);
+  t.falsy(result.errors);
+});
+
+test('"parallel" execution with multiple leaves should write multiple results to state', async (t) => {
+  const plan: ExecutionPlan = {
+    start: 'start',
+    jobs: [
+      {
+        id: 'start',
+        expression: 'export default [s => s]',
+        next: {
+          'job-b': true,
+          'job-c': true,
+        },
+      },
+      {
+        id: 'job-b',
+        expression: 'export default [s => { s.data.b = true; return s }]',
+      },
+      {
+        id: 'job-c',
+        expression: 'export default [s => { s.data.c = true; return s }]',
+      },
+    ],
+  };
+
+  const result = await execute(plan, {}, mockLogger);
+  // Each leaf should write to its own place on state
+  t.deepEqual(result, {
+    'job-b': {
+      data: {
+        b: true,
+      },
+    },
+    'job-c': {
+      data: {
+        c: true,
+      },
+    },
+  });
+});
+
 test('return an error in state', async (t) => {
   const plan: ExecutionPlan = {
     jobs: [


### PR DESCRIPTION
* [x] Add more tests around parallelisation in the runtime (it's fine!)
* [x] In the runtime, publish the next steps when a job is completed (this was a big deal)
* [ ] In the worker, use the next step information to work out the correct input_dataclip_id