### PR TITLE
Leave channels

### DIFF
--- a/.changeset/five-mirrors-smile.md
+++ b/.changeset/five-mirrors-smile.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+worker: leave attempt channel when finished working

--- a/.changeset/old-mails-wash.md
+++ b/.changeset/old-mails-wash.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+Fix log output for job duration

--- a/packages/runtime/src/execute/job.ts
+++ b/packages/runtime/src/execute/job.ts
@@ -110,7 +110,8 @@ const executeJob = async (
 
   // We should by this point have validated the plan, so the job MUST exist
 
-  logger.timer('job');
+  const timerId = `job-${jobId}`;
+  logger.timer(timerId);
   logger.always('Starting job', jobId);
 
   // The expression SHOULD return state, but COULD return anything
@@ -123,7 +124,7 @@ const executeJob = async (
       // TODO include the upstream job
       notify(NOTIFY_JOB_START, { jobId });
       result = await executeExpression(ctx, job.expression, state);
-      const humanDuration = logger.timer('job');
+      const humanDuration = logger.timer(timerId);
       logger.success(`Completed job ${jobId} in ${humanDuration}`);
     } catch (e: any) {
       didError = true;
@@ -133,7 +134,7 @@ const executeJob = async (
         // Whatever the final state was, save that as the intial state to the next thing
         result = state;
 
-        const duration = logger.timer('job');
+        const duration = logger.timer(timerId);
         logger.error(`Failed job ${jobId} after ${duration}`);
         report(state, jobId, error);
 

--- a/packages/runtime/test/execute/job.test.ts
+++ b/packages/runtime/test/execute/job.test.ts
@@ -239,3 +239,18 @@ test(`notify ${NOTIFY_JOB_ERROR} for a fail`, async (t) => {
 
   await execute(context, job, state);
 });
+
+test('log duration of execution', async (t) => {
+  const job = {
+    id: 'j',
+    expression: [(s: State) => s],
+  };
+  const initialState = createState();
+  const context = createContext();
+
+  await execute(context, job, initialState);
+
+  const duration = logger._find('success', /completed job /i);
+
+  t.regex(duration?.message, /completed job j in \d\d?ms/i);
+});

--- a/packages/ws-worker/src/api/execute.ts
+++ b/packages/ws-worker/src/api/execute.ts
@@ -35,7 +35,7 @@ export type Context = {
   channel: Channel;
   state: AttemptState;
   logger: Logger;
-  onComplete: (result: any) => void;
+  onFinish: (result: any) => void;
 };
 
 // mapping engine events to lightning events
@@ -55,13 +55,13 @@ export function execute(
   logger: Logger,
   plan: ExecutionPlan,
   options: AttemptOptions = {},
-  onComplete = (_result: any) => {}
+  onFinish = (_result: any) => {}
 ) {
   logger.info('executing ', plan.id);
 
   const state = createAttemptState(plan, options);
 
-  const context: Context = { channel, state, logger, onComplete };
+  const context: Context = { channel, state, logger, onFinish };
 
   type EventHandler = (context: any, event: any) => void;
 
@@ -253,7 +253,7 @@ export function onWorkflowStart(
 }
 
 export async function onWorkflowComplete(
-  { state, channel, onComplete }: Context,
+  { state, channel, onFinish }: Context,
   _event: WorkflowCompletePayload
 ) {
   // TODO I dont think the attempt final dataclip IS the last job dataclip
@@ -264,14 +264,14 @@ export async function onWorkflowComplete(
     final_dataclip_id: state.lastDataclipId!,
     ...reason,
   });
-  onComplete({ reason, state: result });
+  onFinish({ reason, state: result });
 }
 
 // On error, for now, we just post to workflow complete
 // No unit tests on this (not least because I think it'll change soon)
 // NB this is a crash state!
 export async function onWorkflowError(
-  { state, channel, onComplete }: Context,
+  { state, channel, onFinish }: Context,
   event: WorkflowErrorPayload
 ) {
   // Should we not just report this reason?
@@ -285,7 +285,7 @@ export async function onWorkflowError(
     ...reason,
   });
 
-  onComplete({ reason });
+  onFinish({ reason });
 }
 
 export function onJobLog({ channel, state }: Context, event: JSONLog) {

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -149,8 +149,9 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
       } = await joinAttemptChannel(app.socket, token, id, logger);
 
       // Callback to be triggered when the work is done (including errors)
-      const onComplete = () => {
+      const onFinish = () => {
         delete app.workflows[id];
+        attemptChannel.leave();
       };
       const context = execute(
         attemptChannel,
@@ -158,7 +159,7 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
         logger,
         plan,
         options,
-        onComplete
+        onFinish
       );
 
       app.workflows[id] = context;

--- a/packages/ws-worker/test/api/execute.test.ts
+++ b/packages/ws-worker/test/api/execute.test.ts
@@ -340,11 +340,11 @@ test('workflowComplete should send an attempt:complete event', async (t) => {
 
   const event = {};
 
-  const context = { channel, state, onComplete: () => {} };
+  const context = { channel, state, onFinish: () => {} };
   await onWorkflowComplete(context, event);
 });
 
-test('workflowComplete should call onComplete with final dataclip', async (t) => {
+test('workflowComplete should call onFinish with final dataclip', async (t) => {
   const result = { answer: 42 };
 
   const state = {
@@ -362,7 +362,7 @@ test('workflowComplete should call onComplete with final dataclip', async (t) =>
   const context = {
     channel,
     state,
-    onComplete: ({ state: finalState }) => {
+    onFinish: ({ state: finalState }) => {
       t.deepEqual(result, finalState);
     },
   };
@@ -398,7 +398,7 @@ test('loadCredential should fetch a credential', async (t) => {
   t.deepEqual(state, { apiKey: 'abc' });
 });
 
-test('execute should pass the final result to onComplete', async (t) => {
+test('execute should pass the final result to onFinish', async (t) => {
   const channel = mockChannel(mockEventHandlers);
   const engine = await createMockRTE();
   const logger = createMockLogger();

--- a/packages/ws-worker/test/reasons.test.ts
+++ b/packages/ws-worker/test/reasons.test.ts
@@ -16,7 +16,7 @@ import {
 import { ExitReason } from '../src/types';
 
 // Explicit tests of exit reasons coming out of the worker
-// these test the onComplete callback
+// these test the onFinish callback
 // uses the real runtime engine
 
 let engine;
@@ -48,12 +48,12 @@ const execute = async (plan) =>
       [ATTEMPT_COMPLETE]: async () => true,
     });
 
-    const onComplete = (result) => {
+    const onFinish = (result) => {
       done(result);
     };
 
     // @ts-ignore
-    doExecute(channel, engine, logger, plan, {}, onComplete);
+    doExecute(channel, engine, logger, plan, {}, onFinish);
   });
 
 test('success', async (t) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,19 +146,19 @@ importers:
         specifier: ^5.1.6
         version: 5.1.6
 
-  integration-tests/worker/tmp/openfn/repo/attempts:
+  integration-tests/worker/tmp/repo/attempts:
     dependencies:
       '@openfn/language-common_latest':
         specifier: npm:@openfn/language-common@^1.11.1
         version: /@openfn/language-common@1.11.1
 
-  integration-tests/worker/tmp/openfn/repo/exit-reason:
+  integration-tests/worker/tmp/repo/exit-reason:
     dependencies:
       '@openfn/language-common_latest':
         specifier: npm:@openfn/language-common@^1.11.1
         version: /@openfn/language-common@1.11.1
 
-  integration-tests/worker/tmp/openfn/repo/integration:
+  integration-tests/worker/tmp/repo/integration:
     dependencies:
       '@openfn/language-common_latest':
         specifier: npm:@openfn/language-common@^1.11.1


### PR DESCRIPTION
Leave the attempt channel when work is finished.

Silly that I'm not doing this already.

I think this is triggering timeout errors after work is finished.

This is one of several small fixes I'm likely to raise - I'll bundle them up here when done

Also: 

* Fix job duration in logs
