### PR TITLE
Maybe fix purge?

### DIFF
--- a/.changeset/five-seals-divide.md
+++ b/.changeset/five-seals-divide.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-engine': patch
+---
+
+Updated purge strategy

--- a/packages/engine-multi/src/api/call-worker.ts
+++ b/packages/engine-multi/src/api/call-worker.ts
@@ -48,18 +48,17 @@ export default function initWorkers(
       promise.timeout(timeout);
     }
 
-    if (options.purge) {
-      promise.then(() => {
-        const { pendingTasks } = workers.stats();
-        if (pendingTasks == 0) {
-          logger?.debug('Purging workers');
-          api.emit(PURGE);
-          workers.terminate();
-        }
-      });
-    }
-
     return promise;
+  };
+
+  // @ts-ignore
+  api.purge = () => {
+    const { pendingTasks } = workers.stats();
+    if (pendingTasks == 0) {
+      logger?.debug('Purging workers');
+      api.emit(PURGE);
+      workers.terminate();
+    }
   };
 
   // This will force termination instantly

--- a/packages/engine-multi/src/api/call-worker.ts
+++ b/packages/engine-multi/src/api/call-worker.ts
@@ -51,7 +51,6 @@ export default function initWorkers(
     return promise;
   };
 
-  // @ts-ignore
   engine.purge = () => {
     const { pendingTasks } = workers.stats();
     if (pendingTasks == 0) {

--- a/packages/engine-multi/src/api/call-worker.ts
+++ b/packages/engine-multi/src/api/call-worker.ts
@@ -23,7 +23,7 @@ type WorkerOptions = {
 
 // Adds a `callWorker` function to the API object, which will execute a task in a worker
 export default function initWorkers(
-  api: EngineAPI,
+  engine: EngineAPI,
   workerPath: string,
   options: WorkerOptions = {},
   logger?: Logger
@@ -31,7 +31,7 @@ export default function initWorkers(
   // TODO can we verify the worker path and throw if it's invalid?
   // workerpool won't complain if we give it a nonsense path
   const workers = createWorkers(workerPath, options);
-  api.callWorker = (
+  engine.callWorker = (
     task: string,
     args: any[] = [],
     events: any = {},
@@ -52,17 +52,17 @@ export default function initWorkers(
   };
 
   // @ts-ignore
-  api.purge = () => {
+  engine.purge = () => {
     const { pendingTasks } = workers.stats();
     if (pendingTasks == 0) {
       logger?.debug('Purging workers');
-      api.emit(PURGE);
+      engine.emit(PURGE);
       workers.terminate();
     }
   };
 
   // This will force termination instantly
-  api.closeWorkers = () => {
+  engine.closeWorkers = () => {
     workers.terminate(true);
 
     // Defer the return to allow workerpool to close down

--- a/packages/engine-multi/src/engine.ts
+++ b/packages/engine-multi/src/engine.ts
@@ -98,11 +98,6 @@ const createEngine = async (options: EngineOptions, workerPath?: string) => {
   const contexts: Record<string, ExecutionContext> = {};
   const deferredListeners: Record<string, Record<string, EventHandler>[]> = {};
 
-  // TODO I think this is for later
-  //const activeWorkflows: string[] = [];
-
-  // TOOD I wonder if the engine should a) always accept a worker path
-  // and b) validate it before it runs
   let resolvedWorkerPath;
   if (workerPath) {
     // If a path to the worker has been passed in, just use it verbatim
@@ -190,9 +185,7 @@ const createEngine = async (options: EngineOptions, workerPath?: string) => {
       // @ts-ignore
       execute(context).finally(() => {
         delete contexts[workflowId];
-        // @ts-ignore
         if (Object.keys(contexts).length === 0) {
-          // @ts-ignore
           engine.purge?.();
         }
       });
@@ -207,7 +200,6 @@ const createEngine = async (options: EngineOptions, workerPath?: string) => {
         context.once(evt, fn),
       off: (evt: string, fn: (...args: any[]) => void) => context.off(evt, fn),
     };
-    // return context;
   };
 
   const listen = (

--- a/packages/engine-multi/src/engine.ts
+++ b/packages/engine-multi/src/engine.ts
@@ -183,14 +183,19 @@ const createEngine = async (options: EngineOptions, workerPath?: string) => {
       delete deferredListeners[workflowId];
     }
 
-    // execute(context);
-
     // Run the execute on a timeout so that consumers have a chance
     // to register listeners
     setTimeout(() => {
       // TODO typing between the class and interface isn't right
       // @ts-ignore
-      execute(context);
+      execute(context).finally(() => {
+        delete contexts[workflowId];
+        // @ts-ignore
+        if (Object.keys(contexts).length === 0) {
+          // @ts-ignore
+          engine.purge?.();
+        }
+      });
     }, 1);
 
     // hmm. Am I happy to pass the internal workflow state OUT of the handler?

--- a/packages/engine-multi/src/engine.ts
+++ b/packages/engine-multi/src/engine.ts
@@ -185,7 +185,7 @@ const createEngine = async (options: EngineOptions, workerPath?: string) => {
       // @ts-ignore
       execute(context).finally(() => {
         delete contexts[workflowId];
-        if (Object.keys(contexts).length === 0) {
+        if (options.purge && Object.keys(contexts).length === 0) {
           engine.purge?.();
         }
       });

--- a/packages/engine-multi/src/types.ts
+++ b/packages/engine-multi/src/types.ts
@@ -64,6 +64,7 @@ export interface ExecutionContext extends EventEmitter {
 export interface EngineAPI extends EventEmitter {
   callWorker: CallWorker;
   closeWorkers: () => void;
+  purge?: () => void;
 }
 
 export interface RuntimeEngine extends EventEmitter {

--- a/packages/engine-multi/test/api/call-worker.test.ts
+++ b/packages/engine-multi/test/api/call-worker.test.ts
@@ -12,7 +12,7 @@ let api = new EventEmitter() as EngineAPI;
 const workerPath = path.resolve('src/test/worker-functions.js');
 
 test.before(() => {
-  initWorkers(api, workerPath, { purge: true });
+  initWorkers(api, workerPath);
 });
 
 test.after(() => api.closeWorkers());
@@ -75,17 +75,6 @@ test.serial('callWorker should execute in a different process', async (t) => {
     };
 
     api.callWorker('test', [], { message: onCallback });
-  });
-});
-
-test.serial('callWorker should try to purge workers on complete', async (t) => {
-  return new Promise((done) => {
-    api.on(PURGE, () => {
-      t.pass('purge event called');
-      done();
-    });
-
-    api.callWorker('test', []);
   });
 });
 

--- a/packages/engine-multi/test/engine.test.ts
+++ b/packages/engine-multi/test/engine.test.ts
@@ -1,7 +1,6 @@
 import test from 'ava';
 import path from 'node:path';
 import { createMockLogger } from '@openfn/logger';
-import { createPlan } from '../src/test/util';
 
 import createEngine from '../src/engine';
 import * as e from '../src/events';

--- a/packages/engine-multi/test/engine.test.ts
+++ b/packages/engine-multi/test/engine.test.ts
@@ -239,3 +239,49 @@ test.serial('timeout the whole attempt and emit an error', async (t) => {
     engine.execute(plan, opts);
   });
 });
+
+test.serial('Purge workers when a run is complete', async (t) => {
+  return new Promise(async (done) => {
+    const p = path.resolve('src/test/worker-functions.js');
+    engine = await createEngine(options, p);
+
+    const plan = {
+      id: 'a',
+      jobs: [
+        {
+          expression: '34',
+        },
+      ],
+    };
+
+    engine.on(e.PURGE, () => {
+      t.pass('purge event called');
+      done();
+    });
+
+    engine.execute(plan);
+  });
+});
+
+test.serial('Purge workers when run errors', async (t) => {
+  return new Promise(async (done) => {
+    const p = path.resolve('src/test/worker-functions.js');
+    engine = await createEngine(options, p);
+
+    const plan = {
+      id: 'a',
+      jobs: [
+        {
+          expression: 'throw new Error("test")',
+        },
+      ],
+    };
+
+    engine.on(e.PURGE, () => {
+      t.pass('purge event called');
+      done();
+    });
+
+    engine.execute(plan);
+  });
+});

--- a/packages/engine-multi/test/integration.test.ts
+++ b/packages/engine-multi/test/integration.test.ts
@@ -83,7 +83,7 @@ test.serial('trigger job-complete', (t) => {
 
     api.execute(plan).on('job-complete', (evt) => {
       t.deepEqual(evt.next, []);
-      t.true(evt.duration < 10);
+      t.true(evt.duration < 20);
       t.is(evt.jobId, 'j1');
       t.deepEqual(evt.state, { data: {} });
       t.pass('job completed');


### PR DESCRIPTION
The existing purge will run after a workflow is completed if the workerpools workers are all idle.

But there are cases when workflows are active but not yet in the worker - when compiling or autoinstalling, for example.

I am a bit worried that we're purging worker threads on active workflows, and that might sometimes cause the workflows to fail.

I don't know, maybe not, it's all a bit woolly. It should be safe to kill an idle worker while autoinstall is running.

But we have been seeing intermittent timing issues in end to end tests, and I'm not seeing them on this branch. Plus this approach does feel a bit more robust and sensible than the old one.

So, we're going to merge it and see.