### PR TITLE
Worker: use real runtime in unit tests

### DIFF
--- a/.changeset/lovely-dodos-guess.md
+++ b/.changeset/lovely-dodos-guess.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': minor
+---
+
+Allow globals to be passed into the execution environment

--- a/packages/lightning-mock/src/api-dev.ts
+++ b/packages/lightning-mock/src/api-dev.ts
@@ -111,16 +111,18 @@ const setupDevAPI = (
     attemptId: string,
     fn: (evt: any) => void,
     once = true
-  ) => {
+  ): (() => void) => {
+    const unsubscribe = () => state.events.removeListener(event, handler);
     function handler(e: any) {
       if (e.attemptId && e.attemptId === attemptId) {
         if (once) {
-          state.events.removeListener(event, handler);
+          unsubscribe();
         }
         fn(e);
       }
     }
     state.events.addListener(event, handler);
+    return unsubscribe;
   };
 };
 

--- a/packages/runtime/src/execute/context.ts
+++ b/packages/runtime/src/execute/context.ts
@@ -15,11 +15,14 @@ const freezeAll = (
 
 // Build a safe and helpful execution context
 // This will be shared by all jobs
-export default (state: State, options: Pick<Options, 'jobLogger'>) => {
+export default (state: State, options: Pick<Options, 'jobLogger' | 'globals'>) => {
   const logger = options.jobLogger ?? console;
+  const globals = options.globals || {};
   const context = vm.createContext(
     freezeAll(
       {
+        ...globals,
+        // Note that these globals will be overridden
         console: logger,
         clearInterval,
         clearTimeout,

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -33,6 +33,9 @@ export type Options = {
   linker?: LinkerOptions;
 
   callbacks?: ExecutionCallbacks;
+
+  // inject globals into the environment
+  globals?: any;
 };
 
 const defaultState = { data: {}, configuration: {} };

--- a/packages/ws-worker/src/mock/runtime-engine.ts
+++ b/packages/ws-worker/src/mock/runtime-engine.ts
@@ -91,6 +91,7 @@ async function createMock() {
           level: 'info',
           json: true,
           message: args,
+          time: Date.now(),
         });
       },
     };
@@ -115,7 +116,16 @@ async function createMock() {
     setTimeout(async () => {
       dispatch('workflow-start', { workflowId: id });
 
-      await run(xplan, undefined, opts);
+      try {
+        await run(xplan, undefined, opts);
+      } catch (e: any) {
+        // TODO I have no test on this
+        dispatch('workflow-error', {
+          workflowId: id,
+          type: e.name,
+          message: e.message,
+        });
+      }
 
       delete activeWorkflows[id!];
       dispatch('workflow-complete', { workflowId: id });

--- a/packages/ws-worker/src/mock/runtime-engine.ts
+++ b/packages/ws-worker/src/mock/runtime-engine.ts
@@ -27,10 +27,11 @@ export type WorkflowErrorEvent = {
 
 // this is basically a fake adaptor
 // these functions will be injected into scope
-// maybe
-// needs me to add the globals option to the runtime
-// (which is fine)
-const helpers = {};
+const helpers = {
+  fn: (f: Function) => (s: any) => f(s),
+  wait: (duration: number) => (s: any) =>
+    new Promise((resolve) => setTimeout(resolve, duration)),
+};
 
 // The mock runtime engine creates a fake engine interface
 // around a real runtime engine
@@ -80,6 +81,11 @@ async function createMock() {
           job.configuration
         );
       }
+
+      // Fake compilation
+      if (job.expression && !job.expression.match(/export default \[/)) {
+        job.expression = `export default [${job.expression}];`;
+      }
     }
 
     // TODO do I need a more sophisticated solution here?
@@ -99,6 +105,7 @@ async function createMock() {
       strict: false,
       jobLogger,
       ...options,
+      globals: helpers,
       callbacks: {
         notify: (name: NotifyEvents, payload: any) => {
           // TODO events need to be mapped into runtime engine events (noot runtime events)

--- a/packages/ws-worker/src/mock/runtime-engine.ts
+++ b/packages/ws-worker/src/mock/runtime-engine.ts
@@ -1,6 +1,5 @@
-import crypto from 'node:crypto';
 import { EventEmitter } from 'node:events';
-import run, { ExecutionPlan, JobNode, NotifyEvents } from '@openfn/runtime';
+import run, { ExecutionPlan, NotifyEvents } from '@openfn/runtime';
 import * as engine from '@openfn/engine-multi';
 import mockResolvers from './resolvers';
 
@@ -74,9 +73,9 @@ async function createMock() {
     const { id, jobs } = xplan;
     activeWorkflows[id!] = true;
 
-    // Call the crendtial callback, but don't do anything with it
     for (const job of jobs) {
       if (typeof job.configuration === 'string') {
+        // Call the crendtial callback, but don't do anything with it
         job.configuration = await options.resolvers.credential?.(
           job.configuration
         );
@@ -98,13 +97,10 @@ async function createMock() {
 
     const opts = {
       strict: false,
-      // logger?
       jobLogger,
-      // linker?
       ...options,
       callbacks: {
         notify: (name: NotifyEvents, payload: any) => {
-          // console.log(name, payload);
           // TODO events need to be mapped into runtime engine events (noot runtime events)
           dispatch(name, {
             workflowId: id,
@@ -134,117 +130,6 @@ async function createMock() {
     // Technically the engine should return an event emitter
     // But as I don't think we use it, I'm happy to ignore this
   };
-
-  // const executeJob = async (
-  //   workflowId: string,
-  //   job: JobNode,
-  //   initialState = {},
-  //   resolvers: engine.Resolvers = mockResolvers
-  // ) => {
-  //   const { id, expression, configuration, adaptor } = job;
-
-  //   // If no expression or adaptor, this is (probably) a trigger node.
-  //   // Silently do nothing
-  //   if (!expression && !adaptor) {
-  //     return initialState;
-  //   }
-
-  //   const runId = crypto.randomUUID();
-
-  //   const jobId = id;
-  //   if (typeof configuration === 'string') {
-  //     // Fetch the credential but do nothing with it
-  //     // Maybe later we use it to assemble state
-  //     await resolvers.credential?.(configuration);
-  //   }
-
-  //   const info = (...message: any[]) => {
-  //     dispatch('workflow-log', {
-  //       workflowId,
-  //       message: message,
-  //       level: 'info',
-  //       time: (BigInt(Date.now()) * BigInt(1e3)).toString(),
-  //       name: 'mck',
-  //     });
-  //   };
-
-  //   // Get the job details from lightning
-  //   // start instantly and emit as it goes
-  //   dispatch('job-start', { workflowId, jobId, runId });
-  //   info('Running job ' + jobId);
-  //   let nextState = initialState;
-
-  //   // @ts-ignore
-  //   if (expression?.startsWith?.('wait@')) {
-  //     const [_, delay] = (expression as string).split('@');
-  //     nextState = initialState;
-  //     await new Promise<void>((resolve) => {
-  //       setTimeout(() => resolve(), parseInt(delay));
-  //     });
-  //   } else {
-  //     // Try and parse the expression as JSON, in which case we use it as the final state
-  //     try {
-  //       // @ts-ignore
-  //       nextState = JSON.parse(expression);
-  //       // What does this look like? Should be a logger object
-  //       info('Parsing expression as JSON state');
-  //       info(nextState);
-  //     } catch (e) {
-  //       // Do nothing, it's fine
-  //       nextState = initialState;
-  //     }
-  //   }
-
-  //   dispatch('job-complete', {
-  //     workflowId,
-  //     jobId,
-  //     state: nextState,
-  //     runId,
-  //     next: [], // TODO hmm. I think we need to do better than this.
-  //   });
-
-  //   return nextState;
-  // };
-
-  // // Start executing an ExecutionPlan
-  // // The mock uses lots of timeouts to make testing a bit easier and simulate asynchronicity
-  // const execute = (
-  //   xplan: ExecutionPlan,
-  //   options: { resolvers?: engine.Resolvers; throw?: boolean } = {
-  //     resolvers: mockResolvers,
-  //   }
-  // ) => {
-  //   // This is just an easy way to test the options gets fed through to execute
-  //   // Also lets me test error handling!
-  //   if (options.throw) {
-  //     throw new Error('test error');
-  //   }
-
-  //   const { id, jobs, initialState } = xplan;
-  //   const workflowId = id;
-  //   activeWorkflows[id!] = true;
-
-  //   // TODO do we want to load a globals dataclip from job.state here?
-  //   // This isn't supported right now
-  //   // We would need to use resolvers.dataclip if we wanted it
-
-  //   setTimeout(() => {
-  //     dispatch('workflow-start', { workflowId });
-  //     setTimeout(async () => {
-  //       let state = initialState || {};
-  //       // Trivial job reducer in our mock
-  //       for (const job of jobs) {
-  //         state = await executeJob(id!, job, state, options.resolvers);
-  //       }
-  //       setTimeout(() => {
-  //         delete activeWorkflows[id!];
-  //         dispatch('workflow-complete', { workflowId });
-  //         // TODO on workflow complete we should maybe tidy the listeners?
-  //         // Doesn't really matter in the mock though
-  //       }, 1);
-  //     }, 1);
-  //   }, 1);
-  // };
 
   // return a list of jobs in progress
   const getStatus = () => {

--- a/packages/ws-worker/src/mock/runtime-engine.ts
+++ b/packages/ws-worker/src/mock/runtime-engine.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import { EventEmitter } from 'node:events';
-import type { ExecutionPlan, JobNode } from '@openfn/runtime';
+import run, { ExecutionPlan, JobNode, NotifyEvents } from '@openfn/runtime';
 import * as engine from '@openfn/engine-multi';
 import mockResolvers from './resolvers';
 
@@ -26,6 +26,18 @@ export type WorkflowErrorEvent = {
   message: string;
 };
 
+// this is basically a fake adaptor
+// these functions will be injected into scope
+// maybe
+// needs me to add the globals option to the runtime
+// (which is fine)
+const helpers = {};
+
+// The mock runtime engine creates a fake engine interface
+// around a real runtime engine
+// Note that it  does not dispatch runtime logs and only supports console.log
+// This gives us real eventing in the worker tests
+// TODO - even better would be to re-use the engine's event map or something
 async function createMock() {
   const activeWorkflows = {} as Record<string, true>;
   const bus = new EventEmitter();
@@ -53,116 +65,176 @@ async function createMock() {
     listeners[planId] = events;
   };
 
-  const executeJob = async (
-    workflowId: string,
-    job: JobNode,
-    initialState = {},
-    resolvers: engine.Resolvers = mockResolvers
-  ) => {
-    const { id, expression, configuration, adaptor } = job;
-
-    // If no expression or adaptor, this is (probably) a trigger node.
-    // Silently do nothing
-    if (!expression && !adaptor) {
-      return initialState;
-    }
-
-    const runId = crypto.randomUUID();
-
-    const jobId = id;
-    if (typeof configuration === 'string') {
-      // Fetch the credential but do nothing with it
-      // Maybe later we use it to assemble state
-      await resolvers.credential?.(configuration);
-    }
-
-    const info = (...message: any[]) => {
-      dispatch('workflow-log', {
-        workflowId,
-        message: message,
-        level: 'info',
-        time: (BigInt(Date.now()) * BigInt(1e3)).toString(),
-        name: 'mck',
-      });
-    };
-
-    // Get the job details from lightning
-    // start instantly and emit as it goes
-    dispatch('job-start', { workflowId, jobId, runId });
-    info('Running job ' + jobId);
-    let nextState = initialState;
-
-    // @ts-ignore
-    if (expression?.startsWith?.('wait@')) {
-      const [_, delay] = (expression as string).split('@');
-      nextState = initialState;
-      await new Promise<void>((resolve) => {
-        setTimeout(() => resolve(), parseInt(delay));
-      });
-    } else {
-      // Try and parse the expression as JSON, in which case we use it as the final state
-      try {
-        // @ts-ignore
-        nextState = JSON.parse(expression);
-        // What does this look like? Should be a logger object
-        info('Parsing expression as JSON state');
-        info(nextState);
-      } catch (e) {
-        // Do nothing, it's fine
-        nextState = initialState;
-      }
-    }
-
-    dispatch('job-complete', {
-      workflowId,
-      jobId,
-      state: nextState,
-      runId,
-      next: [], // TODO hmm. I think we need to do better than this.
-    });
-
-    return nextState;
-  };
-
-  // Start executing an ExecutionPlan
-  // The mock uses lots of timeouts to make testing a bit easier and simulate asynchronicity
-  const execute = (
+  const execute = async (
     xplan: ExecutionPlan,
     options: { resolvers?: engine.Resolvers; throw?: boolean } = {
       resolvers: mockResolvers,
     }
   ) => {
-    // This is just an easy way to test the options gets fed through to execute
-    // Also lets me test error handling!
-    if (options.throw) {
-      throw new Error('test error');
-    }
-
-    const { id, jobs, initialState } = xplan;
-    const workflowId = id;
+    const { id, jobs } = xplan;
     activeWorkflows[id!] = true;
 
-    // TODO do we want to load a globals dataclip from job.state here?
-    // This isn't supported right now
-    // We would need to use resolvers.dataclip if we wanted it
+    // Call the crendtial callback, but don't do anything with it
+    for (const job of jobs) {
+      if (typeof job.configuration === 'string') {
+        job.configuration = await options.resolvers.credential?.(
+          job.configuration
+        );
+      }
+    }
 
-    setTimeout(() => {
-      dispatch('workflow-start', { workflowId });
-      setTimeout(async () => {
-        let state = initialState || {};
-        // Trivial job reducer in our mock
-        for (const job of jobs) {
-          state = await executeJob(id!, job, state, options.resolvers);
-        }
-        setTimeout(() => {
-          delete activeWorkflows[id!];
-          dispatch('workflow-complete', { workflowId });
-          // TODO on workflow complete we should maybe tidy the listeners?
-          // Doesn't really matter in the mock though
-        }, 1);
-      }, 1);
+    // TODO do I need a more sophisticated solution here?
+    const jobLogger = {
+      log: (...args) => {
+        dispatch('workflow-log', {
+          workflowId: id,
+          level: 'info',
+          json: true,
+          message: args,
+        });
+      },
+    };
+
+    const opts = {
+      strict: false,
+      // logger?
+      jobLogger,
+      // linker?
+      ...options,
+      callbacks: {
+        notify: (name: NotifyEvents, payload: any) => {
+          // console.log(name, payload);
+          // TODO events need to be mapped into runtime engine events (noot runtime events)
+          dispatch(name, {
+            workflowId: id,
+            ...payload, // ?
+          });
+        },
+      },
+    };
+    setTimeout(async () => {
+      dispatch('workflow-start', { workflowId: id });
+
+      await run(xplan, undefined, opts);
+
+      delete activeWorkflows[id!];
+      dispatch('workflow-complete', { workflowId: id });
     }, 1);
+
+    // Technically the engine should return an event emitter
+    // But as I don't think we use it, I'm happy to ignore this
   };
+
+  // const executeJob = async (
+  //   workflowId: string,
+  //   job: JobNode,
+  //   initialState = {},
+  //   resolvers: engine.Resolvers = mockResolvers
+  // ) => {
+  //   const { id, expression, configuration, adaptor } = job;
+
+  //   // If no expression or adaptor, this is (probably) a trigger node.
+  //   // Silently do nothing
+  //   if (!expression && !adaptor) {
+  //     return initialState;
+  //   }
+
+  //   const runId = crypto.randomUUID();
+
+  //   const jobId = id;
+  //   if (typeof configuration === 'string') {
+  //     // Fetch the credential but do nothing with it
+  //     // Maybe later we use it to assemble state
+  //     await resolvers.credential?.(configuration);
+  //   }
+
+  //   const info = (...message: any[]) => {
+  //     dispatch('workflow-log', {
+  //       workflowId,
+  //       message: message,
+  //       level: 'info',
+  //       time: (BigInt(Date.now()) * BigInt(1e3)).toString(),
+  //       name: 'mck',
+  //     });
+  //   };
+
+  //   // Get the job details from lightning
+  //   // start instantly and emit as it goes
+  //   dispatch('job-start', { workflowId, jobId, runId });
+  //   info('Running job ' + jobId);
+  //   let nextState = initialState;
+
+  //   // @ts-ignore
+  //   if (expression?.startsWith?.('wait@')) {
+  //     const [_, delay] = (expression as string).split('@');
+  //     nextState = initialState;
+  //     await new Promise<void>((resolve) => {
+  //       setTimeout(() => resolve(), parseInt(delay));
+  //     });
+  //   } else {
+  //     // Try and parse the expression as JSON, in which case we use it as the final state
+  //     try {
+  //       // @ts-ignore
+  //       nextState = JSON.parse(expression);
+  //       // What does this look like? Should be a logger object
+  //       info('Parsing expression as JSON state');
+  //       info(nextState);
+  //     } catch (e) {
+  //       // Do nothing, it's fine
+  //       nextState = initialState;
+  //     }
+  //   }
+
+  //   dispatch('job-complete', {
+  //     workflowId,
+  //     jobId,
+  //     state: nextState,
+  //     runId,
+  //     next: [], // TODO hmm. I think we need to do better than this.
+  //   });
+
+  //   return nextState;
+  // };
+
+  // // Start executing an ExecutionPlan
+  // // The mock uses lots of timeouts to make testing a bit easier and simulate asynchronicity
+  // const execute = (
+  //   xplan: ExecutionPlan,
+  //   options: { resolvers?: engine.Resolvers; throw?: boolean } = {
+  //     resolvers: mockResolvers,
+  //   }
+  // ) => {
+  //   // This is just an easy way to test the options gets fed through to execute
+  //   // Also lets me test error handling!
+  //   if (options.throw) {
+  //     throw new Error('test error');
+  //   }
+
+  //   const { id, jobs, initialState } = xplan;
+  //   const workflowId = id;
+  //   activeWorkflows[id!] = true;
+
+  //   // TODO do we want to load a globals dataclip from job.state here?
+  //   // This isn't supported right now
+  //   // We would need to use resolvers.dataclip if we wanted it
+
+  //   setTimeout(() => {
+  //     dispatch('workflow-start', { workflowId });
+  //     setTimeout(async () => {
+  //       let state = initialState || {};
+  //       // Trivial job reducer in our mock
+  //       for (const job of jobs) {
+  //         state = await executeJob(id!, job, state, options.resolvers);
+  //       }
+  //       setTimeout(() => {
+  //         delete activeWorkflows[id!];
+  //         dispatch('workflow-complete', { workflowId });
+  //         // TODO on workflow complete we should maybe tidy the listeners?
+  //         // Doesn't really matter in the mock though
+  //       }, 1);
+  //     }, 1);
+  //   }, 1);
+  // };
 
   // return a list of jobs in progress
   const getStatus = () => {

--- a/packages/ws-worker/test/api/execute.test.ts
+++ b/packages/ws-worker/test/api/execute.test.ts
@@ -24,7 +24,8 @@ import {
 import createMockRTE from '../../src/mock/runtime-engine';
 import { mockChannel } from '../../src/mock/sockets';
 import { stringify, createAttemptState } from '../../src/util';
-import { ExecutionPlan } from '@openfn/runtime';
+
+import type { ExecutionPlan } from '@openfn/runtime';
 import type { AttemptState } from '../../src/types';
 
 const enc = new TextEncoder();

--- a/packages/ws-worker/test/api/execute.test.ts
+++ b/packages/ws-worker/test/api/execute.test.ts
@@ -408,8 +408,7 @@ test('execute should pass the final result to onFinish', async (t) => {
     id: 'a',
     jobs: [
       {
-        // TODO use new fn helper
-        expression: 'export default [() => ({ done: true })]',
+        expression: 'fn(() => ({ done: true }))',
       },
     ],
   };
@@ -433,8 +432,7 @@ test('execute should return a context object', async (t) => {
     id: 'a',
     jobs: [
       {
-        // TODO use new fn helper
-        expression: 'export default [() => ({ done: true })]',
+        expression: 'fn(() => ({ done: true }))',
       },
     ],
   };
@@ -479,8 +477,7 @@ test('execute should lazy-load a credential', async (t) => {
     jobs: [
       {
         configuration: 'abc',
-        // TODO use new fn helper
-        expression: 'export default [() => ({ done: true })]',
+        expression: 'fn(() => ({ done: true }))',
       },
     ],
   };
@@ -515,8 +512,7 @@ test('execute should lazy-load initial state', async (t) => {
     initialState: 'abc',
     jobs: [
       {
-        // TODO use new fn helper
-        expression: 'export default [() => ({ done: true })]',
+        expression: 'fn(() => ({ done: true }))',
       },
     ],
   };
@@ -550,7 +546,7 @@ test('execute should call all events on the socket', async (t) => {
     // GET_DATACLIP, // TODO not really implemented properly yet
     ATTEMPT_START,
     RUN_START,
-    ATTEMPT_LOG, // This won't log with the mock logger
+    ATTEMPT_LOG,
     RUN_COMPLETE,
     ATTEMPT_COMPLETE,
   ];
@@ -564,7 +560,7 @@ test('execute should call all events on the socket', async (t) => {
         id: 'trigger',
         configuration: 'a',
         adaptor: '@openfn/language-common@1.0.0',
-        expression: 'export default [() => console.log("x")]',
+        expression: 'fn(() => console.log("x"))',
       },
     ],
   };
@@ -573,7 +569,6 @@ test('execute should call all events on the socket', async (t) => {
 
   return new Promise((done) => {
     execute(channel, engine, logger, plan, options, (result) => {
-      // console.log(events);
       // Check that events were passed to the socket
       // This is deliberately crude
       t.assert(allEvents.every((e) => events[e]));

--- a/packages/ws-worker/test/api/execute.test.ts
+++ b/packages/ws-worker/test/api/execute.test.ts
@@ -407,7 +407,8 @@ test('execute should pass the final result to onFinish', async (t) => {
     id: 'a',
     jobs: [
       {
-        expression: JSON.stringify({ done: true }),
+        // TODO use new fn helper
+        expression: 'export default [() => ({ done: true })]',
       },
     ],
   };
@@ -431,7 +432,8 @@ test('execute should return a context object', async (t) => {
     id: 'a',
     jobs: [
       {
-        expression: JSON.stringify({ done: true }),
+        // TODO use new fn helper
+        expression: 'export default [() => ({ done: true })]',
       },
     ],
   };
@@ -476,7 +478,8 @@ test('execute should lazy-load a credential', async (t) => {
     jobs: [
       {
         configuration: 'abc',
-        expression: JSON.stringify({ done: true }),
+        // TODO use new fn helper
+        expression: 'export default [() => ({ done: true })]',
       },
     ],
   };
@@ -511,7 +514,8 @@ test('execute should lazy-load initial state', async (t) => {
     initialState: 'abc',
     jobs: [
       {
-        expression: JSON.stringify({ done: true }),
+        // TODO use new fn helper
+        expression: 'export default [() => ({ done: true })]',
       },
     ],
   };
@@ -558,8 +562,8 @@ test('execute should call all events on the socket', async (t) => {
       {
         id: 'trigger',
         configuration: 'a',
-        expression: 'fn(a => a)',
         adaptor: '@openfn/language-common@1.0.0',
+        expression: 'export default [() => console.log("x")]',
       },
     ],
   };

--- a/packages/ws-worker/test/lightning.test.ts
+++ b/packages/ws-worker/test/lightning.test.ts
@@ -30,18 +30,13 @@ test.before(async () => {
 
 let rollingAttemptId = 0;
 
-// simulate an fn operation without compilation
-// TODO even better to mock cmompilation tbh
-const fn = (expression: string) =>
-  `const fn = (f) => (s) => f(s); export default [${expression}]`;
-
 const getAttempt = (ext = {}, jobs?: any) => ({
   id: `a${++rollingAttemptId}`,
   jobs: jobs || [
     {
       id: 'j',
       adaptor: '@openfn/language-common@1.0.0',
-      body: fn('() => ({ answer: 42 })'),
+      body: 'fn(() => ({ answer: 42 }))',
     },
   ],
   ...ext,
@@ -56,7 +51,7 @@ test.serial(
         id: 'attempt-1',
         jobs: [
           {
-            body: fn('() => ({ count: 122 })'),
+            body: 'fn(() => ({ count: 122 }))',
           },
         ],
       };
@@ -82,7 +77,7 @@ test.serial('should run an attempt which returns intial state', async (t) => {
       dataclip_id: 'x',
       jobs: [
         {
-          body: fn('(s) => s'),
+          body: 'fn((s) => s)',
         },
       ],
     };
@@ -178,7 +173,7 @@ test.serial(
           id: 'some-job',
           credential_id: 'a',
           adaptor: '@openfn/language-common@1.0.0',
-          body: fn('() => ({ answer: 42 })'),
+          body: 'fn(() => ({ answer: 42 }))',
         },
       ]);
 
@@ -277,7 +272,7 @@ test.serial(
         id: 'attempt-1',
         jobs: [
           {
-            body: fn('(s) => { console.log("x"); return s }'),
+            body: 'fn((s) => { console.log("x"); return s })',
           },
         ],
       };
@@ -306,13 +301,14 @@ test.serial(
 test.serial.skip(`events: logs should have increasing timestamps`, (t) => {
   return new Promise((done) => {
     const attempt = getAttempt({}, [
-      { body: fn('() => ({ data: 1 })'), adaptor: 'common' },
-      { body: fn('() => ({ data: 1 })'), adaptor: 'common' },
-      { body: fn('() => ({ data: 1 })'), adaptor: 'common' },
-      { body: fn('() => ({ data: 1 })'), adaptor: 'common' },
-      { body: fn('() => ({ data: 1 })'), adaptor: 'common' },
-      { body: fn('() => ({ data: 1 })'), adaptor: 'common' },
-      { body: fn('() => ({ data: 1 })'), adaptor: 'common' },
+      { body: 'fn(() => ({ data: 1 }))', adaptor: 'common' },
+      { body: 'fn(() => ({ data: 1 }))', adaptor: 'common' },
+      { body: 'fn(() => ({ data: 1 }))', adaptor: 'common' },
+      { body: 'fn(() => ({ data: 1 }))', adaptor: 'common' },
+      { body: 'fn(() => ({ data: 1 }))', adaptor: 'common' },
+      { body: 'fn(() => ({ data: 1 }))', adaptor: 'common' },
+      { body: 'fn(() => ({ data: 1 }))', adaptor: 'common' },
+      { body: 'fn(() => ({ data: 1 }))', adaptor: 'common' },
     ]);
 
     const history: bigint[] = [];
@@ -378,7 +374,7 @@ test('should register and de-register attempts to the server', async (t) => {
       id: 'attempt-1',
       jobs: [
         {
-          body: fn('() => ({ count: 122 })'),
+          body: 'fn(() => ({ count: 122 }))',
         },
       ],
     };
@@ -411,7 +407,7 @@ test.skip('should not claim while at capacity', async (t) => {
       id: 'attempt-1',
       jobs: [
         {
-          body: 'wait@500',
+          body: 'wait(500)',
         },
       ],
     };
@@ -453,5 +449,3 @@ test.skip('should not claim while at capacity', async (t) => {
 
 // hmm, i don't even think I can test this in the mock runtime
 test.skip('should pass the right dataclip when running in parallel', () => {});
-
-test.todo(`should run multiple attempts`);


### PR DESCRIPTION
Closes #486 

The worker at the moment uses a mock runtime engine to test against.

This is quite reasonable because we don't want to be spinning up loads of threads while unit testing worker functions. It's overkill.

Previously the engine mock did include it's own fake little runtime with very limited functionality. But there are two big problems with this:
1) Job code passed into worker functions doesn't look like job code. It looks weird because it's written to run against the mock
2) Events and errors coming out of the runtime are quite complex, and the worker needs to be able to run real and sophisticated workflows to test certain behaviours. It's too hard to simulate this in a mock, so I'm using real code instead.

The mock engine does not autoinstall. It will call the credentials resolver. It will do a sort of fake compilation of jobs - it won't download an adaptor and do real compilation, but it will wrap the `fn()` call in an `export default [fn]` wrapper for compatability. It also injects some "fake" adaptor functions into the job scope.

## Globals

To make this work I'm pulling in some old code from #303. This allows us to set globals in the runtime scope.

This functionality is not exposed to the CLI or the Worker. Just the mock worker .