### PR TITLE
Autoinstall issues

### DIFF
--- a/.changeset/honest-otters-cry.md
+++ b/.changeset/honest-otters-cry.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': minor
+---
+
+Remove ENGINE_REPO_DIR - the repo must be passed directly now

--- a/.changeset/moody-bulldogs-camp.md
+++ b/.changeset/moody-bulldogs-camp.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': patch
+---
+
+Queue autoinstall requests to ensure we only install one thing at a time

--- a/.changeset/two-hounds-listen.md
+++ b/.changeset/two-hounds-listen.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Add env var for WORKER_REPO_DIR

--- a/integration-tests/worker/src/factories.ts
+++ b/integration-tests/worker/src/factories.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-export const createAttempt = (triggers, jobs, edges, args) => ({
+export const createAttempt = (triggers, jobs, edges, args = {}) => ({
   id: crypto.randomUUID(),
   triggers,
   jobs,

--- a/integration-tests/worker/src/init.ts
+++ b/integration-tests/worker/src/init.ts
@@ -18,7 +18,7 @@ export const initWorker = async (lightningPort, engineArgs = {}) => {
   const workerPort = randomPort();
 
   const engine = await createEngine({
-    // logger: createLogger('engine', { level: 'debug' }),
+    logger: createLogger('engine', { level: 'debug' }),
     logger: createMockLogger(),
     repoDir: path.resolve('./tmp/repo/default'),
     ...engineArgs,

--- a/integration-tests/worker/src/init.ts
+++ b/integration-tests/worker/src/init.ts
@@ -18,7 +18,7 @@ export const initWorker = async (lightningPort, engineArgs = {}) => {
   const workerPort = randomPort();
 
   const engine = await createEngine({
-    logger: createLogger('engine', { level: 'debug' }),
+    // logger: createLogger('engine', { level: 'debug' }),
     logger: createMockLogger(),
     repoDir: path.resolve('./tmp/repo/default'),
     ...engineArgs,

--- a/integration-tests/worker/test/autoinstall.test.ts
+++ b/integration-tests/worker/test/autoinstall.test.ts
@@ -24,7 +24,6 @@ const run = async (attempt) => {
   return new Promise<any>(async (done, reject) => {
     lightning.on('attempt:complete', (evt) => {
       if (attempt.id === evt.attemptId) {
-        console.log(evt.payload);
         done(lightning.getResult(attempt.id));
       }
     });
@@ -54,7 +53,6 @@ test('autoinstall three things at once', async (t) => {
   const c = generate('googlesheets', '2.2.2');
 
   const [ra, rb, rc] = await Promise.all([run(a), run(b), run(c)]);
-  console.log(ra);
 
   t.is(ra.data, 'common');
   t.is(rb.data, 'http');

--- a/integration-tests/worker/test/autoinstall.test.ts
+++ b/integration-tests/worker/test/autoinstall.test.ts
@@ -1,0 +1,62 @@
+// stress test for autoinstall
+// this could evolve  into stress testing, benchmarking or artillery generally?
+// Also I may skip this in CI after the issue is fixed
+
+import test from 'ava';
+import path from 'node:path';
+
+import { initLightning, initWorker } from '../src/init';
+import { createAttempt, createJob } from '../src/factories';
+
+const generate = (adaptor, version) => {
+  const specifier = `@openfn/language-${adaptor}@${version}`;
+  const job = createJob({
+    body: `fn(() => ({ data: "${adaptor}" }))`,
+    adaptor: specifier,
+  });
+  return createAttempt([], [job], []);
+};
+
+let lightning;
+let worker;
+
+const run = async (attempt) => {
+  return new Promise<any>(async (done, reject) => {
+    lightning.on('attempt:complete', (evt) => {
+      if (attempt.id === evt.attemptId) {
+        console.log(evt.payload);
+        done(lightning.getResult(attempt.id));
+      }
+    });
+
+    lightning.enqueueAttempt(attempt);
+  });
+};
+
+test.before(async () => {
+  const lightningPort = 4321;
+
+  lightning = initLightning(lightningPort);
+
+  ({ worker } = await initWorker(lightningPort, {
+    repoDir: path.resolve('tmp/repo/autoinstall'),
+  }));
+});
+
+test.after(async () => {
+  lightning.destroy();
+  await worker.destroy();
+});
+
+test('autoinstall three things at once', async (t) => {
+  const a = generate('common', '1.11.1');
+  const b = generate('http', '5.0.0');
+  const c = generate('googlesheets', '2.2.2');
+
+  const [ra, rb, rc] = await Promise.all([run(a), run(b), run(c)]);
+  console.log(ra);
+
+  t.is(ra.data, 'common');
+  t.is(rb.data, 'http');
+  t.is(rc.data, 'googlesheets');
+});

--- a/packages/engine-multi/README.md
+++ b/packages/engine-multi/README.md
@@ -65,7 +65,7 @@ The engine has an auto-install feature. This will ensure that all required adapt
 
 Blacklisted modules are not installed.
 
-You can pass the local repo dir through the `repoDir` argument in `createEngine`, or by setting the `ENGINE_REPO_DIR` env var.
+You can pass a path to local repo dir through the `repoDir` argument in `createEngine`. If no path is provided, it will use a default value (see the logs).
 
 ## Resolving Execution Plans
 

--- a/packages/engine-multi/src/api.ts
+++ b/packages/engine-multi/src/api.ts
@@ -27,6 +27,8 @@ export type RTEOptions = Partial<
   }
 >;
 
+const DEFAULT_REPO_DIR = '/tmp/openfn/worker/repo';
+
 // Create the engine and handle user-facing stuff, like options parsing
 // and defaulting
 const createAPI = async function (options: RTEOptions = {}) {
@@ -35,13 +37,8 @@ const createAPI = async function (options: RTEOptions = {}) {
   const logger = options.logger || createLogger('RTE', { level: 'debug' });
 
   if (!repoDir) {
-    if (process.env.ENGINE_REPO_DIR) {
-      repoDir = process.env.ENGINE_REPO_DIR;
-    } else {
-      repoDir = '/tmp/openfn/repo';
-      logger.warn('Using default repodir');
-      logger.warn('Set env var ENGINE_REPO_DIR to use a different directory');
-    }
+    repoDir = DEFAULT_REPO_DIR;
+    logger.warn('Using default repo directory: ', DEFAULT_REPO_DIR);
   }
   logger.info('repoDir set to ', repoDir);
 

--- a/packages/engine-multi/src/api/autoinstall.ts
+++ b/packages/engine-multi/src/api/autoinstall.ts
@@ -35,6 +35,9 @@ const enqueue = (adaptors: string[]) =>
     queue.push({ adaptors, callback: resolve });
   });
 
+// Install any modules for an Execution Plan that are not already installed
+// This will enforce a queue ensuring only one module is installed at a time
+// This fixes https://github.com/OpenFn/kit/issues/503
 const autoinstall = async (context: ExecutionContext): Promise<ModulePaths> => {
   // TODO not a huge fan of these functions in the closure, but it's ok for now
   const processQueue = async () => {
@@ -50,8 +53,7 @@ const autoinstall = async (context: ExecutionContext): Promise<ModulePaths> => {
     }
   };
 
-  // This will actually do the autoinstall for an attempt
-  // it will install one or more adaptors
+  // This will actually do the autoinstall for an attempt (all adaptors)
   const doAutoinstall = async (
     adaptors: string[],
     onComplete: (err?: any) => void

--- a/packages/engine-multi/src/api/autoinstall.ts
+++ b/packages/engine-multi/src/api/autoinstall.ts
@@ -1,5 +1,3 @@
-// https://github.com/OpenFn/kit/issues/251
-
 import {
   ExecutionPlan,
   ensureRepo,
@@ -9,10 +7,11 @@ import {
 } from '@openfn/runtime';
 import { install as runtimeInstall } from '@openfn/runtime';
 
-import type { Logger } from '@openfn/logger';
-import type { ExecutionContext } from '../types';
 import { AUTOINSTALL_COMPLETE, AUTOINSTALL_ERROR } from '../events';
 import { AutoinstallError } from '../errors';
+
+import type { Logger } from '@openfn/logger';
+import type { ExecutionContext } from '../types';
 
 // none of these options should be on the plan actually
 export type AutoinstallOptions = {
@@ -27,7 +26,74 @@ export type AutoinstallOptions = {
 
 const pending: Record<string, Promise<void>> = {};
 
+let busy = false;
+
+const queue: Array<{ adaptors: string[]; callback: (err?: any) => void }> = [];
+
+const enqueue = (adaptors: string[]) =>
+  new Promise((resolve) => {
+    queue.push({ adaptors, callback: resolve });
+  });
+
 const autoinstall = async (context: ExecutionContext): Promise<ModulePaths> => {
+  // TODO not a huge fan of these functions in the closure, but it's ok for now
+  const processQueue = async () => {
+    const next = queue.shift();
+    if (next) {
+      busy = true;
+      const { adaptors, callback } = next;
+      await doAutoinstall(adaptors, callback);
+      processQueue();
+    } else {
+      // do nothing
+      busy = false;
+    }
+  };
+
+  // This will actually do the autoinstall for an attempt
+  // it will install one or more adaptors
+  const doAutoinstall = async (
+    adaptors: string[],
+    onComplete: (err?: any) => void
+  ) => {
+    // Check whether we still need to do any work
+    for (const a of adaptors) {
+      const { name, version } = getNameAndVersion(a);
+      if (await isInstalledFn(a, repoDir, logger)) {
+        continue;
+      }
+
+      const startTime = Date.now();
+      try {
+        await installFn(a, repoDir, logger);
+
+        const duration = Date.now() - startTime;
+        logger.success(`autoinstalled ${a} in ${duration / 1000}s`);
+        context.emit(AUTOINSTALL_COMPLETE, {
+          module: name,
+          version: version!,
+          duration,
+        });
+      } catch (e: any) {
+        delete pending[a];
+
+        logger.error(`ERROR autoinstalling ${a}: ${e.message}`);
+        logger.error(e);
+        const duration = Date.now() - startTime;
+        context.emit(AUTOINSTALL_ERROR, {
+          module: name,
+          version: version!,
+          duration,
+          message: e.message || e.toString(),
+        });
+
+        // Abort on the first error
+        return onComplete(new AutoinstallError(a, e));
+      }
+    }
+    onComplete();
+  };
+
   const { logger, state, options } = context;
   const { plan } = state;
   const { repoDir, whitelist } = options;
@@ -47,71 +113,49 @@ const autoinstall = async (context: ExecutionContext): Promise<ModulePaths> => {
   if (!skipRepoValidation && !didValidateRepo) {
     // TODO what if this throws?
     // Whole server probably needs to crash, so throwing is probably appropriate
+    // TODO do we need to do it on EVERY call? Can we not cache it?
     await ensureRepo(repoDir, logger);
     didValidateRepo = true;
   }
 
   const adaptors = Array.from(identifyAdaptors(plan));
-  // TODO would rather do all this in parallel but this is fine for now
-  // TODO set iteration is weirdly difficult?
   const paths: ModulePaths = {};
 
+  const adaptorsToLoad = [];
   for (const a of adaptors) {
     // Ensure that this is not blacklisted
-    // TODO what if it is? For now we'll log and skip it
     if (whitelist && !whitelist.find((r) => r.exec(a))) {
+      // TODO what if it is? For now we'll log and skip it
+      // TODO actually we should throw a security error in this case
       logger.warn('WARNING: autoinstall skipping blacklisted module ', a);
       continue;
     }
 
-    // Return a path name to this module for the linker to use later
-    // TODO this is all a bit rushed
     const alias = getAliasedName(a);
-    const { name, version } = getNameAndVersion(a);
+    const { name } = getNameAndVersion(a);
     paths[name] = { path: `${repoDir}/node_modules/${alias}` };
 
-    const needsInstalling = !(await isInstalledFn(a, repoDir, logger));
-    if (needsInstalling) {
-      if (!pending[a]) {
-        const startTime = Date.now();
-        pending[a] = installFn(a, repoDir, logger)
-          .then(() => {
-            const duration = Date.now() - startTime;
-
-            logger.success(`autoinstalled ${a} in ${duration / 1000}s`);
-            context.emit(AUTOINSTALL_COMPLETE, {
-              module: name,
-              version: version!,
-              duration,
-            });
-            delete pending[a];
-          })
-          .catch((e: any) => {
-            delete pending[a];
-
-            logger.error(`ERROR autoinstalling ${a}: ${e.message}`);
-            logger.error(e);
-            const duration = Date.now() - startTime;
-            context.emit(AUTOINSTALL_ERROR, {
-              module: name,
-              version: version!,
-              duration,
-              message: e.message || e.toString(),
-            });
-
-            // wrap and re-throw the error
-            throw new AutoinstallError(a, e);
-          });
-      } else {
-        logger.info(
-          `autoinstall waiting for previous promise for ${a} to resolve...`
-        );
-      }
-      // Return the pending promise (safe to do this multiple times)
-      // TODO if this is a chained promise, emit something like "using cache for ${name}"
-      await pending[a].then();
+    if (!(await isInstalledFn(a, repoDir, logger))) {
+      adaptorsToLoad.push(a);
     }
   }
+
+  if (adaptorsToLoad.length) {
+    // Add this to the queue
+    const p = enqueue(adaptorsToLoad);
+
+    if (!busy) {
+      processQueue();
+    }
+
+    return p.then((err) => {
+      if (err) {
+        throw err;
+      }
+      return paths;
+    });
+  }
+
   return paths;
 };
 

--- a/packages/engine-multi/test/api/autoinstall.test.ts
+++ b/packages/engine-multi/test/api/autoinstall.test.ts
@@ -53,6 +53,25 @@ test.afterEach(() => {
   logger._reset();
 });
 
+// maybe keep this as a simple high level test?
+// should work
+test.skip('new test', async (t) => {
+  const autoinstallOpts = {
+    handleInstall: mockHandleInstall,
+    handleIsInstalled: async () => false,
+  };
+  const context = createContext(autoinstallOpts);
+
+  const result = await autoinstall(context);
+  console.log(result);
+});
+
+// TODO
+// error handling
+// Queue for multiple installs
+// Queue for multiple installs of the same version
+// don't autoinstall if it's already there
+
 test('mock is installed: should be installed', async (t) => {
   const isInstalled = mockIsInstalled({
     name: 'repo',
@@ -356,7 +375,7 @@ test.serial('autoinstall: emit on error', async (t) => {
   t.true(!isNaN(evt.duration));
 });
 
-test.serial('autoinstall: throw twice in a ror', async (t) => {
+test.serial('autoinstall: throw twice in a row', async (t) => {
   let callCount = 0;
 
   const mockIsInstalled = async () => false;

--- a/packages/ws-worker/README.md
+++ b/packages/ws-worker/README.md
@@ -48,7 +48,7 @@ You can start a dev server (which rebuilds on save) by running:
 pnpm start:watch
 ```
 
-This will wrap a real runtime engine into the server (?). It will rebuild when the Worker Engine code changes (although you'll have to `pnpm build:watch` in `runtime-manager`). This will use the repo at `ENGINE_REPO_DIR` or `/tmp/openfn/repo`.
+This will wrap a real runtime engine into the server. It will rebuild when the Worker Engine code changes (although you'll have to `pnpm build:watch` in `runtime-manager`). This will use the repo at `WORKER_REPO_DIR` (or a default path in /tmp)
 
 ### Disabling auto-fetch
 

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -20,6 +20,8 @@ type Args = {
   capacity?: number;
 };
 
+const { WORKER_REPO_DIR, WORKER_SECRET } = process.env;
+
 const args = yargs(hideBin(process.argv))
   .command('server', 'Start a ws-worker server')
   .option('port', {
@@ -39,6 +41,7 @@ const args = yargs(hideBin(process.argv))
   .option('repo-dir', {
     alias: 'd',
     description: 'Path to the runtime repo (where modules will be installed)',
+    default: WORKER_REPO_DIR,
   })
   .option('secret', {
     alias: 's',
@@ -79,7 +82,6 @@ if (args.lightning === 'mock') {
     args.secret = 'abdefg';
   }
 } else if (!args.secret) {
-  const { WORKER_SECRET } = process.env;
   if (!WORKER_SECRET) {
     logger.error('WORKER_SECRET is not set');
     process.exit(1);


### PR DESCRIPTION
We are seeing numerous problems in autoinstall in production: see #503

My theory is that if the worker can install two seperate adaptors at once, which is causing interference when installing common dependencies like `lodash`.

This PR enforces autoinstall to use a strict queuing system. Only one adaptor can be installed at a time, and other adaptors must wait.

Also, as a bit of a prelude for this work I've done gone and fixed #454