### PR TITLE
Default to starting ws-worker image with node, not pnpm

### DIFF
--- a/.changeset/stale-spies-rush.md
+++ b/.changeset/stale-spies-rush.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Start ws-worker using node (not pnpm) by default

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /app/packages/ws-worker
 # ------------------------------------------------------------------------------
 
 EXPOSE 2222
-CMD [ "pnpm", "start:prod"]
+CMD [ "node", "dist/start.js"]
 
 # TODO: determine how to pass in the -l from `docker run` for running on mac m1
 # CMD [ "pnpm", "start", "-l", "ws://host.docker.internal:4000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,4 @@ WORKDIR /app/packages/ws-worker
 # ------------------------------------------------------------------------------
 
 EXPOSE 2222
-CMD [ "node", "dist/start.js"]
-
-# TODO: determine how to pass in the -l from `docker run` for running on mac m1
-# CMD [ "pnpm", "start", "-l", "ws://host.docker.internal:4000"]
+CMD [ "node", "./dist/start.js"]


### PR DESCRIPTION
This PR changes the `CMD` for the ws-worker image so it defaults to starting with node. It's been tested and is working on demo.openfn.org 