### PR TITLE
Engine: don't send job logs to stdout

### DIFF
--- a/.changeset/tough-monkeys-drive.md
+++ b/.changeset/tough-monkeys-drive.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': patch
+---
+
+Don't direct job logs to stdout

--- a/packages/engine-multi/src/api/lifecycle.ts
+++ b/packages/engine-multi/src/api/lifecycle.ts
@@ -118,16 +118,9 @@ export const log = (
   event: internalEvents.LogEvent
 ) => {
   const { threadId } = event;
-  // // TODO not sure about this stuff, I think we can drop it?
-  // const newMessage = {
-  //   ...message,
-  //   // Prefix the job id in all local jobs
-  //   // I'm sure there are nicer, more elegant ways of doing this
-  //   message: [`[${workflowId}]`, ...message.message],
-  // };
-  // TODO: if these are logs from within the runtime,
-  // should we use context.runtimeLogger ?
-  context.logger.proxy(event.message);
+
+  // Note: we do not log job stuff to stdout
+  // https://github.com/OpenFn/kit/issues/499
 
   context.emit(externalEvents.WORKFLOW_LOG, {
     threadId,

--- a/packages/engine-multi/test/api/autoinstall.test.ts
+++ b/packages/engine-multi/test/api/autoinstall.test.ts
@@ -21,6 +21,11 @@ const mockHandleInstall = async (specifier: string): Promise<void> =>
 
 const logger = createMockLogger();
 
+const wait = (duration = 10) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, duration);
+  });
+
 const createContext = (
   autoinstallOpts?,
   jobs?: any[],
@@ -205,7 +210,11 @@ test.serial('autoinstall: install in sequence', async (t) => {
   const c2 = createContext(options, [{ adaptor: '@openfn/language-common@2' }]);
   const c3 = createContext(options, [{ adaptor: '@openfn/language-common@3' }]);
 
-  await Promise.all([autoinstall(c1), autoinstall(c2), autoinstall(c3)]);
+  autoinstall(c1);
+  await wait(1);
+  autoinstall(c2);
+  await wait(1);
+  await autoinstall(c3);
 
   const s1 = states['@openfn/language-common@1'];
   const s2 = states['@openfn/language-common@2'];

--- a/packages/lightning-mock/README.md
+++ b/packages/lightning-mock/README.md
@@ -33,7 +33,7 @@ The server exposes a small dev API allowing you to post an Attempt.
 You can add an attempt (`{ jobs, triggers, edges }`) to the queue with:
 
 ```
-curl -X POST http://localhost:8888/attempt -d @tmp/my-attempt.json -H "Content-Type: application/json"
+curl http://localhost:8888/attempt --json @tmp/attempt.json
 ```
 
 Here's an example attempt:

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -74,7 +74,6 @@ const args = yargs(hideBin(process.argv))
   .parse() as Args;
 
 const logger = createLogger('SRV', { level: args.log });
-
 if (args.lightning === 'mock') {
   args.lightning = 'ws://localhost:8888/worker';
   if (!args.secret) {


### PR DESCRIPTION
Remove the the line that emits job logs to stdout.

This means that we don't see anything logged by job code in GCP or local dev or any other hosting platform.

Logs are still sent to lightning. Runtime, engine and worker logs are all still emitted to stdout.

Closes #499

Might also close #506