### PR TITLE
Runtime: on_job_failure edge conditions only take into account the upstream job

### DIFF
--- a/packages/engine-multi/test/integration.test.ts
+++ b/packages/engine-multi/test/integration.test.ts
@@ -83,7 +83,7 @@ test.serial('trigger job-complete', (t) => {
 
     api.execute(plan).on('job-complete', (evt) => {
       t.deepEqual(evt.next, []);
-      t.true(evt.duration < 20);
+      t.true(evt.duration < 50);
       t.is(evt.jobId, 'j1');
       t.deepEqual(evt.state, { data: {} });
       t.pass('job completed');

--- a/packages/ws-worker/src/util/convert-attempt.ts
+++ b/packages/ws-worker/src/util/convert-attempt.ts
@@ -5,17 +5,22 @@ import type {
   JobEdge,
   ExecutionPlan,
 } from '@openfn/runtime';
-import { Attempt, AttemptOptions } from '../types';
+import { Attempt, AttemptOptions, Edge } from '../types';
 
-const conditions: Record<string, any> = {
-  on_job_success: '!state.errors',
-  on_job_failure: 'state.errors',
-  always: null,
-};
+export const conditions: Record<string, (upstreamId: string) => string | null> =
+  {
+    on_job_success: (upstreamId: string) =>
+      `Boolean(!state.errors?.${upstreamId} ?? true)`,
+    on_job_failure: (upstreamId: string) =>
+      `Boolean(state.errors && state.errors.${upstreamId} && true)`,
+    always: (_upstreamId: string) => null,
+  };
 
-const mapEdgeCondition = (condition?: string) => {
+const mapEdgeCondition = (edge: Edge) => {
+  const { condition } = edge;
   if (condition && condition in conditions) {
-    return conditions[condition];
+    const upstream = (edge.source_job_id || edge.source_trigger_id) as string;
+    return conditions[condition](upstream);
   }
   return condition;
 };
@@ -89,7 +94,7 @@ export default (
         .reduce((obj, edge) => {
           const newEdge: JobEdge = {};
 
-          const condition = mapEdgeCondition(edge.condition);
+          const condition = mapEdgeCondition(edge);
           if (condition) {
             newEdge.condition = condition;
           }

--- a/packages/ws-worker/test/util.ts
+++ b/packages/ws-worker/test/util.ts
@@ -38,3 +38,21 @@ export const createPlan = (...jobs) =>
     id: crypto.randomUUID(),
     jobs: [...jobs],
   } as ExecutionPlan);
+
+export const createEdge = (from: string, to: string) => ({
+  id: `${from}-${to}`,
+  source_job_id: from,
+  target_job_id: to,
+});
+
+export const createJob = (body?: string, id?: string) => ({
+  id: id || crypto.randomUUID(),
+  body: body || `fn((s) => s)`,
+});
+
+export const createAttempt = (jobs = [], edges = [], triggers = []) => ({
+  id: crypto.randomUUID(),
+  jobs,
+  edges,
+  triggers,
+});

--- a/packages/ws-worker/test/util/convert-attempt.test.ts
+++ b/packages/ws-worker/test/util/convert-attempt.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import convertAttempt from '../../src/util/convert-attempt';
+import convertAttempt, { conditions } from '../../src/util/convert-attempt';
 import { Attempt, Node } from '../../src/types';
 
 // Creates a lightning node (job or trigger)
@@ -35,6 +35,11 @@ const createJob = (props = {}) => ({
   configuration: 'y',
   ...props,
 });
+
+const testEdgeCondition = (expr, state) => {
+  const fn = new Function('state', 'return ' + expr);
+  return fn(state);
+};
 
 test('convert a single job', (t) => {
   const attempt: Partial<Attempt> = {
@@ -334,6 +339,84 @@ test('convert two linked jobs with a disabled edge', (t) => {
   });
 });
 
+test('on_job_success condition: return true if no errors', (t) => {
+  const condition = conditions.on_job_success('a');
+
+  const state = {};
+  const result = testEdgeCondition(condition, state);
+
+  t.is(result, true);
+});
+
+test('on_job_success condition: return true if unconnected upstream errors', (t) => {
+  const condition = conditions.on_job_success('a');
+
+  const state = {
+    errors: {
+      c: {
+        // some error that occured upstream
+      },
+    },
+  };
+  const result = testEdgeCondition(condition, state);
+
+  t.is(result, true);
+});
+
+test('on_job_success condition: return false if the upstream job errored', (t) => {
+  const condition = conditions.on_job_success('a');
+
+  const state = {
+    errors: {
+      a: {
+        // some error that occured upstream
+      },
+    },
+  };
+  const result = testEdgeCondition(condition, state);
+
+  t.is(result, false);
+});
+
+test('on_job_failure condition: return true if error immediately upstream', (t) => {
+  const condition = conditions.on_job_failure('a');
+
+  const state = {
+    errors: {
+      a: {
+        // some error that occured upstream
+      },
+    },
+  };
+  const result = testEdgeCondition(condition, state);
+
+  t.is(result, true);
+});
+
+test('on_job_failure condition: return false if unrelated error upstream', (t) => {
+  const condition = conditions.on_job_failure('a');
+
+  const state = {
+    errors: {
+      b: {
+        // some error that occured upstream
+      },
+    },
+  };
+  const result = testEdgeCondition(condition, state);
+
+  t.is(result, false);
+});
+
+test('on_job_failure condition: return false if no errors', (t) => {
+  const condition = conditions.on_job_failure('a');
+
+  const state = {};
+  const result = testEdgeCondition(condition, state);
+
+  t.is(result, false);
+});
+
 test('convert edge condition on_job_success', (t) => {
   const attempt: Partial<Attempt> = {
     id: 'w',
@@ -346,7 +429,7 @@ test('convert edge condition on_job_success', (t) => {
   const [job] = plan.jobs;
 
   t.truthy(job.next?.b);
-  t.is(job.next.b.condition, '!state.errors');
+  t.is(job.next.b.condition, conditions.on_job_success('a'));
 });
 
 test('convert edge condition on_job_failure', (t) => {
@@ -361,7 +444,7 @@ test('convert edge condition on_job_failure', (t) => {
   const [job] = plan.jobs;
 
   t.truthy(job.next?.b);
-  t.is(job.next.b.condition, 'state.errors');
+  t.is(job.next.b.condition, conditions.on_job_failure('a'));
 });
 
 test('convert edge condition always', (t) => {


### PR DESCRIPTION
In production when an edge condition is set to `on_job_failure` in Lightning, the Worker converts this into a simple expression `state.errors`. As in, if there's an error on state, run the next job.

This is far too crude. Actually, we only care if the immediately upstream job (the source job of the edge) errored.

So basically we need to generate a more complex edge expression, something like `state.errors.${upstreamId}`.

This PR  does that and adds a bunch of tests.