### PR TITLE
Runtime: report memory usage

### DIFF
--- a/.changeset/fifty-students-pay.md
+++ b/.changeset/fifty-students-pay.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Include duration and threadid in run-complete

--- a/.changeset/happy-pianos-cheat.md
+++ b/.changeset/happy-pianos-cheat.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': patch
+---
+
+Include memory usage in job-compelte events

--- a/.changeset/happy-pianos-cheat.md
+++ b/.changeset/happy-pianos-cheat.md
@@ -2,4 +2,4 @@
 '@openfn/engine-multi': patch
 ---
 
-Include memory usage in job-compelte events
+Include memory usage in job-complete events

--- a/.changeset/ninety-fireants-melt.md
+++ b/.changeset/ninety-fireants-melt.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Send memory usage to lightning on run:complete

--- a/ava.config.js
+++ b/ava.config.js
@@ -11,10 +11,7 @@ module.exports = {
     '--loader=ts-node/esm',
     '--no-warnings', // Disable experimental module warnings
     '--experimental-vm-modules',
-    '--expose-gc', // TODO this should only be in the runtime
   ],
-
-  workerThreads: false, // TMP runtime only - needed to expose gc
 
   files: ['test/**/*test.ts'],
 };

--- a/ava.config.js
+++ b/ava.config.js
@@ -11,7 +11,10 @@ module.exports = {
     '--loader=ts-node/esm',
     '--no-warnings', // Disable experimental module warnings
     '--experimental-vm-modules',
+    '--expose-gc', // TODO this should only be in the runtime
   ],
+
+  workerThreads: false, // TMP runtime only - needed to expose gc
 
   files: ['test/**/*test.ts'],
 };

--- a/integration-tests/worker/test/attempts.test.ts
+++ b/integration-tests/worker/test/attempts.test.ts
@@ -31,18 +31,16 @@ test.after(async () => {
   await worker.destroy();
 });
 
-const humanMb = (sizeInBytes: number) =>
-  `${Math.round(sizeInBytes / 1024 / 1024)}mb`;
+const humanMb = (sizeInBytes: number) => Math.round(sizeInBytes / 1024 / 1024);
 
 const run = async (t, attempt) => {
   return new Promise<any>(async (done, reject) => {
     lightning.on('run:complete', ({ payload }) => {
-      // TODO I'd actually love to include the thread id here, but we don't send it :( Maybe soon?
-      // TODO ditto duration!! omg how am I not sending that?
+      // TODO friendlier job names for this would be nice (rather than run ids)
       t.log(
-        `${payload.job_id}: ${humanMb(payload.mem.job)} (${humanMb(
-          payload.mem.system
-        )})`
+        `run ${payload.run_id} done in ${payload.duration / 1000}s [${humanMb(
+          payload.mem.job
+        )} / ${humanMb(payload.mem.system)}mb] [thread ${payload.thread_id}]`
       );
     });
     lightning.on('attempt:complete', (evt) => {

--- a/integration-tests/worker/test/attempts.test.ts
+++ b/integration-tests/worker/test/attempts.test.ts
@@ -22,14 +22,30 @@ test.before(async () => {
   }));
 });
 
+test.afterEach(async () => {
+  lightning.destroy();
+});
+
 test.after(async () => {
   lightning.destroy();
   await worker.destroy();
 });
 
-const run = async (attempt) => {
+const humanMb = (sizeInBytes: number) =>
+  `${Math.round(sizeInBytes / 1024 / 1024)}mb`;
+
+const run = async (t, attempt) => {
   return new Promise<any>(async (done, reject) => {
-    lightning.once('attempt:complete', (evt) => {
+    lightning.on('run:complete', ({ payload }) => {
+      // TODO I'd actually love to include the thread id here, but we don't send it :( Maybe soon?
+      // TODO ditto duration!! omg how am I not sending that?
+      t.log(
+        `${payload.job_id}: ${humanMb(payload.mem.job)} (${humanMb(
+          payload.mem.system
+        )})`
+      );
+    });
+    lightning.on('attempt:complete', (evt) => {
       if (attempt.id === evt.attemptId) {
         done(lightning.getResult(attempt.id));
       } else {
@@ -42,7 +58,7 @@ const run = async (attempt) => {
   });
 };
 
-test('echo initial state', async (t) => {
+test.serial('echo initial state', async (t) => {
   const initialState = { data: { count: 22 } };
 
   lightning.addDataclip('s1', initialState);
@@ -52,7 +68,7 @@ test('echo initial state', async (t) => {
     dataclip_id: 's1',
   });
 
-  const result = await run(attempt);
+  const result = await run(t, attempt);
 
   t.deepEqual(result, {
     data: {
@@ -61,7 +77,7 @@ test('echo initial state', async (t) => {
   });
 });
 
-test('start from a trigger node', async (t) => {
+test.serial('start from a trigger node', async (t) => {
   let runStartEvent;
   let runCompleteEvent;
 
@@ -84,7 +100,7 @@ test('start from a trigger node', async (t) => {
     runCompleteEvent = evt.payload;
   });
 
-  await run(attempt);
+  await run(t, attempt);
 
   t.truthy(runStartEvent);
   t.is(runStartEvent.job_id, job.id);
@@ -103,7 +119,7 @@ test('start from a trigger node', async (t) => {
 // hmm this event feels a bit fine-grained for this
 // This file should just be about input-output
 // TODO maybe move it into integrations later
-test('run parallel jobs', async (t) => {
+test.serial('run parallel jobs', async (t) => {
   const initialState = { data: { count: 22 } };
 
   lightning.addDataclip('s1', initialState);
@@ -144,7 +160,7 @@ test('run parallel jobs', async (t) => {
     outputJson[evt.payload.job_id] = JSON.parse(evt.payload.output_dataclip);
   });
 
-  const result = await run(attempt);
+  await run(t, attempt);
 
   t.deepEqual(outputJson[x.id].data, {
     a: true,
@@ -168,4 +184,24 @@ test('run parallel jobs', async (t) => {
   //     y: true,
   //   },
   // });
+});
+
+test('run a http adaptor job', async (t) => {
+  const job = createJob({
+    adaptor: '@openfn/language-http@5.0.4',
+    body: 'get("https://jsonplaceholder.typicode.com/todos/1");',
+  });
+  const attempt = createAttempt([], [job], []);
+  const result = await run(t, attempt);
+
+  t.truthy(result.response);
+  t.is(result.response.status, 200);
+  t.truthy(result.response.headers);
+
+  t.deepEqual(result.data, {
+    userId: 1,
+    id: 1,
+    title: 'delectus aut autem',
+    completed: false,
+  });
 });

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -236,39 +236,6 @@ test('run a job with initial state (no top level keys)', (t) => {
   });
 });
 
-test('run a http adaptor job', (t) => {
-  return new Promise(async (done) => {
-    const attempt = {
-      id: crypto.randomUUID(),
-      jobs: [
-        {
-          adaptor: '@openfn/language-http@5.0.4',
-          body: 'get("https://jsonplaceholder.typicode.com/todos/1");',
-        },
-      ],
-    };
-
-    lightning.once('attempt:complete', () => {
-      const result = lightning.getResult(attempt.id);
-
-      t.truthy(result.response);
-      t.is(result.response.status, 200);
-      t.truthy(result.response.headers);
-
-      t.deepEqual(result.data, {
-        userId: 1,
-        id: 1,
-        title: 'delectus aut autem',
-        completed: false,
-      });
-
-      done();
-    });
-
-    lightning.enqueueAttempt(attempt);
-  });
-});
-
 // TODO this sort of works but the server side of it does not
 // Will work on it more
 // TODO2: the runtime doesn't return config anymore (correctly!)

--- a/packages/engine-multi/src/api/lifecycle.ts
+++ b/packages/engine-multi/src/api/lifecycle.ts
@@ -84,7 +84,7 @@ export const jobComplete = (
   context: ExecutionContext,
   event: internalEvents.JobCompleteEvent
 ) => {
-  const { threadId, state, duration, jobId, next } = event;
+  const { threadId, state, duration, jobId, next, mem } = event;
 
   context.emit(externalEvents.JOB_COMPLETE, {
     threadId,
@@ -92,6 +92,7 @@ export const jobComplete = (
     duration,
     jobId,
     next,
+    mem,
   });
 };
 

--- a/packages/engine-multi/src/events.ts
+++ b/packages/engine-multi/src/events.ts
@@ -72,6 +72,10 @@ export interface JobCompletePayload extends ExternalEvent {
   duration: number;
   state: any; // the result state
   next: string[]; // downstream jobs
+  mem: {
+    job: number;
+    system: number;
+  };
 }
 
 export interface JobErrorPayload extends ExternalEvent {

--- a/packages/engine-multi/src/worker/events.ts
+++ b/packages/engine-multi/src/worker/events.ts
@@ -45,6 +45,10 @@ export interface JobCompleteEvent extends InternalEvent {
   state: any;
   duration: number;
   next: string[];
+  mem: {
+    job: number;
+    system: number;
+  };
 }
 
 export interface JobErrorEvent extends InternalEvent {

--- a/packages/engine-multi/src/worker/mock-worker.ts
+++ b/packages/engine-multi/src/worker/mock-worker.ts
@@ -65,6 +65,7 @@ function mock(plan: MockExecutionPlan) {
         duration: 100,
         state,
         next: [],
+        mem: { job: 100, system: 1000 },
       });
       resolve(state);
     }, job._delay || 1);

--- a/packages/engine-multi/test/api/lifecycle.test.ts
+++ b/packages/engine-multi/test/api/lifecycle.test.ts
@@ -142,6 +142,8 @@ test(`job-complete: emits ${e.JOB_COMPLETE}`, (t) => {
       jobId: 'j',
       duration: 200,
       state: 22,
+      next: [],
+      mem: { job: 100, system: 1000 },
     };
 
     context.on(e.JOB_COMPLETE, (evt) => {
@@ -150,6 +152,8 @@ test(`job-complete: emits ${e.JOB_COMPLETE}`, (t) => {
       t.is(evt.jobId, 'j');
       t.is(evt.state, 22);
       t.is(evt.duration, 200);
+      t.deepEqual(evt.next, []);
+      t.deepEqual(evt.mem, event.mem);
       done();
     });
 

--- a/packages/engine-multi/test/integration.test.ts
+++ b/packages/engine-multi/test/integration.test.ts
@@ -90,6 +90,8 @@ test.serial('trigger job-complete', (t) => {
       t.is(evt.jobId, 'j1');
       t.deepEqual(evt.state, { data: {} });
       t.pass('job completed');
+      t.truthy(evt.mem.job);
+      t.truthy(evt.mem.system);
       done();
     });
   });

--- a/packages/runtime/ava.config.cjs
+++ b/packages/runtime/ava.config.cjs
@@ -1,0 +1,7 @@
+const baseConfig = require('../../ava.config');
+
+module.exports = {
+  ...baseConfig,
+
+  files: ['!test/memory.test.ts'],
+};

--- a/packages/runtime/memtest.ava.config.cjs
+++ b/packages/runtime/memtest.ava.config.cjs
@@ -1,0 +1,24 @@
+// This is special ava config just for the memory test, because:
+// a) it should explicitly expose gc
+// b) it does not use worker threads
+// c) it should not run in ci
+module.exports = {
+  extensions: {
+    ts: 'module',
+  },
+
+  environmentVariables: {
+    TS_NODE_TRANSPILE_ONLY: 'true',
+  },
+
+  nodeArguments: [
+    '--loader=ts-node/esm',
+    '--no-warnings',
+    '--experimental-vm-modules',
+    '--expose-gc',
+  ],
+
+  workerThreads: false,
+
+  files: ['test/memory.test.ts'],
+};

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -17,6 +17,7 @@
     "test": "pnpm ava",
     "test:watch": "pnpm ava -w",
     "test:types": "pnpm tsc --project tsconfig.test.json",
+    "test:memory": "pnpm ava --config memtest.ava.config.cjs",
     "build": "tsup --config ../../tsup.config.js src/index.ts",
     "build:watch": "pnpm build --watch",
     "pack": "pnpm pack --pack-destination ../../dist"

--- a/packages/runtime/src/execute/job.ts
+++ b/packages/runtime/src/execute/job.ts
@@ -157,20 +157,22 @@ const executeJob = async (
     }
 
     if (!didError) {
+      const humanDuration = logger.timer(timerId);
+      logger.success(`Completed job ${jobId} in ${humanDuration}`);
+
       // Take a memory snapshot
-      // IMPORTANT: this runs after the state object has been serialized
+      // IMPORTANT: this runs _after_ the state object has been serialized
       // Which has a big impact on memory
       // This is reasonable I think because your final state is part of the job!
       const { heapUsed, rss } = process.memoryUsage();
-      const humanDuration = logger.timer(timerId);
 
       const jobMemory = heapUsed;
       const systemMemory = rss;
 
       const humanJobMemory = Math.round(jobMemory / 1024 / 1024);
-      // TODO is this something we want to always log?
-      logger.success(
-        `Completed job ${jobId} in ${humanDuration} (used ${humanJobMemory}mb)`
+      const humanSystemMemory = Math.round(systemMemory / 1024 / 1024);
+      logger.debug(
+        `Final memory usage: [job ${humanJobMemory}mb] [system ${humanSystemMemory}mb]`
       );
 
       next = calculateNext(job, result);

--- a/packages/runtime/src/execute/job.ts
+++ b/packages/runtime/src/execute/job.ts
@@ -157,6 +157,10 @@ const executeJob = async (
     }
 
     if (!didError) {
+      // Take a memory snapshot
+      // IMPORTANT: this runs after the state object has been serialized
+      // Which has a big impact on memory
+      // This is reasonable I think because your final state is part of the job!
       const { heapUsed, rss } = process.memoryUsage();
       const humanDuration = logger.timer(timerId);
 

--- a/packages/runtime/src/execute/job.ts
+++ b/packages/runtime/src/execute/job.ts
@@ -159,12 +159,23 @@ const executeJob = async (
     }
 
     if (!didError) {
+      const { heapUsed, rss } = process.memoryUsage();
+      const used = heapUsed / 1024 / 1024;
+      const humanUsed = Math.round(used);
+      const humanRSS = Math.round(rss / 1024 / 1024);
+      console.log(`Job ${jobId} heap ${humanUsed} MB`);
+      console.log(`Job ${jobId} rss ${humanRSS} MB`);
+
       next = calculateNext(job, result);
       notify(NOTIFY_JOB_COMPLETE, {
         duration: Date.now() - duration,
         state: result,
         jobId,
         next,
+        mem: {
+          heapUsedMb: used,
+          totalMb: rss / 1024 / 1024,
+        },
       });
     }
   } else {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -150,6 +150,10 @@ export type NotifyJobCompletePayload = {
   state: any;
   jobId: string;
   next: string[];
+  mem: {
+    job: number;
+    system: number;
+  };
 };
 
 export type NotifyJobErrorPayload = {

--- a/packages/runtime/test/execute/job.test.ts
+++ b/packages/runtime/test/execute/job.test.ts
@@ -31,7 +31,7 @@ test.afterEach(() => {
   logger._reset();
 });
 
-test('resolve and return next for a simple job', async (t) => {
+test.serial('resolve and return next for a simple job', async (t) => {
   const job = {
     id: 'j',
     expression: [(s: State) => s],
@@ -45,7 +45,7 @@ test('resolve and return next for a simple job', async (t) => {
   t.deepEqual(next, ['k']);
 });
 
-test('resolve and return next for a trigger-style job', async (t) => {
+test.serial('resolve and return next for a trigger-style job', async (t) => {
   const job = {
     id: 'j',
     next: { k: true, a: false },
@@ -58,7 +58,7 @@ test('resolve and return next for a trigger-style job', async (t) => {
   t.deepEqual(next, ['k']);
 });
 
-test('resolve and return next for a failed job', async (t) => {
+test.serial('resolve and return next for a failed job', async (t) => {
   const job = {
     id: 'j',
     expression: [
@@ -77,7 +77,7 @@ test('resolve and return next for a failed job', async (t) => {
   t.deepEqual(next, ['k']);
 });
 
-test(`notify ${NOTIFY_JOB_START}`, async (t) => {
+test.serial(`notify ${NOTIFY_JOB_START}`, async (t) => {
   const job = {
     id: 'j',
     expression: [(s: State) => s],
@@ -95,25 +95,28 @@ test(`notify ${NOTIFY_JOB_START}`, async (t) => {
   await execute(context, job, state);
 });
 
-test(`don't notify ${NOTIFY_JOB_START} for trigger-style jobs`, async (t) => {
-  const job = {
-    id: 'j',
-  };
-  const state = createState();
+test.serial(
+  `don't notify ${NOTIFY_JOB_START} for trigger-style jobs`,
+  async (t) => {
+    const job = {
+      id: 'j',
+    };
+    const state = createState();
 
-  const notify = (event: string, payload?: any) => {
-    if (event === NOTIFY_JOB_START) {
-      t.fail('should not notify job-start for trigger nodes');
-    }
-  };
+    const notify = (event: string, payload?: any) => {
+      if (event === NOTIFY_JOB_START) {
+        t.fail('should not notify job-start for trigger nodes');
+      }
+    };
 
-  const context = createContext({ notify });
+    const context = createContext({ notify });
 
-  await execute(context, job, state);
-  t.pass('all ok');
-});
+    await execute(context, job, state);
+    t.pass('all ok');
+  }
+);
 
-test(`notify ${NOTIFY_JOB_COMPLETE} with no next`, async (t) => {
+test.serial(`notify ${NOTIFY_JOB_COMPLETE} with no next`, async (t) => {
   const job = {
     id: 'j',
     expression: [(s: State) => s],
@@ -139,7 +142,7 @@ test(`notify ${NOTIFY_JOB_COMPLETE} with no next`, async (t) => {
   await execute(context, job, state);
 });
 
-test(`notify ${NOTIFY_JOB_COMPLETE} with two nexts`, async (t) => {
+test.serial(`notify ${NOTIFY_JOB_COMPLETE} with two nexts`, async (t) => {
   const job = {
     id: 'j',
     expression: [(s: State) => s],
@@ -165,49 +168,55 @@ test(`notify ${NOTIFY_JOB_COMPLETE} with two nexts`, async (t) => {
   await execute(context, job, state);
 });
 
-test(`don't notify ${NOTIFY_JOB_COMPLETE} for trigger-style jobs`, async (t) => {
-  const job = {
-    id: 'j',
-  };
-  const state = createState();
+test.serial(
+  `don't notify ${NOTIFY_JOB_COMPLETE} for trigger-style jobs`,
+  async (t) => {
+    const job = {
+      id: 'j',
+    };
+    const state = createState();
 
-  const notify = (event: string) => {
-    if (event === NOTIFY_JOB_COMPLETE) {
-      t.fail('should not notify job-start for trigger nodes');
-    }
-  };
+    const notify = (event: string) => {
+      if (event === NOTIFY_JOB_COMPLETE) {
+        t.fail('should not notify job-start for trigger nodes');
+      }
+    };
 
-  const context = createContext({ notify });
+    const context = createContext({ notify });
 
-  await execute(context, job, state);
-  t.pass('all ok');
-});
+    await execute(context, job, state);
+    t.pass('all ok');
+  }
+);
 
-test(`notify ${NOTIFY_JOB_COMPLETE} should publish serializable state`, async (t) => {
-  // Promises will trigger an exception if you try to serialize them
-  // If we don't return finalState in  execute/expression, this test will fail
-  const resultState = { x: new Promise((r) => r), y: 22 };
-  const job = {
-    id: 'j',
-    expression: [() => resultState],
-  };
-  const state = createState();
+test.serial(
+  `notify ${NOTIFY_JOB_COMPLETE} should publish serializable state`,
+  async (t) => {
+    // Promises will trigger an exception if you try to serialize them
+    // If we don't return finalState in  execute/expression, this test will fail
+    const resultState = { x: new Promise((r) => r), y: 22 };
+    const job = {
+      id: 'j',
+      expression: [() => resultState],
+    };
+    const state = createState();
 
-  const notify = (event: string, payload: any) => {
-    if (event === NOTIFY_JOB_COMPLETE) {
-      const { state, duration, jobId } = payload;
-      t.truthy(state);
-      t.assert(!isNaN(duration));
-      t.is(jobId, 'j');
-    }
-  };
+    const notify = (event: string, payload: any) => {
+      if (event === NOTIFY_JOB_COMPLETE) {
+        const { state, duration, jobId } = payload;
+        t.truthy(state);
+        t.assert(!isNaN(duration));
+        t.is(jobId, 'j');
+      }
+    };
 
-  const context = createContext({ notify });
+    const context = createContext({ notify });
 
-  await execute(context, job, state);
-});
+    await execute(context, job, state);
+  }
+);
 
-test(`notify ${NOTIFY_JOB_ERROR} for a fail`, async (t) => {
+test.serial(`notify ${NOTIFY_JOB_ERROR} for a fail`, async (t) => {
   const job = {
     id: 'j',
     expression: [
@@ -241,9 +250,9 @@ test(`notify ${NOTIFY_JOB_ERROR} for a fail`, async (t) => {
   await execute(context, job, state);
 });
 
-test('log duration of execution', async (t) => {
+test.serial('log duration of execution', async (t) => {
   const job = {
-    id: 'j',
+    id: 'y',
     expression: [(s: State) => s],
   };
   const initialState = createState();
@@ -253,5 +262,22 @@ test('log duration of execution', async (t) => {
 
   const duration = logger._find('success', /completed job /i);
 
-  t.regex(duration?.message, /completed job j in \d\d?ms/i);
+  t.regex(duration?.message, /completed job y in \d\d?ms/i);
+});
+
+test.serial('log memory usage', async (t) => {
+  const job = {
+    id: 'z',
+    expression: [(s: State) => s],
+  };
+  const initialState = createState();
+  const context = createContext();
+
+  await execute(context, job, initialState);
+
+  const memory = logger._find('debug', /final memory usage/i);
+
+  // All we're looking for here is two strings of numbers in mb
+  // the rest is for the birds
+  t.regex(memory?.message, /\d+mb(.+)\d+mb/i);
 });

--- a/packages/runtime/test/execute/job.test.ts
+++ b/packages/runtime/test/execute/job.test.ts
@@ -123,12 +123,13 @@ test(`notify ${NOTIFY_JOB_COMPLETE} with no next`, async (t) => {
 
   const notify = (event: string, payload: any) => {
     if (event === NOTIFY_JOB_COMPLETE) {
-      const { state, duration, jobId, next } = payload;
+      const { state, duration, jobId, next, mem } = payload;
       t.truthy(state);
       t.deepEqual(state, state);
       t.deepEqual(next, []);
       t.assert(!isNaN(duration));
       t.true(duration < 100);
+      t.true(mem);
       t.is(jobId, 'j');
     }
   };

--- a/packages/runtime/test/execute/job.test.ts
+++ b/packages/runtime/test/execute/job.test.ts
@@ -129,7 +129,7 @@ test(`notify ${NOTIFY_JOB_COMPLETE} with no next`, async (t) => {
       t.deepEqual(next, []);
       t.assert(!isNaN(duration));
       t.true(duration < 100);
-      t.true(mem);
+      t.truthy(mem);
       t.is(jobId, 'j');
     }
   };

--- a/packages/runtime/test/memory.test.ts
+++ b/packages/runtime/test/memory.test.ts
@@ -1,0 +1,110 @@
+import test from 'ava';
+
+import {
+  ExecutionPlan,
+  NOTIFY_JOB_COMPLETE,
+  NotifyJobCompletePayload,
+} from '../src';
+import callRuntime from '../src/runtime';
+
+/**
+ * This file contains various memory tests for runtime usage
+ * The aim right now sis to understand how accurate process.memoryUsage()
+ * reports are at the end of the job
+ *
+ * Something to bear in mind here is that all the tests run in the same process and share memory
+ * I fully expect test 1 to have an impact on test 2
+ * Part of the testing is to understand how much
+ *
+ * Also a consideration for the engine: after a job completes, I don't think we do any cleanup
+ * of the SourceTextModule and context etc that we created for it.
+ *
+ * In the CLI this doesn't mattter because the process ends, and actually in the worker right now
+ * We burn the thread so it still doesn't matter much/
+ */
+
+type Mem = {
+  job: number; // heapUsed in bytes
+  system: number; // rss in bytes
+};
+
+// This helper will run a workflow and return
+// memory usage per run
+const run = async (t, workflow: ExecutionPlan) => {
+  const useage: Record<string, Mem> = {};
+
+  const notify = (evt: string, payload: NotifyJobCompletePayload) => {
+    if (evt === NOTIFY_JOB_COMPLETE) {
+      useage[payload.jobId] = payload.mem;
+    }
+  };
+
+  const state = await callRuntime(
+    workflow,
+    {},
+    {
+      strict: false,
+      callbacks: { notify },
+    }
+  );
+  logUsage(t, useage.a);
+  return { state, useage };
+};
+
+const logUsage = (t: any, mem: Mem, label = '') => {
+  // What kind of rounding should I Do?
+  // Rounding to an integer is best for humans but I think in these tests we lose a lot of fidelity
+  // I mean you could lose nearly 500kb of accuracy, that's a lot!
+  const job = (mem.job / 1024 / 1024).toFixed(2);
+  const system = (mem.system / 1024 / 1024).toFixed(2);
+  t.log(`${label} job: ${job}mb / system ${system}mb`);
+};
+
+// const jobs = {
+//   fn: () => 'export default [(s) => s]',
+
+// };
+
+const expressions = {
+  readMemory: (jobName: string) => (s: any) => {
+    // Hmm, the rounded human number actually looks quite different to theactual reported number
+    const mem = process.memoryUsage();
+    s[jobName] = { job: mem.heapUsed, system: mem.rss };
+    return s;
+  },
+};
+
+test('emit memory usage to job-complete', async (t) => {
+  const plan = {
+    jobs: [
+      {
+        id: 'a',
+        // This seems to use ~55mb of heap (job)
+        expression: [(s) => s],
+      },
+    ],
+  };
+
+  const { useage } = await run(t, plan);
+  t.true(!isNaN(useage.a.job));
+  t.true(!isNaN(useage.a.system));
+  t.true(useage.a.job < useage.a.system);
+});
+
+test('report memory usage for a job to state', async (t) => {
+  const plan = {
+    jobs: [
+      {
+        id: 'a',
+        expression: [expressions.readMemory('a')],
+      },
+    ],
+  };
+
+  const { state } = await run(t, plan);
+  logUsage(t, state.a, 'state: ');
+
+  t.true(!isNaN(state.a.job));
+  t.true(!isNaN(state.a.system));
+  t.true(state.a.job < state.a.system);
+});

--- a/packages/runtime/test/memory.test.ts
+++ b/packages/runtime/test/memory.test.ts
@@ -1,3 +1,8 @@
+/**
+ * IGNORED BY AVA
+ * RUN WITH pnpm test:memory
+ * */
+
 import test from 'ava';
 
 import {
@@ -314,3 +319,5 @@ test.serial(
     t.true(roughlyEqual(mem.a.job, state.a.job, 0.01));
   }
 );
+
+test.todo('will gc run if we leave a long timeout?');

--- a/packages/runtime/test/repo/get-latest-installed-version.ts
+++ b/packages/runtime/test/repo/get-latest-installed-version.ts
@@ -47,7 +47,7 @@ test('return the higher if order is changed', async (t) => {
 test('should read package json from disk', async (t) => {
   const result = await getLatestInstalledVersion(
     'ultimate-answer',
-    path.resolve('test/__repo')
+    path.resolve('test/__repo__')
   );
   t.assert(result === 'ultimate-answer_2.0.0');
 });

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -13,7 +13,11 @@ import run from '../src/runtime';
 
 // High level examples of runtime usages
 
-test('run simple expression', async (t) => {
+// TODO create memory test
+// create large arrays or something to inflate memory usage
+// https://www.valentinog.com/blog/node-usage/
+
+test.only('run simple expression', async (t) => {
   const expression = 'export default [(s) => {s.data.done = true; return s}]';
 
   const result: any = await run(expression);

--- a/packages/ws-worker/src/api/execute.ts
+++ b/packages/ws-worker/src/api/execute.ts
@@ -216,6 +216,8 @@ export function onJobComplete(
   }
   state.dataclips[dataclipId] = event.state;
 
+  delete state.activeRun;
+  delete state.activeJob;
   // TODO right now, the last job to run will be the result for the attempt
   // this may not stand up in the future
   // I'd feel happer if the runtime could judge what the final result is
@@ -229,8 +231,6 @@ export function onJobComplete(
     state.inputDataclips[nextJobId] = dataclipId;
   });
 
-  delete state.activeRun;
-  delete state.activeJob;
   const { reason, error_message, error_type } = calculateJobExitReason(
     job_id,
     event.state,
@@ -247,6 +247,7 @@ export function onJobComplete(
     reason,
     error_message,
     error_type,
+    mem: event.mem,
   };
   return sendEvent<RunCompletePayload>(channel, RUN_COMPLETE, evt);
 }

--- a/packages/ws-worker/src/api/execute.ts
+++ b/packages/ws-worker/src/api/execute.ts
@@ -247,7 +247,10 @@ export function onJobComplete(
     reason,
     error_message,
     error_type,
+
     mem: event.mem,
+    duration: event.duration,
+    thread_id: event.threadId,
   };
   return sendEvent<RunCompletePayload>(channel, RUN_COMPLETE, evt);
 }

--- a/packages/ws-worker/src/mock/runtime-engine.ts
+++ b/packages/ws-worker/src/mock/runtime-engine.ts
@@ -15,15 +15,18 @@ export type EngineEvent =
 
 export type WorkflowStartEvent = {
   workflowId: string;
+  threadId: string;
 };
 
 export type WorkflowCompleteEvent = {
   workflowId: string;
   error?: any; // hmm maybe not
+  threadId: string;
 };
 
 export type WorkflowErrorEvent = {
   workflowId: string;
+  threadId: string;
   message: string;
 };
 

--- a/packages/ws-worker/test/api/execute.test.ts
+++ b/packages/ws-worker/test/api/execute.test.ts
@@ -220,7 +220,7 @@ test('jobComplete should generate an exit reason: success', async (t) => {
   t.is(event.error_message, null);
 });
 
-test('jobComplete should send a run:complete event', async (t) => {
+test.only('jobComplete should send a run:complete event', async (t) => {
   const plan = { id: 'attempt-1' };
   const jobId = 'job-1';
   const result = { x: 10 };
@@ -236,10 +236,18 @@ test('jobComplete should send a run:complete event', async (t) => {
       t.truthy(evt.output_dataclip_id);
       t.is(evt.output_dataclip, JSON.stringify(result));
       t.deepEqual(evt.mem, event.mem);
+      t.is(evt.duration, event.duration);
+      t.is(evt.thread_id, event.threadId);
     },
   });
 
-  const event = { state: result, next: ['a'], mem: { job: 1, system: 10 } };
+  const event = {
+    state: result,
+    next: ['a'],
+    mem: { job: 1, system: 10 },
+    duration: 61,
+    threadId: 'abc',
+  };
   await onJobComplete({ channel, state }, event);
 });
 

--- a/packages/ws-worker/test/api/execute.test.ts
+++ b/packages/ws-worker/test/api/execute.test.ts
@@ -235,10 +235,11 @@ test('jobComplete should send a run:complete event', async (t) => {
       t.truthy(evt.run_id);
       t.truthy(evt.output_dataclip_id);
       t.is(evt.output_dataclip, JSON.stringify(result));
+      t.deepEqual(evt.mem, event.mem);
     },
   });
 
-  const event = { state: result, next: ['a'] };
+  const event = { state: result, next: ['a'], mem: { job: 1, system: 10 } };
   await onJobComplete({ channel, state }, event);
 });
 

--- a/packages/ws-worker/test/lightning.test.ts
+++ b/packages/ws-worker/test/lightning.test.ts
@@ -275,6 +275,9 @@ test.serial(
         t.truthy(payload.run_id);
         t.truthy(payload.output_dataclip);
         t.truthy(payload.output_dataclip_id);
+        t.truthy(payload.mem.job);
+        t.truthy(payload.mem.system);
+        t.true(payload.mem.system > payload.mem.job);
         t.pass('called run complete');
       });
 

--- a/packages/ws-worker/test/lightning.test.ts
+++ b/packages/ws-worker/test/lightning.test.ts
@@ -264,13 +264,14 @@ test.serial(`events: lightning should receive a ${e.RUN_START} event`, (t) => {
   });
 });
 
-test.serial(
+test.serial.only(
   `events: lightning should receive a ${e.RUN_COMPLETE} event`,
   (t) => {
     return new Promise((done) => {
       const attempt = getAttempt();
 
       lng.onSocketEvent(e.RUN_COMPLETE, attempt.id, ({ payload }) => {
+        console.log(payload);
         t.is(payload.job_id, 'j');
         t.truthy(payload.run_id);
         t.truthy(payload.output_dataclip);

--- a/packages/ws-worker/test/mock/runtime-engine.test.ts
+++ b/packages/ws-worker/test/mock/runtime-engine.test.ts
@@ -53,7 +53,8 @@ test('Dispatch complete events when a workflow completes', async (t) => {
     'workflow-complete'
   );
 
-  t.deepEqual(evt, { workflowId: 'w1' });
+  t.is(evt.workflowId, 'w1');
+  t.truthy(evt.threadId);
 });
 
 test('Dispatch start events for a job', async (t) => {


### PR DESCRIPTION
## Overview

This PR will:
* Record memory usage at the end of every job
* Log it to stdout (which the worker will pick up and send to lightning as log)
* Emit it as an event (which the worker can pick up and send directly to lightning)

Closes #28

Note: This does NOT limit memory usage or kill a worker which exceeds a limit - that's a separate piece of work.

CLI output:

![image](https://github.com/OpenFn/kit/assets/7052509/42b9be42-5fba-46fe-a764-12ef0815a7a5)


## Details

We use `process.memoryUsage()` to report memory usage to the user.

This is a **snapshot** of memory at the moment we call the function. Which, right now, as at the end of a **job**.

This is not a particularly reliable number and represents final, not peak, memory allocation. See the discussion below.

We get a few numbers of out of `process.memoryUsage()`, see the discussion at the end of the issue. I am choosing to represent `heapUsed` as Job memory - that's how much memory the actual job code took and excludes compiler/runtime overheads. I'm using `rss`, which I think is the memory used by the whole node process, as System memory. The user has no control over this stuff - that's the memory we require to run the job in the first place.

Difficulty: I think `rss` represents the entire Engine memory, ie all the worker threads combined, not just the current thread. If I'm reading the docs right.

The runtime will log memory usage to debug at the end of each job, and emit an event with the same usage in it. The worker will send the memory used (along with the thread id and duration) to Lightning. I am using these values in integration tests to report how much memory each job uses, which is neat.

![image](https://github.com/OpenFn/kit/assets/7052509/87f68c03-352e-4f63-b50b-d183318e6175)

## Testing

I've been testing a bunch of behaviours (including manually triggering garbage collection) in `runtime/test/memory.test.ts`. This is not run CI because it's a bit weird. Use `pnpm test:memory` to run it - I think this is quite a good illustration of some of node's memory management and reporting behaviours.

## Discussion

Reporting accurately is actually going to be super difficult.

`process.memoryUsage()` takes a snapshot at a given moment in time. When garbage collection (gc) runs, memory will be freed up. Which is all well and good, but the memory we report is the final memory (after we've serialised state) - not the peak memory usage.

I am not really sure how useful this final usage figure is.

We could introduce higher resolution recording by taking a snapshot at the end of each operation (not just each job). But this still isn't useful if there are 100 lines of code inside an `fn` block. If gc is run at the end, or in the middle, then the bulk of the memory could be freed up and our reporting is very misleading.

Also note that when the state object is large, serializing it at the end of the job can consume a lot of memory.

Alternatively we could try and call memoryusage on an interval, or maybe even listen to gc events (although we only get an event after gc and may not know how much was freed up). But there is a performance cost with the memoryUsage API, it does take time and effort to read the size of the memory stack. I am not sure yet if it's a SIGNIFICANT performance cost. But even so, I'm not sure what the maximum rate of measuring would be.

## TODO

* [x] Should we always log memory usage? Do we really care about it? It's probably a debug thing right?
* [x] Look at logging in CLI and Worker, is there anything to do here?
* [x] Send memory usage to Lightning (it can present it to user s if we want)
* [x] Tweak ava testing so that only runtime tests use the gc stuff. Ideally actually these tests would be disabled and only run from a special command.