### PR TITLE
Catch async errors (fixes postgres)

### DIFF
--- a/.changeset/twenty-oranges-push.md
+++ b/.changeset/twenty-oranges-push.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': patch
+---
+
+Handle async errors in the runtime

--- a/packages/engine-multi/src/api/call-worker.ts
+++ b/packages/engine-multi/src/api/call-worker.ts
@@ -96,5 +96,8 @@ export function createWorkers(workerPath: string, options: WorkerOptions) {
         maxOldGenerationSizeMb: memoryLimitMb,
       },
     },
+    onTerminateWorker: () => {
+      console.log(' ******* WORKER DIED ****');
+    },
   });
 }

--- a/packages/engine-multi/src/api/call-worker.ts
+++ b/packages/engine-multi/src/api/call-worker.ts
@@ -96,8 +96,5 @@ export function createWorkers(workerPath: string, options: WorkerOptions) {
         maxOldGenerationSizeMb: memoryLimitMb,
       },
     },
-    onTerminateWorker: () => {
-      console.log(' ******* WORKER DIED ****');
-    },
   });
 }

--- a/packages/engine-multi/src/api/execute.ts
+++ b/packages/engine-multi/src/api/execute.ts
@@ -77,6 +77,7 @@ const execute = async (context: ExecutionContext) => {
         error(context, { workflowId: state.plan.id, error: evt.error });
       },
     };
+
     return callWorker(
       'run',
       [state.plan, runOptions],

--- a/packages/engine-multi/src/errors.ts
+++ b/packages/engine-multi/src/errors.ts
@@ -28,7 +28,7 @@ export class TimeoutError extends EngineError {
 export class ExecutionError extends EngineError {
   severity = 'exception';
   type = 'ExecutionError';
-  subtype;
+  name = 'ExecutionError';
   message;
 
   original: any; // this is the original error
@@ -37,7 +37,6 @@ export class ExecutionError extends EngineError {
     this.original = original;
 
     this.message = original.message;
-    this.subtype = original.type || original.constructor.name;
   }
 }
 


### PR DESCRIPTION
Catch async errors to better handle stuff like the postgres syntax error in #509

Fun one this!

Usually when job or adaptor code throws, the exception is caught in, well, a few places actually. It eventually bubbles back out to the worker where it'll be handled.

But! Those wrapping catches only apply to the original callstack. Any async code which uses setTimeout or process.nextTick or something will throw to the process root and cause an exit.

In other words we can't catch this bad boy and bad things happen:
```
fn((s) => return new Promise(() => {
  setTimeout(() => { throw \"e\" }, 1) }
))
```

The solution is to use the handy `process.on('uncaughtException',fn)` as a catch-all. This lets us catch any off-piste errors and return a nice error event out to the worker.

It's worth noting that if async code runs after the job completes, and happens to throw, that throw will be ignored. The worker basically stops listening after the return. This is a bit of a moot point because the thread will be burned anyway.