### PR TITLE
Handle process exit 

### DIFF
--- a/.changeset/violet-ligers-walk.md
+++ b/.changeset/violet-ligers-walk.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': patch
+---
+
+Throw a better error on process.exit

--- a/integration-tests/worker/test/exit-reasons.test.ts
+++ b/integration-tests/worker/test/exit-reasons.test.ts
@@ -100,3 +100,23 @@ test('kill: oom', async (t) => {
   t.is(error_type, 'OOMError');
   t.is(error_message, 'Run exceeded maximum memory usage');
 });
+
+test('crash: process.exit() triggered by postgres', async (t) => {
+  const attempt = {
+    id: crypto.randomUUID(),
+    jobs: [
+      {
+        adaptor: '@openfn/language-postgresql@4.1.8', // version number is important
+        body: "sql('select * from food_hygiene_interview');",
+      },
+    ],
+  };
+
+  const result = await run(attempt);
+
+  const { reason, error_type, error_message } = result;
+
+  t.is(reason, 'crash');
+  t.is(error_type, 'ExitError');
+  t.regex(error_message, /Process exited with code: 1/i);
+});

--- a/packages/engine-multi/src/api/call-worker.ts
+++ b/packages/engine-multi/src/api/call-worker.ts
@@ -96,5 +96,9 @@ export function createWorkers(workerPath: string, options: WorkerOptions) {
         maxOldGenerationSizeMb: memoryLimitMb,
       },
     },
+    onTerminateWorker: (evt) => {
+      console.log(' **** worker terminated ');
+      console.log(evt);
+    },
   });
 }

--- a/packages/engine-multi/src/api/call-worker.ts
+++ b/packages/engine-multi/src/api/call-worker.ts
@@ -96,9 +96,5 @@ export function createWorkers(workerPath: string, options: WorkerOptions) {
         maxOldGenerationSizeMb: memoryLimitMb,
       },
     },
-    onTerminateWorker: (evt) => {
-      console.log(' **** worker terminated ');
-      console.log(evt);
-    },
   });
 }

--- a/packages/engine-multi/src/api/execute.ts
+++ b/packages/engine-multi/src/api/execute.ts
@@ -87,8 +87,13 @@ const execute = async (context: ExecutionContext) => {
       // Catch process.exit from inside the thread
       // This approach is not pretty - we are banking on replacing workerpool soon
       if (e.message.match(/^Workerpool Worker terminated Unexpectedly/)) {
-        const exitCode = e.message.match(/exitCode: `(\d+)`/);
-        e = new ExitError(parseInt(exitCode[1]));
+        const [_match, exitCode] = e.message.match(/exitCode: `(\d+)`/);
+        if (exitCode === '111111') {
+          // This means a controlled exit from inside the worker
+          // The error has already been reported and we should do nothing
+          return;
+        }
+        e = new ExitError(parseInt(exitCode));
       } else if (e.code === 'ERR_WORKER_OUT_OF_MEMORY') {
         e = new OOMError();
       } else if (e instanceof WorkerPoolPromise.TimeoutError) {

--- a/packages/engine-multi/src/api/execute.ts
+++ b/packages/engine-multi/src/api/execute.ts
@@ -97,7 +97,7 @@ const execute = async (context: ExecutionContext) => {
       }
 
       error(context, { workflowId: state.plan.id, error: e });
-      logger.error(e);
+      logger.error(`Critical error thrown by ${state.plan.id}`, e);
     });
   } catch (e: any) {
     if (!e.severity) {

--- a/packages/engine-multi/src/errors.ts
+++ b/packages/engine-multi/src/errors.ts
@@ -82,4 +82,18 @@ export class OOMError extends EngineError {
   }
 }
 
+export class ExitError extends EngineError {
+  severity = 'kill';
+  type = 'ExitError';
+  name = 'ExitError';
+  code;
+  message;
+
+  constructor(code: number) {
+    super();
+    this.code = code;
+    this.message = `Process exited with code: ${code}`;
+  }
+}
+
 // CredentialsError (exception)

--- a/packages/engine-multi/src/errors.ts
+++ b/packages/engine-multi/src/errors.ts
@@ -83,7 +83,7 @@ export class OOMError extends EngineError {
 }
 
 export class ExitError extends EngineError {
-  severity = 'kill';
+  severity = 'crash';
   type = 'ExitError';
   name = 'ExitError';
   code;

--- a/packages/engine-multi/src/errors.ts
+++ b/packages/engine-multi/src/errors.ts
@@ -93,6 +93,9 @@ export class ExitError extends EngineError {
     super();
     this.code = code;
     this.message = `Process exited with code: ${code}`;
+    // Remove the stack trace
+    // It contains no useful information
+    this.stack = '';
   }
 }
 

--- a/packages/engine-multi/src/worker/worker-helper.ts
+++ b/packages/engine-multi/src/worker/worker-helper.ts
@@ -6,7 +6,7 @@ import { threadId } from 'node:worker_threads';
 import createLogger, { SanitizePolicies } from '@openfn/logger';
 
 import * as workerEvents from './events';
-import { ExecutionError, ExitError } from '../errors';
+import { ExecutionError } from '../errors';
 
 export const createLoggers = (
   workflowId: string,

--- a/packages/engine-multi/src/worker/worker-helper.ts
+++ b/packages/engine-multi/src/worker/worker-helper.ts
@@ -88,14 +88,19 @@ async function helper(workflowId: string, execute: () => Promise<any>) {
     // For now, we'll write this off as a crash-level generic execution error
     // TODO did this come from job or adaptor code?
     const e = new ExecutionError(err);
-    e.severity = 'crash'; // Downgrade this to a crash becuase it's likely not our fault
+    e.severity = 'crash'; // Downgrade this to a crash because it's likely not our fault
     handleError(e);
+
+    // Close down the process justto be 100% sure that all async code stops
+    // This is in a timeout to give the emitted message time to escape
+    // There is a TINY WINDOW in which async code can still run and affect the next attempt
+    // This should all go away when we replace workerpool
+    setTimeout(() => {
+      process.exit(111111);
+    }, 2);
   });
 
   try {
-    // Note that the worker thread may fire logs after completion
-    // I think this is fine, it's just a log stream thing
-    // But the output is very confusing!
     const result = await execute();
     publish(workflowId, workerEvents.WORKFLOW_COMPLETE, { state: result });
 

--- a/packages/engine-multi/src/worker/worker-helper.ts
+++ b/packages/engine-multi/src/worker/worker-helper.ts
@@ -6,7 +6,7 @@ import { threadId } from 'node:worker_threads';
 import createLogger, { SanitizePolicies } from '@openfn/logger';
 
 import * as workerEvents from './events';
-import { ExecutionError } from '../errors';
+import { ExecutionError, ExitError } from '../errors';
 
 export const createLoggers = (
   workflowId: string,
@@ -90,7 +90,6 @@ async function helper(workflowId: string, execute: () => Promise<any>) {
     const e = new ExecutionError(err);
     e.severity = 'crash'; // Downgrade this to a crash becuase it's likely not our fault
     handleError(e);
-    process.exit(1);
   });
 
   try {

--- a/packages/engine-multi/test/__repo__/node_modules/helper_1.0.0/index.cjs
+++ b/packages/engine-multi/test/__repo__/node_modules/helper_1.0.0/index.cjs
@@ -1,0 +1,6 @@
+module.exports =  {
+  exit: function() {
+    console.log('exiting process')
+    process.exit(1)
+  }
+};

--- a/packages/engine-multi/test/__repo__/node_modules/helper_1.0.0/index.cjs
+++ b/packages/engine-multi/test/__repo__/node_modules/helper_1.0.0/index.cjs
@@ -1,6 +1,9 @@
 module.exports =  {
   exit: function() {
-    console.log('exiting process')
-    process.exit(1)
+    return function (state) {
+      console.log('exiting process')
+      process.exit(42)
+      return state;
+    }
   }
 };

--- a/packages/engine-multi/test/__repo__/node_modules/helper_1.0.0/package.json
+++ b/packages/engine-multi/test/__repo__/node_modules/helper_1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "helper",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.cjs",
+  "private": true
+}

--- a/packages/engine-multi/test/__repo__/package.json
+++ b/packages/engine-multi/test/__repo__/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-repo",
+  "private": true,
+  "version": "1.0.0",
+  "dependencies": {
+    "helper_1.0.0": "@npm:helper@1.0.0"
+  }
+}

--- a/packages/engine-multi/test/errors.test.ts
+++ b/packages/engine-multi/test/errors.test.ts
@@ -124,7 +124,7 @@ test.serial('execution error from async code', (t) => {
   });
 });
 
-test.serial('emit a kill error on process.exit()', (t) => {
+test.serial('emit a crash error on process.exit()', (t) => {
   return new Promise((done) => {
     const plan = {
       id: 'z',
@@ -138,7 +138,7 @@ test.serial('emit a kill error on process.exit()', (t) => {
 
     engine.execute(plan).on(WORKFLOW_ERROR, (evt) => {
       t.is(evt.type, 'ExitError');
-      t.is(evt.severity, 'kill');
+      t.is(evt.severity, 'crash');
       t.is(evt.message, 'Process exited with code: 42');
       done();
     });


### PR DESCRIPTION
So it turns out that some adaptors trigger a process.exit and that causes us all sorts of problems - see #520 for details and a reproduction.

There is a limit to what we can do about this. Inside the worker we can listen for `process.on('exit')`, but we have to run synchronous code in there. We don't actually seem to be able to send a message out of the worker thread.

So instead, outside the thread in the main process, we keep an eye out for workers which throw with a message like `Workerpool Worker terminated Unexpectedly`. Looking at the workerpool source I'm reasonably confident that this is only triggered by process.exit.

So we can detect an early exit and report a vague exit reason. I'm calling it a `kill` (although it's an internal rather than external kill)

Lightning should now get an attempt:complete with this reason:
```
{
"reason":"kill",
"error_type":"ExitError",
"error_message":"Process exited with code: 1"
}
```
Bonus fix: I caught a small issue with some prior error handling. A promise inside the worker which throws an uncaught error is never resolved, and so the engine never releases the worker . 

To fix this, I'm forcing a process.exit just to be absolutely sure the worker stops executing. This kind of undermines the purge policy but whatever - all this is going to be ripped out soon anyway (probably).