### PR TITLE
Warn on no return state

### DIFF
--- a/.changeset/yellow-pumpkins-dress.md
+++ b/.changeset/yellow-pumpkins-dress.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+Warn if a non-leaf job does not return state

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -69,7 +69,6 @@ export default (
       duration = Date.now() - duration;
 
       const finalState = prepareFinalState(opts, result);
-
       // return the final state
       resolve(finalState);
     } catch (e: any) {
@@ -104,6 +103,8 @@ export const wrapOperation = (
     const start = new Date().getTime();
     const newState = immutableState ? clone(state) : state;
     const result = await fn(newState);
+    // TODO should we warn if an operation does not return state?
+    // the trick is saying WHICH operation without source mapping
     const duration = printDuration(new Date().getTime() - start);
     logger.info(`Operation ${name} complete in ${duration}`);
     return result;

--- a/packages/runtime/src/execute/job.ts
+++ b/packages/runtime/src/execute/job.ts
@@ -192,6 +192,12 @@ const executeJob = async (
     next = calculateNext(job, result);
   }
 
+  if (next.length && !didError && !result) {
+    logger.warn(
+      `WARNING: job ${jobId} did not return a state object. This may cause downstream jobs to fail.`
+    );
+  }
+
   return { next, state: result };
 };
 

--- a/packages/runtime/test/execute/job.test.ts
+++ b/packages/runtime/test/execute/job.test.ts
@@ -281,3 +281,56 @@ test.serial('log memory usage', async (t) => {
   // the rest is for the birds
   t.regex(memory?.message, /\d+mb(.+)\d+mb/i);
 });
+
+test('warn if a non-leaf job does not return state', async (t) => {
+  const job = {
+    id: 'k',
+    expression: [(s: State) => {}],
+    next: { l: true },
+  };
+
+  const context = createContext();
+  const state = createState();
+
+  // @ts-ignore ts complains that the job does not return state
+  const result = await execute(context, job, state);
+  const warn = logger._find('warn', /did not return a state object/);
+  t.truthy(warn);
+});
+
+test('do not warn if a leaf job does not return state', async (t) => {
+  const job = {
+    id: 'k',
+    expression: [(s: State) => {}],
+  };
+
+  const context = createContext();
+  const state = createState();
+
+  // @ts-ignore ts complains that the job does not return state
+  const result = await execute(context, job, state);
+
+  const warn = logger._find('warn', /did not return a state object/);
+  t.falsy(warn);
+});
+
+test('do not warn a non-leaf job does not return state and there was an error', async (t) => {
+  const job = {
+    id: 'k',
+    expression: [
+      (s: State) => {
+        throw 'e';
+      },
+    ],
+    next: { l: true },
+  };
+
+  const context = createContext();
+  const state = createState();
+
+  // @ts-ignore ts complains that the job does not return state
+  const result = await execute(context, job, state);
+
+  const warn = logger._find('warn', /did not return a state object/);
+  t.falsy(warn);
+});


### PR DESCRIPTION
Simple PR to log a warning for a job that does not return state.

The log is only printed if:
* The job is a leaf node, ie, there is another job  downstream
* The job did not previously throw an error

Closes #449

## Notes

Originally I wanted to crash here. But on reflection I think that's too strong an action - at least for now. The downstream job will blow up if it needs to, and at least there's a nice warning before now.

Note that in future it may be even more useful to warn for each OPERATION that doesn't return state. That would be cool because it's probably more likely that you'll do `sql("blah", () => { data })` and kill a client object.

The only reason I'm NOT doing that now is that I don't have any source mapping yet, so I can't say "the operation on line 4 did not return state". So it would be a bit of a frustrating error message I think.