### PR TITLE
worker: better edge conditions

### DIFF
--- a/.changeset/angry-islands-tan.md
+++ b/.changeset/angry-islands-tan.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Make edge conditions more stable if state is not passed

--- a/packages/ws-worker/src/util/convert-attempt.ts
+++ b/packages/ws-worker/src/util/convert-attempt.ts
@@ -10,9 +10,9 @@ import { Attempt, AttemptOptions, Edge } from '../types';
 export const conditions: Record<string, (upstreamId: string) => string | null> =
   {
     on_job_success: (upstreamId: string) =>
-      `Boolean(!state.errors?.["${upstreamId}"] ?? true)`,
+      `Boolean(!state?.errors?.["${upstreamId}"] ?? true)`,
     on_job_failure: (upstreamId: string) =>
-      `Boolean(state.errors && state.errors["${upstreamId}"])`,
+      `Boolean(state?.errors && state.errors["${upstreamId}"])`,
     always: (_upstreamId: string) => null,
   };
 
@@ -79,7 +79,7 @@ export default (
 
       nodes[id] = {
         id,
-        configuration: job.credential_id,
+        configuration: job.credential || job.credential_id,
         expression: job.body,
         adaptor: job.adaptor,
       };

--- a/packages/ws-worker/src/util/convert-attempt.ts
+++ b/packages/ws-worker/src/util/convert-attempt.ts
@@ -79,7 +79,7 @@ export default (
 
       nodes[id] = {
         id,
-        configuration: job.credential || job.credential_id,
+        configuration: job.credential_id,
         expression: job.body,
         adaptor: job.adaptor,
       };

--- a/packages/ws-worker/test/util/convert-attempt.test.ts
+++ b/packages/ws-worker/test/util/convert-attempt.test.ts
@@ -348,6 +348,17 @@ test('on_job_success condition: return true if no errors', (t) => {
   t.is(result, true);
 });
 
+// You can argue this both ways, but a job which returned no state is technically not in error
+// Mostly I dont want it to blow up
+test('on_job_success condition: return true if state is undefined', (t) => {
+  const condition = conditions.on_job_success('a');
+
+  const state = undefined;
+  const result = testEdgeCondition(condition, state);
+
+  t.is(result, true);
+});
+
 test('on_job_success condition: return true if unconnected upstream errors', (t) => {
   const condition = conditions.on_job_success('a');
 
@@ -412,6 +423,15 @@ test('on_job_failure condition: return false if no errors', (t) => {
   const condition = conditions.on_job_failure('a');
 
   const state = {};
+  const result = testEdgeCondition(condition, state);
+
+  t.is(result, false);
+});
+
+test('on_job_failure condition: return false if state is undefined', (t) => {
+  const condition = conditions.on_job_failure('a');
+
+  const state = undefined;
   const result = testEdgeCondition(condition, state);
 
   t.is(result, false);


### PR DESCRIPTION
A small PR to make edge conditions a bit more robust

There is no issue for this. I just noticed today that if an upstream job fails to return state, the edge condition will fail to execute.

I've updated the conditions again in https://github.com/OpenFn/Lightning/issues/1268