### PR TITLE
CLI:  Don't throw if job doesn't return state

### DIFF
--- a/.changeset/eighty-moons-smile.md
+++ b/.changeset/eighty-moons-smile.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Fix an issue where an error is thrown if a job does not return state

--- a/packages/cli/src/execute/handler.ts
+++ b/packages/cli/src/execute/handler.ts
@@ -58,12 +58,12 @@ const executeHandler = async (options: ExecuteOptions, logger: Logger) => {
     const result = await execute(input!, state, options);
     await serializeOutput(options, result, logger);
     const duration = printDuration(new Date().getTime() - start);
-    if (result.errors) {
+    if (result?.errors) {
       logger.warn(
         `Errors reported in ${Object.keys(result.errors).length} jobs`
       );
     }
-    logger.success(`Finished in ${duration}${result.errors ? '' : ' ✨'}`);
+    logger.success(`Finished in ${duration}${result?.errors ? '' : ' ✨'}`);
     return result;
   } catch (err: any) {
     if (!err.handled) {

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -123,7 +123,7 @@ test.serial('run a job with defaults: openfn job.js', async (t) => {
   t.assert(result.data.count === 42);
 });
 
-test.only('run a job which does not return state', async (t) => {
+test('run a job which does not return state', async (t) => {
   const result = await run('openfn job.js', 'export default [s => {}]');
 
   t.is(result.data, 42);

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -123,6 +123,12 @@ test.serial('run a job with defaults: openfn job.js', async (t) => {
   t.assert(result.data.count === 42);
 });
 
+test.only('run a job which does not return state', async (t) => {
+  const result = await run('openfn job.js', 'export default [s => {}]');
+
+  t.is(result.data, 42);
+});
+
 test.serial('run a workflow', async (t) => {
   const workflow = {
     jobs: [

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -123,10 +123,10 @@ test.serial('run a job with defaults: openfn job.js', async (t) => {
   t.assert(result.data.count === 42);
 });
 
-test('run a job which does not return state', async (t) => {
+test.serial('run a job which does not return state', async (t) => {
   const result = await run('openfn job.js', 'export default [s => {}]');
 
-  t.is(result.data, 42);
+  t.falsy(result);
 });
 
 test.serial('run a workflow', async (t) => {

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -255,3 +255,16 @@ test('run a job without compilation', async (t) => {
   const result = await handler(options, logger);
   t.is(result.data.count, 42);
 });
+
+test('run a job which does not return state', async (t) => {
+  const job = `${fn}fn(() => {});`;
+  const options = {
+    ...defaultOptions,
+    job,
+  };
+  const result = await handler(options, logger);
+  t.falsy(result);
+
+  // Check that no error messages have been logged
+  t.is(logger._history.length, 0);
+});

--- a/packages/engine-multi/test/integration.test.ts
+++ b/packages/engine-multi/test/integration.test.ts
@@ -165,6 +165,29 @@ test.serial('compile and run', (t) => {
   });
 });
 
+test.serial('run without error if no state is returned', (t) => {
+  return new Promise(async (done) => {
+    api = await createAPI({
+      logger,
+    });
+
+    const plan = createPlan([
+      {
+        expression: `${withFn}fn(() => {})`,
+      },
+    ]);
+
+    api.execute(plan).on('workflow-complete', ({ state }) => {
+      t.falsy(state);
+
+      // Ensure there are no error logs
+      const err = logger._find('error', /./);
+      t.falsy(err);
+      done();
+    });
+  });
+});
+
 test.serial('evaluate conditional edges', (t) => {
   return new Promise(async (done) => {
     api = await createAPI({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
         specifier: ^5.1.6
         version: 5.1.6
 
-  integration-tests/worker/tmp/repo/exit-reason:
+  integration-tests/worker/tmp/repo/integration:
     dependencies:
       '@openfn/language-common_latest':
         specifier: npm:@openfn/language-common@^1.11.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,12 +146,6 @@ importers:
         specifier: ^5.1.6
         version: 5.1.6
 
-  integration-tests/worker/tmp/repo/integration:
-    dependencies:
-      '@openfn/language-common_latest':
-        specifier: npm:@openfn/language-common@^1.11.1
-        version: /@openfn/language-common@1.11.1
-
   packages/cli:
     dependencies:
       '@inquirer/prompts':


### PR DESCRIPTION
A small fix for for the CLI which stops an error being thrown if a workflow doesn't return a state object.

Closes #353 

I don't think this affects the worker - I've been testing around and raising some other PRs in that area.