### PR TITLE
Simplify version reporting

### DIFF
--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/integration-tests-worker
 
+## 1.0.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/ws-worker@0.3.1
+
 ## 1.0.24
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ws-worker
 
+## 0.3.1
+
+### Patch Changes
+
+- Don't log compiler and runtime version logs
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/ws-worker/src/util/versions.ts
+++ b/packages/ws-worker/src/util/versions.ts
@@ -23,9 +23,11 @@ export default (runId: string, versions: Versions, adaptor?: string) => {
   let str = `Versions for run ${runId}:
 ${prefix('node.js')}${versions.node || 'unknown'}
 ${prefix('worker')}${versions.worker || 'unknown'}
-${prefix('engine')}${versions.engine || 'unknown'}
-${prefix('runtime')}${versions.runtime || 'unknown'}
-${prefix('compiler')}${versions.compiler || 'unknown'}`;
+${prefix('engine')}${versions.engine || 'unknown'}`;
+
+  // Unfortunately the runtime and compiler versions get reported as workspace:* in prod right now
+  // ${prefix('runtime')}${versions.runtime || 'unknown'}
+  // ${prefix('compiler')}${versions.compiler || 'unknown'}`;
 
   if (Object.keys(adaptors).length) {
     let allAdaptors = Object.keys(adaptors);

--- a/packages/ws-worker/test/events/run-start.test.ts
+++ b/packages/ws-worker/test/events/run-start.test.ts
@@ -139,5 +139,5 @@ test('also logs the version number', async (t) => {
   t.log(message);
   // This just a light test of the string to make sure it's here
   // It uses src/util/versions, which is tested elsewhere
-  t.regex(message, /(node\.js).+(worker).+(engine).+(compiler)/is);
+  t.regex(message, /(node\.js).+(worker).+(engine)/is);
 });

--- a/packages/ws-worker/test/util/versions.test.ts
+++ b/packages/ws-worker/test/util/versions.test.ts
@@ -5,10 +5,10 @@ import calculateVersionString from '../../src/util/versions';
 // keys in this obejct are scrambled on purpose
 const versions = {
   worker: '2',
-  compiler: '5',
+  // compiler: '5',
   node: '1',
   engine: '3',
-  runtime: '4',
+  // runtime: '4',
 };
 
 // Util function to parse a version string into something easier to test
@@ -35,9 +35,7 @@ test('calculate version string', (t) => {
     `Versions for run run-1:
     ▸ node.js     1
     ▸ worker      2
-    ▸ engine      3
-    ▸ runtime     4
-    ▸ compiler    5`
+    ▸ engine      3`
   );
 });
 
@@ -49,8 +47,6 @@ test('helper should parse a version string and return the correct order', (t) =>
     ['node.js', '1'],
     ['worker', '2'],
     ['engine', '3'],
-    ['runtime', '4'],
-    ['compiler', '5'],
   ]);
 });
 
@@ -63,8 +59,6 @@ test("show unknown if a version isn't passed", (t) => {
     ['node.js', 'unknown'],
     ['worker', 'unknown'],
     ['engine', 'unknown'],
-    ['runtime', 'unknown'],
-    ['compiler', 'unknown'],
   ]);
 });
 
@@ -75,7 +69,7 @@ test('show adaptors last', (t) => {
   });
 
   const parsed = parse(str);
-  const common = parsed[5];
+  const common = parsed[3];
   t.deepEqual(common, ['@openfn/language-common', '1.0.0']);
 });
 
@@ -89,9 +83,9 @@ test('sort and list multiple adaptors', (t) => {
 
   const parsed = parse(str);
 
-  const a = parsed[5];
-  const j = parsed[6];
-  const z = parsed[7];
+  const a = parsed[3];
+  const j = parsed[4];
+  const z = parsed[5];
 
   t.deepEqual(a, ['a', '1']);
   t.deepEqual(j, ['j', '2']);


### PR DESCRIPTION
Don't report compiler and runtime as `workspace:*`

A real fix will take a little longer - I hope  dynamic import will do it.

But this is just a super quick patch to not log junk data.

Versions are bumped - this just needs to be merged and tagged for release.