### PR TITLE
Fix typo `CLI README.md`

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -237,7 +237,7 @@ If something unexpected happens during a command, your first step should be to r
 
 `debug` level logging is highly verbose and aims to tell you everything that's going on under-the hood. This is aimed mostly at CLI/runtime developers and can be very useful for debugging problems.
 
-### Structred/JSON logging
+### Structured/JSON logging
 
 By default all logs will be printed as human-readable strings.
 


### PR DESCRIPTION
## Short Description

Add `u` in `Structred` 
