### PR TITLE
Engine child process

### DIFF
--- a/integration-tests/worker/test/benchmark.test.ts
+++ b/integration-tests/worker/test/benchmark.test.ts
@@ -8,7 +8,7 @@ import { run, humanMb } from '../src/util';
 let lightning;
 let worker;
 
-const maxConcurrency = 1;
+const maxConcurrency = 5;
 
 test.before(async () => {
   const lightningPort = 4322;
@@ -53,7 +53,7 @@ test.after(async () => {
 });
 
 // Skipping these in CI (for now at least)
-test.serial.skip('run 100 attempts', async (t) => {
+test.serial('run 100 attempts', async (t) => {
   return new Promise((done, reject) => {
     const attemptsTotal = 100;
     let attemptsComplete = 0;
@@ -90,7 +90,7 @@ test.serial.skip('run 100 attempts', async (t) => {
 
     lightning.on('run:complete', (evt) => {
       // May want to disable this  but it's nice feedback
-      //console.log('Completed ', evt.attemptId);
+      console.log('Completed ', evt.attemptId);
 
       if (evt.payload.reason !== 'success') {
         t.log('Atempt failed:');

--- a/packages/engine-multi/src/api/call-worker.ts
+++ b/packages/engine-multi/src/api/call-worker.ts
@@ -7,6 +7,8 @@ import { PURGE } from '../events';
 import type { EngineAPI } from '../types';
 import type { Logger } from '@openfn/logger';
 
+import childprocessWorkers from '../worker/child-process';
+
 // All events coming out of the worker need to include a type key
 type WorkerEvent = {
   type: string;
@@ -29,14 +31,14 @@ export default function initWorkers(
   options: WorkerOptions = {},
   logger?: Logger
 ) {
-  const workers = createWorkers(workerPath, options);
+  // const workers = createWorkers(workerPath, options);
   engine.callWorker = (
     task: string,
     args: any[] = [],
     events: any = {},
     timeout?: number
   ) => {
-    const promise = workers.exec(task, args, {
+    const promise = childprocessWorkers.exec(task, args, {
       on: ({ type, ...args }: WorkerEvent) => {
         // just call the callback
         events[type]?.(args);

--- a/packages/engine-multi/src/api/call-worker.ts
+++ b/packages/engine-multi/src/api/call-worker.ts
@@ -53,16 +53,17 @@ export default function initWorkers(
   };
 
   engine.purge = () => {
-    const { pendingTasks } = workers.stats();
-    if (pendingTasks == 0) {
-      logger?.debug('Purging workers');
-      engine.emit(PURGE);
-      workers.terminate();
-    }
+    // const { pendingTasks } = workers.stats();
+    // if (pendingTasks == 0) {
+    //   logger?.debug('Purging workers');
+    //   engine.emit(PURGE);
+    //   workers.terminate();
+    // }
   };
 
   // This will force termination (with grace period if allowed)
-  engine.closeWorkers = async (instant?: boolean) => workers.terminate(instant);
+  // engine.closeWorkers = async (instant?: boolean) => workers.terminate(instant);
+  engine.closeWorkers = async () => {};
 }
 
 export function createWorkers(workerPath: string, options: WorkerOptions) {

--- a/packages/engine-multi/src/api/execute.ts
+++ b/packages/engine-multi/src/api/execute.ts
@@ -53,6 +53,7 @@ const execute = async (context: ExecutionContext) => {
 
     const events = {
       [workerEvents.WORKFLOW_START]: (evt: workerEvents.WorkflowStartEvent) => {
+        console.log('WORKFLOW START', evt);
         workflowStart(context, evt);
       },
       [workerEvents.WORKFLOW_COMPLETE]: (

--- a/packages/engine-multi/src/api/execute.ts
+++ b/packages/engine-multi/src/api/execute.ts
@@ -53,7 +53,6 @@ const execute = async (context: ExecutionContext) => {
 
     const events = {
       [workerEvents.WORKFLOW_START]: (evt: workerEvents.WorkflowStartEvent) => {
-        console.log('WORKFLOW START', evt);
         workflowStart(context, evt);
       },
       [workerEvents.WORKFLOW_COMPLETE]: (

--- a/packages/engine-multi/src/worker/child-process.ts
+++ b/packages/engine-multi/src/worker/child-process.ts
@@ -1,0 +1,50 @@
+import child_process from 'node:child_process';
+
+// make the API look like workerpool
+// (it's just an easier integration for how)
+const api = {
+  // mimic the handshake task
+  // (basically we'll just return true)
+  _handshake: () => {},
+
+  _run: async (plan: any, options: any) => {
+    return runInChildProcess(plan, options);
+  },
+
+  exec: (task: string, args: any[]) => {
+    if (task === 'run') {
+      return api._run(...args);
+    }
+  },
+};
+
+function runInChildProcess(plan: any, options: any) {
+  console.log('*', process.pid);
+  return new Promise((resolve, reject) => {
+    console.log('starting child process....');
+    const p = child_process.fork(
+      './dist/worker/child_worker.js',
+      [JSON.stringify(plan), JSON.stringify(options)],
+      {
+        detached: true, // child will live if parent dies.
+        // although tbf, what's the point?
+      }
+    );
+
+    p.on('message', (e) => {
+      console.log(e);
+      if (e.type === 'worker:workflow-complete') {
+        console.log('heard workflow complete!');
+        const state = e.state;
+
+        p.disconnect();
+
+        resolve(state);
+      }
+
+      // TODO kill the process now
+    });
+  });
+}
+
+export default api;

--- a/packages/engine-multi/src/worker/child-process.ts
+++ b/packages/engine-multi/src/worker/child-process.ts
@@ -29,8 +29,13 @@ function runInChildProcess(plan: any, options: any, events: any = {}) {
   const p = new Promise((resolve, reject) => {
     console.log('starting child process....');
 
-    const dirname = path.dirname(fileURLToPath(import.meta.url));
-    // console.log(' >> ', dirname);
+    let dirname = path.dirname(fileURLToPath(import.meta.url));
+
+    // // nasty hack to sort out pathing
+    if (dirname.endsWith('/dist')) {
+      dirname += '/worker';
+    }
+    console.log(' >> ', dirname);
     const p = child_process.fork(
       // TODO I dont think this path is right
       path.resolve(dirname, '../../dist/worker/child_worker.js'),

--- a/packages/engine-multi/src/worker/child-process.ts
+++ b/packages/engine-multi/src/worker/child-process.ts
@@ -22,12 +22,12 @@ const api = {
 };
 
 function runInChildProcess(plan: any, options: any, events: any = {}) {
-  console.log('*', process.pid);
+  // console.log('*', process.pid);
 
   // const events = new EventEmitter();
 
   const p = new Promise((resolve, reject) => {
-    console.log('starting child process....');
+    // console.log('starting child process....');
 
     let dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -35,12 +35,13 @@ function runInChildProcess(plan: any, options: any, events: any = {}) {
     if (dirname.endsWith('/dist')) {
       dirname += '/worker';
     }
-    console.log(' >> ', dirname);
+    // console.log(' >> ', dirname);
     const p = child_process.fork(
       // TODO I dont think this path is right
       path.resolve(dirname, '../../dist/worker/child_worker.js'),
       [JSON.stringify(plan), JSON.stringify(options)],
       {
+        execArgv: ['--experimental-vm-modules', '--no-warnings'],
         detached: true, // child will live if parent dies.
         // although tbf, what's the point?
       }

--- a/packages/engine-multi/src/worker/child-worker.ts
+++ b/packages/engine-multi/src/worker/child-worker.ts
@@ -1,0 +1,96 @@
+import process from 'node:process';
+import createLogger, { SanitizePolicies } from '@openfn/logger';
+import execute, { NotifyEvents } from '@openfn/runtime';
+
+import * as workerEvents from './events';
+
+console.log('hello from inside the child', process.pid);
+// This is what runs inside the node child processs
+
+// Pull the run arguments from the incoming command
+const [_cmd, _module, p, o] = process.argv;
+const plan = JSON.parse(p);
+const options = JSON.parse(o || '{}');
+
+const workflowId = plan.id;
+const threadId = process.pid;
+
+export function publish<T extends workerEvents.WorkerEvents>(
+  type: T,
+  payload: Omit<workerEvents.EventMap[T], 'type' | 'workflowId' | 'threadId'>
+) {
+  process.send?.({
+    workflowId,
+    threadId,
+    type,
+    ...payload,
+  });
+}
+
+export const createLoggers = (sanitize?: SanitizePolicies) => {
+  const log = (message: string) => {
+    publish(workerEvents.LOG, {
+      // Apparently the json log stringifies the message
+      // We don't really want it to do that
+      message: JSON.parse(message),
+    } as workerEvents.LogEvent);
+  };
+
+  const emitter: any = {
+    info: log,
+    debug: log,
+    log,
+    warn: log,
+    error: log,
+    success: log,
+    always: log,
+  };
+
+  const logger = createLogger('R/T', {
+    logger: emitter,
+    level: 'debug',
+    json: true,
+    sanitize,
+  });
+  const jobLogger = createLogger('JOB', {
+    logger: emitter,
+    level: 'debug',
+    json: true,
+    sanitize,
+  });
+
+  return { logger, jobLogger };
+};
+
+// TODO there's no error handling at all here
+async function run() {
+  const { adaptorPaths, whitelist, sanitize } = options;
+  const { logger, jobLogger } = createLoggers(plan.id!, sanitize);
+  const opts = {
+    strict: false,
+    logger,
+    jobLogger,
+    linker: {
+      modules: adaptorPaths,
+      whitelist,
+      cacheKey: plan.id,
+    },
+    callbacks: {
+      // TODO: this won't actually work across the worker boundary
+      // For now I am preloading credentials
+      // resolveCredential: async (id: string) => {},
+      notify: (name: NotifyEvents, payload: any) => {
+        // convert runtime notify events to internal engine events
+        publish(`worker:${name}`, payload);
+      },
+    },
+  };
+
+  publish(workerEvents.WORKFLOW_START, {});
+
+  const result = await execute(plan, undefined, opts);
+
+  publish(workerEvents.WORKFLOW_COMPLETE, { state: result });
+}
+
+run();

--- a/packages/engine-multi/src/worker/child-worker.ts
+++ b/packages/engine-multi/src/worker/child-worker.ts
@@ -4,7 +4,7 @@ import execute, { NotifyEvents } from '@openfn/runtime';
 
 import * as workerEvents from './events';
 
-console.log('hello from inside the child', process.pid);
+console.log('child process', process.pid);
 // This is what runs inside the node child processs
 
 // Pull the run arguments from the incoming command
@@ -72,7 +72,7 @@ async function run() {
     jobLogger,
     linker: {
       modules: adaptorPaths,
-      whitelist,
+      whitelist: undefined, // TODO - major issue, whitelist regexes get turned into objects for some reason??
       cacheKey: plan.id,
     },
     callbacks: {
@@ -85,7 +85,7 @@ async function run() {
       },
     },
   };
-
+  //console.log(' >> WHITELIST', opts.linker?.whitelist);
   publish(workerEvents.WORKFLOW_START, {});
 
   const result = await execute(plan, undefined, opts);

--- a/packages/engine-multi/src/worker/child-worker.ts
+++ b/packages/engine-multi/src/worker/child-worker.ts
@@ -65,7 +65,7 @@ export const createLoggers = (sanitize?: SanitizePolicies) => {
 // TODO there's no error handling at all here
 async function run() {
   const { adaptorPaths, whitelist, sanitize } = options;
-  const { logger, jobLogger } = createLoggers(plan.id!, sanitize);
+  const { logger, jobLogger } = createLoggers(sanitize);
   const opts = {
     strict: false,
     logger,

--- a/packages/engine-multi/test/worker/child-process.test.ts
+++ b/packages/engine-multi/test/worker/child-process.test.ts
@@ -23,3 +23,23 @@ test('run a workflow', async (t) => {
 
   t.deepEqual(result, { x: 1 });
 });
+
+test('listen to an event', async (t) => {
+  return new Promise((done) => {
+    const plan = {
+      id: 'a',
+      jobs: [
+        {
+          expression: 'export default [(s) => ({ x: 1 })]',
+        },
+      ],
+    };
+
+    const options = {};
+
+    workers.exec('run', [plan, options]).on('worker:job-complete', () => {
+      t.pass();
+      done();
+    });
+  });
+});

--- a/packages/engine-multi/test/worker/child-process.test.ts
+++ b/packages/engine-multi/test/worker/child-process.test.ts
@@ -37,9 +37,13 @@ test('listen to an event', async (t) => {
 
     const options = {};
 
-    workers.exec('run', [plan, options]).on('worker:job-complete', () => {
-      t.pass();
-      done();
+    workers.exec('run', [plan, options], {
+      on: (evt) => {
+        if (evt.type === 'worker:job-complete') {
+          t.pass();
+          done();
+        }
+      },
     });
   });
 });

--- a/packages/engine-multi/test/worker/child-process.test.ts
+++ b/packages/engine-multi/test/worker/child-process.test.ts
@@ -1,0 +1,25 @@
+// just enough testing to dev against
+// this is probably throwaway
+import test from 'ava';
+
+import workers from '../../src/worker/child-process';
+
+// TODO is it worth a direct comparison with threads here?
+// maybe?
+
+test('run a workflow', async (t) => {
+  const plan = {
+    id: 'a',
+    jobs: [
+      {
+        expression: 'export default [(s) => ({ x: 1 })]',
+      },
+    ],
+  };
+
+  const options = {};
+
+  const result = await workers.exec('run', [plan, options]);
+
+  t.deepEqual(result, { x: 1 });
+});

--- a/packages/engine-multi/tsup.config.js
+++ b/packages/engine-multi/tsup.config.js
@@ -5,6 +5,7 @@ export default {
   splitting: false,
   entry: {
     index: 'src/index.ts',
+    'worker/child_worker': 'src/worker/child-worker.ts',
     'worker/worker': 'src/worker/worker.ts',
     // TODO I don't actually want to build this into the dist, I don't think?
     'worker/mock': 'src/worker/mock-worker.ts',


### PR DESCRIPTION
Rough cut of an alternative engine which runs all attempts in a child process

* instead of calling `workerpool.exec`, we now call my own child-process-worker. I've tried to match the workerpool API to keep things simple.
* My worker will create and then destroy a forked child process for each attempt, so each attempt runs totally in isolation
* It's a rough implementation - I haven't mapped all the error handling stuff, as it's not really needed for these tests