### PR TITLE
Deploy: Add condition type to incoming spec

### DIFF
--- a/.changeset/chilly-hairs-dress.md
+++ b/.changeset/chilly-hairs-dress.md
@@ -1,0 +1,5 @@
+---
+'@openfn/deploy': minor
+---
+
+Support `condition_expression` on edges

--- a/packages/deploy/src/stateTransform.ts
+++ b/packages/deploy/src/stateTransform.ts
@@ -148,6 +148,7 @@ function mergeEdges(
               enabled: pickValue(specEdge, stateEdge || {}, 'enabled', true),
             },
             {
+              condition_type: specEdge.condition_type,
               condition_expression: specEdge.condition_expression,
               condition_label: specEdge.condition_label,
               source_job_id: jobs[specEdge.source_job ?? -1]?.id,

--- a/packages/deploy/src/validator.ts
+++ b/packages/deploy/src/validator.ts
@@ -53,6 +53,7 @@ export function parseAndValidate(input: string): {
           pushUniqueKey(workflow, (workflow as any).key.value);
 
           validateJobs((workflow as any).value);
+          // validateEdges((workflow as any).value);
         }
       }
     } else {
@@ -87,6 +88,12 @@ export function parseAndValidate(input: string): {
           });
 
           return doc.createPair('jobs', {});
+        }
+      }
+
+      if (pair.key && pair.key.value === 'condition_expression') {
+        if (typeof pair.value.value !== 'string') {
+          pair.value.value = String(pair.value.value);
         }
       }
     },

--- a/packages/deploy/src/validator.ts
+++ b/packages/deploy/src/validator.ts
@@ -53,7 +53,6 @@ export function parseAndValidate(input: string): {
           pushUniqueKey(workflow, (workflow as any).key.value);
 
           validateJobs((workflow as any).value);
-          // validateEdges((workflow as any).value);
         }
       }
     } else {

--- a/packages/deploy/test/validator.test.ts
+++ b/packages/deploy/test/validator.test.ts
@@ -45,4 +45,34 @@ workflows:
   t.truthy(findError(results.errors, 'duplicate key: foo'));
 
   t.truthy(findError(results.errors, 'jobs: must be a map'));
+
+  doc = `
+name: project-name
+workflows:
+  workflow-one:
+    name: workflow one
+    jobs:
+      Transform-data-to-FHIR-standard:
+        name: Transform data to FHIR standard
+        adaptor: '@openfn/language-http@latest'
+        body: |
+          fn(state => state);
+
+    triggers:
+      webhook:
+        type: webhook
+        enabled: true
+    edges:
+      webhook->Transform-data-to-FHIR-standard:
+        condition_type: js_expression
+        condition_expression: true
+  `;
+
+  results = parseAndValidate(doc);
+
+  t.assert(
+    results.doc.workflows['workflow-one'].edges![
+      'webhook->Transform-data-to-FHIR-standard'
+    ].condition_expression === 'true'
+  );
 });


### PR DESCRIPTION
## Short Description

Add condition type to incoming spec.

This requires an up to date version of Lightning that correctly handles the `condition_type` in it's changesets.

Some casting has been added to change `true` to a string, since YAML assumes it's a boolean.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added unit tests
- [x] Changesets have been added (if there are production code changes)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
