### PR TITLE
Options improvements

### DIFF
--- a/.changeset/angry-ladybugs-breathe.md
+++ b/.changeset/angry-ladybugs-breathe.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Added env vars for CAPACITY, BACKOFF, LOG_LEVEL, PORT

--- a/.changeset/angry-ladybugs-breathe.md
+++ b/.changeset/angry-ladybugs-breathe.md
@@ -2,4 +2,4 @@
 '@openfn/ws-worker': patch
 ---
 
-Added env vars for CAPACITY, BACKOFF, LOG_LEVEL, PORT
+Updated start env vars and arguments

--- a/.changeset/mighty-beds-shop.md
+++ b/.changeset/mighty-beds-shop.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': patch
+---
+
+Replace timeout option with attemptTimeout

--- a/.changeset/mighty-beds-shop.md
+++ b/.changeset/mighty-beds-shop.md
@@ -2,4 +2,4 @@
 '@openfn/engine-multi': patch
 ---
 
-Replace timeout option with attemptTimeout
+Replace timeout option with attemptTimeoutMs

--- a/.changeset/old-doors-sparkle.md
+++ b/.changeset/old-doors-sparkle.md
@@ -2,6 +2,6 @@
 '@openfn/ws-worker': patch
 ---
 
-Support attemptTimeout in attempt options
+Support attemptTimeoutMs in attempt options
 Better server logging at startup
 Support start arguments from the environment (but prefer CLI)

--- a/.changeset/old-doors-sparkle.md
+++ b/.changeset/old-doors-sparkle.md
@@ -1,0 +1,7 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Support attemptTimeout in attempt options
+Better server logging at startup
+Support start arguments from the environment (but prefer CLI)

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -338,7 +338,7 @@ test('a timeout error should still call run-complete', (t) => {
         },
       ],
       options: {
-        timeout: 500,
+        runTimeout: 500,
       },
     };
 

--- a/packages/engine-multi/src/api/execute.ts
+++ b/packages/engine-multi/src/api/execute.ts
@@ -55,7 +55,7 @@ const execute = async (context: ExecutionContext) => {
 
     const workerOptions = {
       memoryLimitMb: options.memoryLimitMb,
-      timeout: options.attemptTimeout,
+      timeout: options.attemptTimeoutMs,
     };
 
     // Put out a log with the memory limit for the attempt

--- a/packages/engine-multi/src/api/execute.ts
+++ b/packages/engine-multi/src/api/execute.ts
@@ -55,7 +55,7 @@ const execute = async (context: ExecutionContext) => {
 
     const workerOptions = {
       memoryLimitMb: options.memoryLimitMb,
-      timeout: options.timeout,
+      timeout: options.attemptTimeout,
     };
 
     // Put out a log with the memory limit for the attempt

--- a/packages/engine-multi/src/engine.ts
+++ b/packages/engine-multi/src/engine.ts
@@ -114,6 +114,8 @@ const createEngine = async (options: EngineOptions, workerPath?: string) => {
   const contexts: Record<string, ExecutionContext> = {};
   const deferredListeners: Record<string, Record<string, EventHandler>[]> = {};
 
+  const defaultTimeout = options.attemptTimeout || DEFAULT_ATTEMPT_TIMEOUT;
+
   let resolvedWorkerPath;
   if (workerPath) {
     // If a path to the worker has been passed in, just use it verbatim
@@ -180,7 +182,7 @@ const createEngine = async (options: EngineOptions, workerPath?: string) => {
         ...options,
         sanitize: opts.sanitize,
         resolvers: opts.resolvers,
-        attemptTimeout: opts.attemptTimeout || DEFAULT_ATTEMPT_TIMEOUT,
+        attemptTimeout: opts.attemptTimeout ?? defaultTimeout,
         memoryLimitMb: opts.memoryLimitMb || DEFAULT_MEMORY_LIMIT_MB,
       },
     });

--- a/packages/engine-multi/src/engine.ts
+++ b/packages/engine-multi/src/engine.ts
@@ -21,8 +21,7 @@ import type { EngineAPI, EventHandler, WorkflowState } from './types';
 import type { Logger } from '@openfn/logger';
 import type { AutoinstallOptions } from './api/autoinstall';
 
-// NB this is the ATTEMPT timeout
-const DEFAULT_ATTEMPT_TIMEOUT = 1000 * 60 * 10;
+const DEFAULT_ATTEMPT_TIMEOUT = 1000 * 60 * 10; // ms
 
 const DEFAULT_MEMORY_LIMIT_MB = 500;
 
@@ -85,9 +84,9 @@ export type EngineOptions = {
   // Timeout for the whole workflow
   // timeout?: number;
 
-  // Default timeouts (used if an attempt does not provide its own)
-  attemptTimeout?: number;
-  runTimeout?: number;
+  // Default timeouts in ms(used if an attempt does not provide its own)
+  attemptTimeoutMs?: number;
+  runTimeoutMs?: number;
 
   statePropsToRemove?: string[];
 };
@@ -99,7 +98,7 @@ export type ExecuteOptions = {
   // timeout?: number; // DEPRECATED
 
   // NB this deliberately uses old terminology
-  attemptTimeout?: number;
+  attemptTimeoutMs?: number;
   runTimeout?: number;
 
   memoryLimitMb?: number;
@@ -114,7 +113,7 @@ const createEngine = async (options: EngineOptions, workerPath?: string) => {
   const contexts: Record<string, ExecutionContext> = {};
   const deferredListeners: Record<string, Record<string, EventHandler>[]> = {};
 
-  const defaultTimeout = options.attemptTimeout || DEFAULT_ATTEMPT_TIMEOUT;
+  const defaultTimeout = options.attemptTimeoutMs || DEFAULT_ATTEMPT_TIMEOUT;
 
   let resolvedWorkerPath;
   if (workerPath) {
@@ -182,7 +181,7 @@ const createEngine = async (options: EngineOptions, workerPath?: string) => {
         ...options,
         sanitize: opts.sanitize,
         resolvers: opts.resolvers,
-        attemptTimeout: opts.attemptTimeout ?? defaultTimeout,
+        attemptTimeoutMs: opts.attemptTimeoutMs ?? defaultTimeout,
         memoryLimitMb: opts.memoryLimitMb || DEFAULT_MEMORY_LIMIT_MB,
       },
     });

--- a/packages/engine-multi/test/api/execute.test.ts
+++ b/packages/engine-multi/test/api/execute.test.ts
@@ -230,7 +230,7 @@ test.serial('should emit error on timeout', async (t) => {
 
   const wfOptions: ExecuteOptions = {
     ...options,
-    attemptTimeout: 10,
+    attemptTimeoutMs: 10,
   };
 
   let event;

--- a/packages/engine-multi/test/api/execute.test.ts
+++ b/packages/engine-multi/test/api/execute.test.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import test from 'ava';
-import { EngineAPI, WorkflowState } from '../../src/types';
 import initWorkers from '../../src/api/call-worker';
 import execute from '../../src/api/execute';
 import { createMockLogger } from '@openfn/logger';
@@ -12,8 +11,11 @@ import {
   WORKFLOW_LOG,
   WORKFLOW_START,
 } from '../../src/events';
-import { RTEOptions } from '../../src/api';
 import ExecutionContext from '../../src/classes/ExecutionContext';
+
+import type { RTEOptions } from '../../src/api';
+import type { WorkflowState } from '../../src/types';
+import { ExecuteOptions } from '../../src/engine';
 
 const workerPath = path.resolve('dist/test/mock-run.js');
 
@@ -226,9 +228,9 @@ test.serial('should emit error on timeout', async (t) => {
     },
   } as WorkflowState;
 
-  const wfOptions = {
+  const wfOptions: ExecuteOptions = {
     ...options,
-    timeout: 10,
+    attemptTimeout: 10,
   };
 
   let event;

--- a/packages/engine-multi/test/engine.test.ts
+++ b/packages/engine-multi/test/engine.test.ts
@@ -232,7 +232,7 @@ test.serial(
       };
 
       const opts: ExecuteOptions = {
-        attemptTimeout: 10,
+        attemptTimeoutMs: 10,
       };
 
       engine.listen(plan.id, {
@@ -256,7 +256,7 @@ test.serial(
       engine = await createEngine(
         {
           ...options,
-          attemptTimeout: 22,
+          attemptTimeoutMs: 22,
         },
         p
       );

--- a/packages/engine-multi/test/engine.test.ts
+++ b/packages/engine-multi/test/engine.test.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import path from 'node:path';
 import { createMockLogger } from '@openfn/logger';
 
-import createEngine from '../src/engine';
+import createEngine, { ExecuteOptions } from '../src/engine';
 import * as e from '../src/events';
 import { ExecutionPlan } from '@openfn/runtime';
 
@@ -229,8 +229,8 @@ test.serial('timeout the whole attempt and emit an error', async (t) => {
       ],
     };
 
-    const opts = {
-      timeout: 10,
+    const opts: ExecuteOptions = {
+      attemptTimeout: 10,
     };
 
     engine.listen(plan.id, {

--- a/packages/ws-worker/src/mock/runtime-engine.ts
+++ b/packages/ws-worker/src/mock/runtime-engine.ts
@@ -36,6 +36,9 @@ const helpers = {
   fn: (f: Function) => (s: any) => f(s),
   wait: (duration: number) => (s: any) =>
     new Promise((resolve) => setTimeout(() => resolve(s), duration)),
+  err: () => {
+    throw new Error('test_err');
+  },
 };
 
 // The mock runtime engine creates a fake engine interface

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -126,8 +126,6 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
   const logger = options.logger || createMockLogger();
   const port = options.port || DEFAULT_PORT;
 
-  logger.debug('Starting server');
-
   const app = new Koa() as ServerApp;
   app.id = humanId({ separator: '-', capitalize: false });
   const router = new Router();
@@ -146,7 +144,7 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
   app.destroyed = false;
 
   app.server = app.listen(port);
-  logger.success(`ws-worker ${app.id} listening on ${port}`);
+  logger.success(`Worker ${app.id} listening on ${port}`);
 
   process.send?.('READY');
 

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -31,6 +31,7 @@ const {
   STATE_PROPS_TO_REMOVE,
   WORKER_REPO_DIR,
   WORKER_SECRET,
+  ATTEMPT_TIMEOUT_SECONDS,
 } = process.env;
 
 const args = yargs(hideBin(process.argv))
@@ -93,6 +94,12 @@ const args = yargs(hideBin(process.argv))
     description: 'Maximum memory allocated to a single run, in mb',
     type: 'number',
     default: MAX_RUN_MEMORY ? parseInt(MAX_RUN_MEMORY) : 500,
+  })
+  .option('attempt-timeout-seconds', {
+    alias: 't',
+    description: 'Default attempt timeout for the server, in seconds',
+    type: 'number',
+    default: ATTEMPT_TIMEOUT_SECONDS,
   })
   .parse() as Args;
 

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -23,14 +23,14 @@ type Args = {
 };
 
 const {
+  BACKOFF,
+  CAPACITY,
+  LOG_LEVEL,
+  MAX_RUN_MEMORY,
+  PORT,
+  STATE_PROPS_TO_REMOVE,
   WORKER_REPO_DIR,
   WORKER_SECRET,
-  MAX_RUN_MEMORY,
-  STATE_PROPS_TO_REMOVE,
-  CAPACITY,
-  BACKOFF,
-  LOG_LEVEL,
-  PORT,
 } = process.env;
 
 const args = yargs(hideBin(process.argv))

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -29,7 +29,7 @@ const {
   WORKER_LIGHTNING_SERVICE_URL,
   WORKER_LOG_LEVEL,
   WORKER_MAX_RUN_DURATION_SECONDS,
-  WORKER_MAX_RUN_MEMORY,
+  WORKER_MAX_RUN_MEMORY_MB,
   WORKER_PORT,
   WORKER_REPO_DIR,
   WORKER_SECRET,
@@ -97,9 +97,11 @@ const args = yargs(hideBin(process.argv))
   })
   .option('run-memory', {
     description:
-      'Maximum memory allocated to a single run, in mb. Env: WORKER_MAX_RUN_MEMORY',
+      'Maximum memory allocated to a single run, in mb. Env: WORKER_MAX_RUN_MEMORY_MB',
     type: 'number',
-    default: WORKER_MAX_RUN_MEMORY ? parseInt(WORKER_MAX_RUN_MEMORY) : 500,
+    default: WORKER_MAX_RUN_MEMORY_MB
+      ? parseInt(WORKER_MAX_RUN_MEMORY_MB)
+      : 500,
   })
   .option('max-run-duration-seconds', {
     alias: 't',

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -162,7 +162,7 @@ if (args.mock) {
     memoryLimitMb: args.runMemory,
     maxWorkers: args.capacity,
     statePropsToRemove: args.statePropsToRemove,
-    attemptTimeout: args.maxRunDurationSeconds * 1000,
+    attemptTimeoutMs: args.maxRunDurationSeconds * 1000,
   };
   logger.debug('Creating runtime engine...');
   logger.debug('Engine options:', engineOptions);

--- a/packages/ws-worker/src/types.d.ts
+++ b/packages/ws-worker/src/types.d.ts
@@ -81,7 +81,7 @@ export type AttemptOptions = {
   // this is the internal old terminology, which will be deprecated soon
   attemptTimeout?: number;
 
-  // deprecared alias for timeout. Maps to "attemptTimeout" internally
+  // deprecated alias for timeout. Maps to "attemptTimeout" internally
   timeout?: number;
 
   sanitize?: SanitizePolicies;

--- a/packages/ws-worker/src/types.d.ts
+++ b/packages/ws-worker/src/types.d.ts
@@ -74,7 +74,16 @@ export type Attempt = {
 };
 
 export type AttemptOptions = {
+  // This is what Lightning will ssend us
+  // Note that this is the NEW terminology, so it's the timeout  for the whole "attempt"
+  runTimeout?: number;
+
+  // this is the internal old terminology, which will be deprecated soon
+  attemptTimeout?: number;
+
+  // deprecared alias for timeout. Maps to "attemptTimeout" internally
   timeout?: number;
+
   sanitize?: SanitizePolicies;
 };
 

--- a/packages/ws-worker/src/types.d.ts
+++ b/packages/ws-worker/src/types.d.ts
@@ -79,7 +79,9 @@ export type AttemptOptions = {
   runTimeout?: number;
 
   // this is the internal old terminology, which will be deprecated soon
-  attemptTimeout?: number;
+  attemptTimeoutMs?: number;
+
+  attemptTimeout?: number; // deprecated
 
   // deprecated alias for timeout. Maps to "attemptTimeout" internally
   timeout?: number;

--- a/packages/ws-worker/src/util/convert-attempt.ts
+++ b/packages/ws-worker/src/util/convert-attempt.ts
@@ -39,7 +39,7 @@ const mapOptions = (options: AttemptOptions): AttemptOptions => {
   const to = runTimeout || attemptTimeout || timeout;
 
   if (to) {
-    (opts as AttemptOptions).attemptTimeout = to;
+    (opts as AttemptOptions).attemptTimeoutMs = to;
   }
 
   return opts;

--- a/packages/ws-worker/src/util/convert-attempt.ts
+++ b/packages/ws-worker/src/util/convert-attempt.ts
@@ -33,6 +33,18 @@ const mapTriggerEdgeCondition = (edge: Edge) => {
   return condition;
 };
 
+const mapOptions = (options: AttemptOptions): AttemptOptions => {
+  const { attemptTimeout, timeout, runTimeout, ...opts } = options;
+
+  const to = runTimeout || attemptTimeout || timeout;
+
+  if (to) {
+    (opts as AttemptOptions).attemptTimeout = to;
+  }
+
+  return opts;
+};
+
 export default (
   attempt: Attempt
 ): { plan: ExecutionPlan; options: AttemptOptions } => {
@@ -125,6 +137,6 @@ export default (
 
   return {
     plan: plan as ExecutionPlan,
-    options,
+    options: mapOptions(options),
   };
 };

--- a/packages/ws-worker/test/channels/attempt.test.ts
+++ b/packages/ws-worker/test/channels/attempt.test.ts
@@ -25,7 +25,7 @@ test('loadAttempt should return an execution plan and options', async (t) => {
     ...attempts['attempt-1'],
     options: {
       sanitize: 'obfuscate',
-      timeout: 10,
+      attemptTimeout: 10,
     },
   };
 
@@ -56,7 +56,7 @@ test('should join an attempt channel with a token', async (t) => {
       join: () => ({ status: 'ok' }),
       [GET_ATTEMPT]: () => ({
         id: 'a',
-        options: { timeout: 10 },
+        options: { attemptTimeout: 10 },
       }),
     }),
   });
@@ -70,7 +70,7 @@ test('should join an attempt channel with a token', async (t) => {
 
   t.truthy(channel);
   t.deepEqual(plan, { id: 'a', jobs: [] });
-  t.deepEqual(options, { timeout: 10 });
+  t.deepEqual(options, { attemptTimeout: 10 });
 });
 
 test('should fail to join an attempt channel with an invalid token', async (t) => {

--- a/packages/ws-worker/test/lightning.test.ts
+++ b/packages/ws-worker/test/lightning.test.ts
@@ -261,7 +261,7 @@ test.serial(`events: lightning should receive a ${e.RUN_START} event`, (t) => {
   });
 });
 
-test.serial.only(
+test.serial(
   `events: lightning should receive a ${e.RUN_COMPLETE} event`,
   (t) => {
     return new Promise((done) => {
@@ -291,22 +291,20 @@ test.serial(
   `events: lightning should receive a ${e.RUN_COMPLETE} event even if the attempt fails`,
   (t) => {
     return new Promise((done) => {
-      // This attempt should timeout
-      const attempt = getAttempt({ options: { timeout: 100 } }, [
+      const attempt = getAttempt({}, [
         {
           id: 'z',
           adaptor: '@openfn/language-common@1.0.0',
-          body: 'wait(1000)',
+          body: 'err()',
         },
       ]);
 
       lng.onSocketEvent(e.RUN_COMPLETE, attempt.id, ({ payload }) => {
-        t.not(payload.reason, 'success');
+        t.is(payload.reason, 'fail');
         t.pass('called run complete');
       });
 
       lng.onSocketEvent(e.ATTEMPT_COMPLETE, attempt.id, ({ payload }) => {
-        t.not(payload.reason, 'success');
         done();
       });
 

--- a/packages/ws-worker/test/reasons.test.ts
+++ b/packages/ws-worker/test/reasons.test.ts
@@ -228,7 +228,7 @@ test('kill: timeout', async (t) => {
   });
 
   const options = {
-    attemptTimeout: 100,
+    attemptTimeoutMs: 100,
   };
 
   const { reason } = await execute(plan, options);

--- a/packages/ws-worker/test/util/convert-attempt.test.ts
+++ b/packages/ws-worker/test/util/convert-attempt.test.ts
@@ -64,7 +64,7 @@ test('convert a single job with options', (t) => {
     edges: [],
     options: {
       sanitize: 'obfuscate',
-      attemptTimeout: 10,
+      attemptTimeoutMs: 10,
     },
   };
   const { plan, options } = convertAttempt(attempt as Attempt);
@@ -531,7 +531,7 @@ test('convert options, mapping timeout', (t) => {
   };
   const { options } = convertAttempt(attempt as Attempt);
 
-  t.deepEqual(options, { attemptTimeout: 123 });
+  t.deepEqual(options, { attemptTimeoutMs: 123 });
 });
 
 test('convert options, mapping runTimeout', (t) => {
@@ -543,7 +543,7 @@ test('convert options, mapping runTimeout', (t) => {
   };
   const { options } = convertAttempt(attempt as Attempt);
 
-  t.deepEqual(options, { attemptTimeout: 123 });
+  t.deepEqual(options, { attemptTimeoutMs: 123 });
 });
 
 test('convert options, preferring runTimeout', (t) => {
@@ -551,11 +551,11 @@ test('convert options, preferring runTimeout', (t) => {
     id: 'w',
     options: {
       runTimeout: 123,
-      attemptTimeout: 456,
+      attemptTimeoutMs: 456,
       timeout: 789,
     },
   };
   const { options } = convertAttempt(attempt as Attempt);
 
-  t.deepEqual(options, { attemptTimeout: 123 });
+  t.deepEqual(options, { attemptTimeoutMs: 123 });
 });

--- a/packages/ws-worker/test/util/convert-attempt.test.ts
+++ b/packages/ws-worker/test/util/convert-attempt.test.ts
@@ -64,7 +64,7 @@ test('convert a single job with options', (t) => {
     edges: [],
     options: {
       sanitize: 'obfuscate',
-      timeout: 10,
+      attemptTimeout: 10,
     },
   };
   const { plan, options } = convertAttempt(attempt as Attempt);
@@ -506,4 +506,56 @@ test('convert edge condition always', (t) => {
   const [job] = plan.jobs;
 
   t.false(job.next.b.hasOwnProperty('condition'));
+});
+
+test('convert random options', (t) => {
+  const attempt: Partial<Attempt> = {
+    id: 'w',
+    options: {
+      a: 1,
+      b: 2,
+      c: 3,
+    },
+  };
+  const { options } = convertAttempt(attempt as Attempt);
+
+  t.deepEqual(options, { a: 1, b: 2, c: 3 });
+});
+
+test('convert options, mapping timeout', (t) => {
+  const attempt: Partial<Attempt> = {
+    id: 'w',
+    options: {
+      timeout: 123,
+    },
+  };
+  const { options } = convertAttempt(attempt as Attempt);
+
+  t.deepEqual(options, { attemptTimeout: 123 });
+});
+
+test('convert options, mapping runTimeout', (t) => {
+  const attempt: Partial<Attempt> = {
+    id: 'w',
+    options: {
+      runTimeout: 123,
+    },
+  };
+  const { options } = convertAttempt(attempt as Attempt);
+
+  t.deepEqual(options, { attemptTimeout: 123 });
+});
+
+test('convert options, preferring runTimeout', (t) => {
+  const attempt: Partial<Attempt> = {
+    id: 'w',
+    options: {
+      runTimeout: 123,
+      attemptTimeout: 456,
+      timeout: 789,
+    },
+  };
+  const { options } = convertAttempt(attempt as Attempt);
+
+  t.deepEqual(options, { attemptTimeout: 123 });
 });


### PR DESCRIPTION
This PR bundles a few things:
* Uses env vars in worker config
* Adds an `attemptTimeout` to the worker and engine. I don't think this is the place to rename it to `runTimeout` for the new terminology, so that will follow
* Adds better logging of config to the worker, so it's clearer what's happening

Targeting the fancy-engine rework (I may merge it in)

Closes #500 #439

Note that #414 is is still outstanding in the runtime and CLI. I want to create `attemptTimeout` and `runTimeout` options there so that it's always clear what you mean by timeout.