### PR TITLE
Worker: Log exit reason in attempt log

### DIFF
--- a/.changeset/seven-seas-sneeze.md
+++ b/.changeset/seven-seas-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Send the exit reason to the attempt logs

--- a/packages/ws-worker/src/api/execute.ts
+++ b/packages/ws-worker/src/api/execute.ts
@@ -17,17 +17,17 @@ import type { JSONLog, Logger } from '@openfn/logger';
 import type {
   RuntimeEngine,
   Resolvers,
-  WorkflowCompletePayload,
   WorkflowErrorPayload,
   WorkflowStartPayload,
 } from '@openfn/engine-multi';
 import { ExecutionPlan } from '@openfn/runtime';
-import { calculateAttemptExitReason, calculateJobExitReason } from './reasons';
+import { calculateJobExitReason } from './reasons';
 
 // TODO: I want to move all event handlers out into their own files
 // TODO just export the index yeah?
 import handleRunComplete from '../events/run-complete';
 import handleRunStart from '../events/run-start';
+import handleAttemptComplete from '../events/atttempt-complete';
 import createThrottler from '../util/throttle';
 
 const enc = new TextDecoder('utf-8');
@@ -112,7 +112,7 @@ export function execute(
     addEvent('job-error', throttle(onJobError)),
     addEvent('workflow-log', throttle(onJobLog)),
     // This will also resolve the promise
-    addEvent('workflow-complete', throttle(onWorkflowComplete)),
+    addEvent('workflow-complete', throttle(handleAttemptComplete)),
 
     addEvent('workflow-error', throttle(onWorkflowError))
 
@@ -200,21 +200,6 @@ export function onWorkflowStart(
   _event: WorkflowStartPayload
 ) {
   return sendEvent<AttemptStartPayload>(channel, ATTEMPT_START);
-}
-
-export async function onWorkflowComplete(
-  { state, channel, onFinish }: Context,
-  _event: WorkflowCompletePayload
-) {
-  // TODO I dont think the attempt final dataclip IS the last job dataclip
-  // Especially not in parallelisation
-  const result = state.dataclips[state.lastDataclipId!];
-  const reason = calculateAttemptExitReason(state);
-  await sendEvent<AttemptCompletePayload>(channel, ATTEMPT_COMPLETE, {
-    final_dataclip_id: state.lastDataclipId!,
-    ...reason,
-  });
-  onFinish({ reason, state: result });
 }
 
 export async function onWorkflowError(

--- a/packages/ws-worker/src/api/execute.ts
+++ b/packages/ws-worker/src/api/execute.ts
@@ -144,7 +144,7 @@ export function execute(
         engine.execute(plan, { resolvers, ...options });
       } catch (e: any) {
         // TODO what if there's an error?
-        onWorkflowError(context, {
+        handleAttemptError(context, {
           workflowId: plan.id!,
           message: e.message,
           type: e.type,

--- a/packages/ws-worker/src/api/reasons.ts
+++ b/packages/ws-worker/src/api/reasons.ts
@@ -41,7 +41,7 @@ const isLeafNode = (state: AttemptState, job: JobNode) => {
   return !hasDownstream;
 };
 
-const calculateAttemptExitReason = (state: AttemptState) => {
+const calculateAttemptExitReason = (state: AttemptState): ExitReason => {
   if (state.plan && state.reasons) {
     // A crash or greater will trigger an error, and the error
     // basically becomes the exit reason

--- a/packages/ws-worker/src/events/attempt-error.ts
+++ b/packages/ws-worker/src/events/attempt-error.ts
@@ -1,0 +1,37 @@
+import { calculateJobExitReason } from '../api/reasons';
+
+import type { WorkflowErrorPayload } from '@openfn/engine-multi';
+
+import { ATTEMPT_COMPLETE, AttemptCompletePayload } from '../events';
+import { sendEvent, Context, onJobError } from '../api/execute';
+import logFinalReason from '../util/log-final-reason';
+
+export default async function onAttemptError(
+  context: Context,
+  event: WorkflowErrorPayload
+) {
+  const { state, channel, logger, onFinish } = context;
+
+  try {
+    // Ok, let's try that, let's just generate a reason from the event
+    const reason = calculateJobExitReason('', { data: {} }, event);
+    // If there's a job still running, make sure it gets marked complete
+    if (state.activeJob) {
+      await onJobError(context, { error: event });
+    }
+
+    await logFinalReason(context, reason);
+
+    await sendEvent<AttemptCompletePayload>(channel, ATTEMPT_COMPLETE, {
+      final_dataclip_id: state.lastDataclipId!,
+      ...reason,
+    });
+
+    onFinish({ reason });
+  } catch (e: any) {
+    logger.error('ERROR in workflow-error handler:', e.message);
+    logger.error(e);
+
+    onFinish({});
+  }
+}

--- a/packages/ws-worker/src/events/atttempt-complete.ts
+++ b/packages/ws-worker/src/events/atttempt-complete.ts
@@ -1,0 +1,39 @@
+import { timestamp } from '@openfn/logger';
+import type { WorkflowCompletePayload } from '@openfn/engine-multi';
+
+import { ATTEMPT_COMPLETE, AttemptCompletePayload } from '../events';
+import { calculateAttemptExitReason } from '../api/reasons';
+import { sendEvent, Context, onJobLog } from '../api/execute';
+
+export default async function onWorkflowComplete(
+  context: Context,
+  _event: WorkflowCompletePayload
+) {
+  const { state, channel, onFinish } = context;
+
+  // TODO I dont think the attempt final dataclip IS the last job dataclip
+  // Especially not in parallelisation
+  const result = state.dataclips[state.lastDataclipId!];
+  const reason = calculateAttemptExitReason(state);
+
+  const time = (timestamp() - BigInt(10e6)).toString();
+
+  let message = `Run complete with status: ${reason.reason}`;
+  if (reason.reason !== 'success') {
+    message += `\n${reason.error_type}: ${reason.error_message || 'unknown'}`;
+  }
+
+  await onJobLog(context, {
+    time,
+    message: [message],
+    level: 'info',
+    name: 'R/T',
+  });
+
+  await sendEvent<AttemptCompletePayload>(channel, ATTEMPT_COMPLETE, {
+    final_dataclip_id: state.lastDataclipId!,
+    ...reason,
+  });
+
+  onFinish({ reason, state: result });
+}

--- a/packages/ws-worker/src/util/log-final-reason.ts
+++ b/packages/ws-worker/src/util/log-final-reason.ts
@@ -1,0 +1,19 @@
+import { timestamp } from '@openfn/logger';
+import { Context, onJobLog } from '../api/execute';
+import { ExitReason } from '../types';
+
+export default async (context: Context, reason: ExitReason) => {
+  const time = (timestamp() - BigInt(10e6)).toString();
+
+  let message = `Run complete with status: ${reason.reason}`;
+  if (reason.reason !== 'success') {
+    message += `\n${reason.error_type}: ${reason.error_message || 'unknown'}`;
+  }
+
+  await onJobLog(context, {
+    time,
+    message: [message],
+    level: 'info',
+    name: 'R/T',
+  });
+};

--- a/packages/ws-worker/test/api/execute.test.ts
+++ b/packages/ws-worker/test/api/execute.test.ts
@@ -14,7 +14,6 @@ import {
   onJobLog,
   execute,
   onWorkflowStart,
-  onWorkflowError,
   loadDataclip,
   loadCredential,
   sendEvent,
@@ -242,113 +241,6 @@ test('workflowStart should send an empty attempt:start event', async (t) => {
 
 //   await onWorkflowComplete(context, event);
 // });
-
-test('workflowError should trigger runComplete with a reason', async (t) => {
-  const jobId = 'job-1';
-
-  const state = {
-    reasons: {},
-    dataclips: {},
-    lastDataclipId: 'x',
-    activeJob: jobId,
-    activeRun: 'b',
-    errors: {},
-  };
-
-  const channel = mockChannel({
-    [RUN_COMPLETE]: (evt) => {
-      t.is(evt.reason, 'crash');
-      t.is(evt.error_message, 'it crashed');
-      return true;
-    },
-    [ATTEMPT_COMPLETE]: () => true,
-  });
-
-  const event = {
-    severity: 'crash',
-    type: 'Err',
-    message: 'it crashed',
-  };
-
-  const context = { channel, state, onFinish: () => {} };
-
-  await onWorkflowError(context, event);
-});
-
-test('workflow error should send reason to onFinish', async (t) => {
-  const jobId = 'job-1';
-
-  const state = {
-    reasons: {},
-    dataclips: {},
-    lastDataclipId: 'x',
-    activeJob: jobId,
-    activeRun: 'b',
-    errors: {},
-  };
-
-  const channel = mockChannel({
-    [RUN_COMPLETE]: (evt) => true,
-    [ATTEMPT_COMPLETE]: () => true,
-  });
-
-  const event = {
-    error: {
-      severity: 'crash',
-      type: 'Err',
-      message: 'it crashed',
-    },
-    state: {},
-  };
-
-  const context = {
-    channel,
-    state,
-    onFinish: (evt) => {
-      t.is(evt.reason.reason, 'crash');
-    },
-  };
-
-  await onWorkflowError(context, event);
-});
-
-test('workflowError should not call job complete if the job is not active', async (t) => {
-  const state = {
-    reasons: {},
-    dataclips: {},
-    lastDataclipId: 'x',
-    activeJob: undefined,
-    activeRun: undefined,
-    errors: {},
-  };
-
-  const channel = mockChannel({
-    [RUN_COMPLETE]: (evt) => {
-      t.fail('should not call!');
-      return true;
-    },
-    [ATTEMPT_COMPLETE]: () => true,
-  });
-
-  const event = {
-    error: {
-      severity: 'crash',
-      type: 'Err',
-      message: 'it crashed',
-    },
-    state: {},
-  };
-
-  const context = {
-    channel,
-    state,
-    onFinish: () => {
-      t.pass();
-    },
-  };
-
-  await onWorkflowError(context, event);
-});
 
 // TODO what if an error?
 test('loadDataclip should fetch a dataclip', async (t) => {

--- a/packages/ws-worker/test/api/execute.test.ts
+++ b/packages/ws-worker/test/api/execute.test.ts
@@ -14,7 +14,6 @@ import {
   onJobLog,
   execute,
   onWorkflowStart,
-  onWorkflowComplete,
   onWorkflowError,
   loadDataclip,
   loadCredential,
@@ -193,56 +192,56 @@ test('workflowStart should send an empty attempt:start event', async (t) => {
   await onWorkflowStart({ channel });
 });
 
-test('workflowComplete should send an attempt:complete event', async (t) => {
-  const result = { answer: 42 };
+// test('workflowComplete should send an attempt:complete event', async (t) => {
+//   const result = { answer: 42 };
 
-  const state = {
-    reasons: {},
-    dataclips: {
-      x: result,
-    },
-    lastDataclipId: 'x',
-  };
+//   const state = {
+//     reasons: {},
+//     dataclips: {
+//       x: result,
+//     },
+//     lastDataclipId: 'x',
+//   };
 
-  const channel = mockChannel({
-    [ATTEMPT_COMPLETE]: (evt) => {
-      t.deepEqual(evt.final_dataclip_id, 'x');
-    },
-  });
+//   const channel = mockChannel({
+//     [ATTEMPT_COMPLETE]: (evt) => {
+//       t.deepEqual(evt.final_dataclip_id, 'x');
+//     },
+//   });
 
-  const event = {};
+//   const event = {};
 
-  const context = { channel, state, onFinish: () => {} };
-  await onWorkflowComplete(context, event);
-});
+//   const context = { channel, state, onFinish: () => {} };
+//   await onWorkflowComplete(context, event);
+// });
 
-test('workflowComplete should call onFinish with final dataclip', async (t) => {
-  const result = { answer: 42 };
+// test('workflowComplete should call onFinish with final dataclip', async (t) => {
+//   const result = { answer: 42 };
 
-  const state = {
-    reasons: {},
-    dataclips: {
-      x: result,
-    },
-    lastDataclipId: 'x',
-  };
+//   const state = {
+//     reasons: {},
+//     dataclips: {
+//       x: result,
+//     },
+//     lastDataclipId: 'x',
+//   };
 
-  const channel = mockChannel({
-    [ATTEMPT_COMPLETE]: () => true,
-  });
+//   const channel = mockChannel({
+//     [ATTEMPT_COMPLETE]: () => true,
+//   });
 
-  const context = {
-    channel,
-    state,
-    onFinish: ({ state: finalState }) => {
-      t.deepEqual(result, finalState);
-    },
-  };
+//   const context = {
+//     channel,
+//     state,
+//     onFinish: ({ state: finalState }) => {
+//       t.deepEqual(result, finalState);
+//     },
+//   };
 
-  const event = { state: result };
+//   const event = { state: result };
 
-  await onWorkflowComplete(context, event);
-});
+//   await onWorkflowComplete(context, event);
+// });
 
 test('workflowError should trigger runComplete with a reason', async (t) => {
   const jobId = 'job-1';

--- a/packages/ws-worker/test/events/attempt-complete.test.ts
+++ b/packages/ws-worker/test/events/attempt-complete.test.ts
@@ -1,0 +1,144 @@
+import test from 'ava';
+import handleAttemptComplete from '../../src/events/atttempt-complete';
+
+import { mockChannel } from '../../src/mock/sockets';
+import { ATTEMPT_COMPLETE, ATTEMPT_LOG } from '../../src/events';
+import { createAttemptState } from '../../src/util';
+
+test('should send an attempt:complete event', async (t) => {
+  const result = { answer: 42 };
+  const plan = { id: 'attempt-1', jobs: [] };
+
+  const state = createAttemptState(plan);
+  state.dataclips = {
+    x: result,
+  };
+  state.lastDataclipId = 'x';
+
+  const channel = mockChannel({
+    [ATTEMPT_LOG]: () => true,
+    [ATTEMPT_COMPLETE]: (evt) => {
+      t.deepEqual(evt.final_dataclip_id, 'x');
+    },
+  });
+
+  const event = {};
+
+  const context = { channel, state, onFinish: () => {} };
+  await handleAttemptComplete(context, event);
+});
+
+test('should call onFinish with final dataclip', async (t) => {
+  const result = { answer: 42 };
+  const plan = { id: 'attempt-1', jobs: [] };
+
+  const state = createAttemptState(plan);
+  state.dataclips = {
+    x: result,
+  };
+  state.lastDataclipId = 'x';
+
+  const channel = mockChannel({
+    [ATTEMPT_LOG]: () => true,
+    [ATTEMPT_COMPLETE]: () => true,
+  });
+
+  const context = {
+    channel,
+    state,
+    onFinish: ({ state: finalState }) => {
+      t.deepEqual(result, finalState);
+    },
+  };
+
+  const event = { state: result };
+
+  await handleAttemptComplete(context, event);
+});
+
+test('should send a reason log and return reason for success', async (t) => {
+  const result = { answer: 42 };
+  const plan = { id: 'attempt-1', jobs: [] };
+
+  const state = createAttemptState(plan);
+  state.dataclips = {
+    x: result,
+  };
+  state.lastDataclipId = 'x';
+
+  let logEvent;
+  let completeEvent;
+
+  const channel = mockChannel({
+    [ATTEMPT_LOG]: (e) => {
+      logEvent = e;
+    },
+    [ATTEMPT_COMPLETE]: (e) => {
+      completeEvent = e;
+    },
+  });
+
+  const context = {
+    channel,
+    state,
+    onFinish: ({ state: finalState }) => {
+      t.deepEqual(result, finalState);
+    },
+  };
+
+  const event = { state: result };
+
+  await handleAttemptComplete(context, event);
+
+  t.is(logEvent.message[0], 'Run complete with status: success');
+  t.is(completeEvent.reason, 'success');
+  t.falsy(completeEvent.error_type);
+  t.falsy(completeEvent.error_message);
+});
+
+test('should send a reason log and return reason for fail', async (t) => {
+  const result = { answer: 42 };
+  const plan = { id: 'attempt-1', jobs: [{ id: 'x' }] };
+
+  const state = createAttemptState(plan);
+  state.dataclips = {
+    x: result,
+  };
+  state.lastDataclipId = 'x';
+  state.reasons = {
+    x: {
+      reason: 'fail',
+      error_message: 'err',
+      error_type: 'TEST',
+    },
+  };
+
+  let logEvent;
+  let completeEvent;
+
+  const channel = mockChannel({
+    [ATTEMPT_LOG]: (e) => {
+      logEvent = e;
+    },
+    [ATTEMPT_COMPLETE]: (e) => {
+      completeEvent = e;
+    },
+  });
+
+  const context = {
+    channel,
+    state,
+    onFinish: ({ state: finalState }) => {
+      t.deepEqual(result, finalState);
+    },
+  };
+
+  const event = { state: result };
+
+  await handleAttemptComplete(context, event);
+
+  t.is(logEvent.message[0], 'Run complete with status: fail\nTEST: err');
+  t.is(completeEvent.reason, 'fail');
+  t.is(completeEvent.error_type, 'TEST');
+  t.is(completeEvent.error_message, 'err');
+});

--- a/packages/ws-worker/test/events/attempt-error.test.ts
+++ b/packages/ws-worker/test/events/attempt-error.test.ts
@@ -1,0 +1,138 @@
+import test from 'ava';
+import onAttemptError from '../../src/events/attempt-error';
+
+import { mockChannel } from '../../src/mock/sockets';
+import { ATTEMPT_COMPLETE, ATTEMPT_LOG, RUN_COMPLETE } from '../../src/events';
+import { createAttemptState } from '../../src/util';
+
+const plan = { id: 'attempt-1', jobs: [] };
+
+test('attemptError should trigger runComplete with a reason', async (t) => {
+  const jobId = 'job-1';
+
+  const state = createAttemptState(plan);
+  state.lastDataclipId = 'x';
+  state.activeRun = 'b';
+  state.activeJob = jobId;
+
+  const channel = mockChannel({
+    [ATTEMPT_LOG]: () => true,
+    [RUN_COMPLETE]: (evt) => {
+      t.is(evt.reason, 'crash');
+      t.is(evt.error_message, 'it crashed');
+      return true;
+    },
+    [ATTEMPT_COMPLETE]: () => true,
+  });
+
+  const event = {
+    severity: 'crash',
+    type: 'Err',
+    message: 'it crashed',
+  };
+
+  const context = { channel, state, onFinish: () => {} };
+
+  await onAttemptError(context, event);
+});
+
+test('workflow error should send reason to onFinish', async (t) => {
+  const jobId = 'job-1';
+
+  const state = createAttemptState(plan);
+  state.lastDataclipId = 'x';
+  state.activeRun = 'b';
+  state.activeJob = jobId;
+
+  const channel = mockChannel({
+    [ATTEMPT_LOG]: () => true,
+    [RUN_COMPLETE]: (evt) => true,
+    [ATTEMPT_COMPLETE]: () => true,
+  });
+
+  const event = {
+    error: {
+      severity: 'crash',
+      type: 'Err',
+      message: 'it crashed',
+    },
+    state: {},
+  };
+
+  const context = {
+    channel,
+    state,
+    onFinish: (evt) => {
+      t.is(evt.reason.reason, 'crash');
+    },
+  };
+
+  await onAttemptError(context, event);
+});
+
+test('attemptError should not call job complete if the job is not active', async (t) => {
+  const state = createAttemptState(plan);
+  state.lastDataclipId = 'x';
+
+  const channel = mockChannel({
+    [ATTEMPT_LOG]: () => true,
+    [RUN_COMPLETE]: (evt) => {
+      t.fail('should not call!');
+      return true;
+    },
+    [ATTEMPT_COMPLETE]: () => true,
+  });
+
+  const event = {
+    error: {
+      severity: 'crash',
+      type: 'Err',
+      message: 'it crashed',
+    },
+    state: {},
+  };
+
+  const context = {
+    channel,
+    state,
+    onFinish: () => {
+      t.pass();
+    },
+  };
+
+  await onAttemptError(context, event);
+});
+
+test('attemptError should log the reason', async (t) => {
+  const jobId = 'job-1';
+
+  const state = createAttemptState({
+    id: 'attempt-1',
+    jobs: [{ id: 'job-1' }],
+  });
+  state.lastDataclipId = 'x';
+  state.activeRun = 'b';
+  state.activeJob = jobId;
+
+  const event = {
+    severity: 'crash',
+    type: 'Err',
+    message: 'it crashed',
+  };
+  state.reasons['x'] = event;
+
+  let logEvent;
+
+  const channel = mockChannel({
+    [ATTEMPT_LOG]: (e) => {
+      logEvent = e;
+    },
+    [RUN_COMPLETE]: (evt) => true,
+    [ATTEMPT_COMPLETE]: () => true,
+  });
+
+  const context = { channel, state, onFinish: () => {} };
+
+  await onAttemptError(context, event);
+  t.is(logEvent.message[0], 'Run complete with status: crash\nErr: it crashed');
+});


### PR DESCRIPTION
This PR will print the exit reason at the bottom of the log

![image](https://github.com/OpenFn/kit/assets/7052509/08a3ece2-f57f-4fec-971f-fddd0e57f02a)

This log isn't generated by the runtime or the engine - it's added as a sort of post-script by the worker itself. We can't do it anywhere else because only the worker knows what the reason is.

But it's such an important point of feedback I think it's important to include it. Even for success states.

This closes #567