### PR TITLE
Send worker versions

### DIFF
--- a/packages/lexicon/index.d.ts
+++ b/packages/lexicon/index.d.ts
@@ -1,1 +1,2 @@
 export * from './core';
+export * as lightning from './lighting';

--- a/packages/lexicon/index.js
+++ b/packages/lexicon/index.js
@@ -1,0 +1,1 @@
+export * as lightning from './lightning';

--- a/packages/lexicon/lightning.d.ts
+++ b/packages/lexicon/lightning.d.ts
@@ -1,6 +1,8 @@
 import type { SanitizePolicies } from '@openfn/logger';
 import { State } from './core';
 
+export const API_VERSION: number;
+
 type StepId = string;
 
 /**

--- a/packages/lexicon/lightning.js
+++ b/packages/lexicon/lightning.js
@@ -1,0 +1,6 @@
+/*
+ * The API SPEC version represented in lighting.d.ts
+ * Note that the major version represents the API spec version, while the minor version
+ * represents the lexicon implementation of it
+ */
+export const API_VERSION = 1.1;

--- a/packages/lexicon/package.json
+++ b/packages/lexicon/package.json
@@ -5,7 +5,14 @@
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",
   "type": "module",
+  "main": "index.js",
   "exports": {
+    ".": {
+      "import": {
+        "default": "./index.js",
+        "types": "./core.d.ts"
+      }
+    },
     "./lightning": {
       "import": {
         "default": "./lightning.js",

--- a/packages/lexicon/package.json
+++ b/packages/lexicon/package.json
@@ -4,10 +4,12 @@
   "description": "Central repo of names and type definitions",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",
+  "type": "module",
   "exports": {
-    "lightning": {
+    "./lightning": {
       "import": {
-        "types": "./lightning.d/.ts"
+        "default": "./lightning.js",
+        "types": "./lightning.d.ts"
       }
     }
   },

--- a/packages/ws-worker/src/channels/worker-queue.ts
+++ b/packages/ws-worker/src/channels/worker-queue.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'node:events';
 import { Socket as PhxSocket } from 'phoenix';
 import { WebSocket } from 'ws';
-
+import { API_VERSION } from '@openfn/lexicon/lightning';
 import generateWorkerToken from '../util/worker-token';
 
 import type { Logger } from '@openfn/logger';
@@ -16,10 +16,20 @@ const connectToWorkerQueue = (
 ) => {
   const events = new EventEmitter();
 
-  generateWorkerToken(secret, serverId, logger).then((token) => {
+  generateWorkerToken(secret, serverId, logger).then(async (token) => {
+    const pkg = await import('../../package.json', {
+      assert: { type: 'json' },
+    });
+
+    const params = {
+      token,
+      api_version: API_VERSION,
+      worker_version: pkg.default.version,
+    };
+
     // @ts-ignore ts doesn't like the constructor here at all
     const socket = new SocketConstructor(endpoint, {
-      params: { token },
+      params,
       transport: WebSocket,
     });
 

--- a/packages/ws-worker/test/channels/worker-queue.test.ts
+++ b/packages/ws-worker/test/channels/worker-queue.test.ts
@@ -76,9 +76,7 @@ test('should connect with api and worker versions', async (t) => {
 
     connectToWorkerQueue('www', 'a', 'secret', logger, createSocket as any).on(
       'connect',
-      ({ socket, channel }) => {
-        done();
-      }
+      done
     );
   });
 });


### PR DESCRIPTION
_Temporarily targeted at `lexicon` as that's where I branched from._

This PR encodes `api_version` and `worker_version` into the URL to connect to the worker queue.

API version represents the API spec/contract supported by this worker version. That uses a `major.minor` numbering scheme, where `major` is the actual spec version (`v1`), and `minor` is the implementation version (also `v1`).

The worker_version is the npm version of the actual worker.

Although I think `api_version` is the more valuable feature, it is cheap and easy to send both ¯\_(ツ)_/¯

Closes #563