### PR TITLE
Tidy version output

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -43,7 +43,8 @@ const handlers = {
   ['repo-install']: install,
   ['repo-pwd']: pwd,
   ['repo-list']: list,
-  version: async (opts: Opts, logger: Logger) => printVersions(logger, opts),
+  version: async (opts: Opts, logger: Logger) =>
+    printVersions(logger, opts, true),
 };
 
 // Top level command parser

--- a/packages/cli/test/util/print-versions.test.ts
+++ b/packages/cli/test/util/print-versions.test.ts
@@ -6,7 +6,7 @@ import printVersions from '../../src/util/print-versions';
 
 const root = path.resolve('package.json');
 
-test('print versions for node, cli, runtime and compiler', async (t) => {
+test('print versions for node and cli', async (t) => {
   const logger = createMockLogger('', { level: 'info' });
   await printVersions(logger);
 
@@ -17,12 +17,11 @@ test('print versions for node, cli, runtime and compiler', async (t) => {
   // very crude testing but it's ok to test the intent here
   t.regex(message, /Versions:/);
   t.regex(message, /cli/);
-  t.regex(message, /runtime/);
-  t.regex(message, /compiler/);
+  t.regex(message, /node/);
   t.notRegex(message, /adaptor/);
 });
 
-test('print versions for node, cli, runtime, compiler and adaptor', async (t) => {
+test('print versions for node, cli and adaptor', async (t) => {
   const logger = createMockLogger('', { level: 'info' });
   await printVersions(logger, { adaptors: ['http'] });
 
@@ -31,27 +30,24 @@ test('print versions for node, cli, runtime, compiler and adaptor', async (t) =>
 
   t.regex(message, /Versions:/);
   t.regex(message, /cli/);
-  t.regex(message, /runtime/);
-  t.regex(message, /compiler/);
+  t.regex(message, /node/);
   t.regex(message, /http .+ latest/);
 });
 
-test('print versions for node, cli, runtime, compiler and adaptor with version', async (t) => {
+test('print versions for node, cli and adaptor with version', async (t) => {
   const logger = createMockLogger('', { level: 'info' });
   await printVersions(logger, { adaptors: ['http@1234'] });
 
   const last = logger._parse(logger._last);
   const message = last.message as string;
 
-  // very crude testing but it's ok to test the intent here
   t.regex(message, /Versions:/);
   t.regex(message, /cli/);
-  t.regex(message, /runtime/);
-  t.regex(message, /compiler/);
+  t.regex(message, /node/);
   t.regex(message, /http .+ 1234/);
 });
 
-test('print versions for node, cli, runtime, compiler and long-form adaptor', async (t) => {
+test('print versions for node, cli and long-form adaptor', async (t) => {
   const logger = createMockLogger('', { level: 'info' });
   await printVersions(logger, { adaptors: ['@openfn/language-http'] });
 
@@ -61,7 +57,7 @@ test('print versions for node, cli, runtime, compiler and long-form adaptor', as
   t.regex(message, /@openfn\/language-http .+ latest/);
 });
 
-test('print versions for node, cli, runtime, compiler and long-form adaptor with version', async (t) => {
+test('print versions for node, cli and long-form adaptor with version', async (t) => {
   const logger = createMockLogger('', { level: 'info' });
   await printVersions(logger, { adaptors: ['@openfn/language-http@1234'] });
 
@@ -69,6 +65,24 @@ test('print versions for node, cli, runtime, compiler and long-form adaptor with
   const message = last.message as string;
 
   t.regex(message, /@openfn\/language-http .+ 1234/);
+});
+
+test('print version of adaptor with monorepo', async (t) => {
+  mock({
+    '/repo/http/package.json': '{ "version": "1.0.0" }',
+    [root]: mock.load(root, {}),
+  });
+
+  const logger = createMockLogger('', { level: 'info' });
+  await printVersions(logger, {
+    adaptors: ['@openfn/language-http@1.0.0'],
+    monorepoPath: '.',
+  });
+
+  const last = logger._parse(logger._last);
+  const message = last.message as string;
+
+  t.regex(message, /@openfn\/language-http(.+)monorepo/);
 });
 
 test('print version of adaptor with path', async (t) => {
@@ -80,6 +94,24 @@ test('print version of adaptor with path', async (t) => {
   const logger = createMockLogger('', { level: 'info' });
   await printVersions(logger, {
     adaptors: ['@openfn/language-http=/repo/http'],
+  });
+
+  const last = logger._parse(logger._last);
+  const message = last.message as string;
+
+  t.regex(message, /@openfn\/language-http(.+)1\.0\.0/);
+});
+
+test('print version of adaptor with path even if monorepo is set', async (t) => {
+  mock({
+    '/repo/http/package.json': '{ "version": "1.0.0" }',
+    [root]: mock.load(root, {}),
+  });
+
+  const logger = createMockLogger('', { level: 'info' });
+  await printVersions(logger, {
+    adaptors: ['@openfn/language-http=/repo/http'],
+    monorepoPath: '.',
   });
 
   const last = logger._parse(logger._last);
@@ -115,7 +147,5 @@ test('json output', async (t) => {
   const [{ versions }] = last.message;
   t.truthy(versions['node.js']);
   t.truthy(versions['cli']);
-  t.truthy(versions['runtime']);
-  t.truthy(versions['compiler']);
   t.truthy(versions['http']);
 });

--- a/packages/cli/test/util/print-versions.test.ts
+++ b/packages/cli/test/util/print-versions.test.ts
@@ -19,6 +19,8 @@ test('print versions for node and cli', async (t) => {
   t.regex(message, /cli/);
   t.regex(message, /node/);
   t.notRegex(message, /adaptor/);
+  t.notRegex(message, /compiler/);
+  t.notRegex(message, /runtime/);
 });
 
 test('print versions for node, cli and adaptor', async (t) => {
@@ -30,6 +32,21 @@ test('print versions for node, cli and adaptor', async (t) => {
 
   t.regex(message, /Versions:/);
   t.regex(message, /cli/);
+  t.regex(message, /node/);
+  t.regex(message, /http .+ latest/);
+});
+
+test('print versions for node, cli, components and adaptor', async (t) => {
+  const logger = createMockLogger('', { level: 'info' });
+  await printVersions(logger, { adaptors: ['http'] }, true);
+
+  const last = logger._parse(logger._last);
+  const message = last.message as string;
+
+  t.regex(message, /Versions:/);
+  t.regex(message, /cli/);
+  t.regex(message, /node/);
+  t.regex(message, /runtime/);
   t.regex(message, /node/);
   t.regex(message, /http .+ latest/);
 });

--- a/packages/ws-worker/src/util/versions.ts
+++ b/packages/ws-worker/src/util/versions.ts
@@ -5,29 +5,23 @@ const { triangleRightSmall: t } = mainSymbols;
 export type Versions = {
   node: string;
   worker: string;
-  engine: string;
 
   [adaptor: string]: string;
 };
 
 export default (stepId: string, versions: Versions, adaptor?: string) => {
-  let longest = 'compiler'.length; // Bit wierdly defensive but ensure padding is reasonable even if version has no props
+  let longest = 'worker'.length; // Bit wierdly defensive but ensure padding is reasonable even if version has no props
   for (const v in versions) {
     longest = Math.max(v.length, longest);
   }
 
-  const { node, compiler, engine, worker, runtime, ...adaptors } = versions;
+  const { node, worker, ...adaptors } = versions;
   // Prefix and pad version numbers
   const prefix = (str: string) => `    ${t} ${str.padEnd(longest + 4, ' ')}`;
 
   let str = `Versions for step ${stepId}:
 ${prefix('node.js')}${versions.node || 'unknown'}
-${prefix('worker')}${versions.worker || 'unknown'}
-${prefix('engine')}${versions.engine || 'unknown'}`;
-
-  // Unfortunately the runtime and compiler versions get reported as workspace:* in prod right now
-  // ${prefix('runtime')}${versions.runtime || 'unknown'}
-  // ${prefix('compiler')}${versions.compiler || 'unknown'}`;
+${prefix('worker')}${versions.worker || 'unknown'}`;
 
   if (Object.keys(adaptors).length) {
     let allAdaptors = Object.keys(adaptors);

--- a/packages/ws-worker/test/util/versions.test.ts
+++ b/packages/ws-worker/test/util/versions.test.ts
@@ -5,10 +5,7 @@ import calculateVersionString from '../../src/util/versions';
 // keys in this obejct are scrambled on purpose
 const versions = {
   worker: '2',
-  // compiler: '5',
   node: '1',
-  engine: '3',
-  // runtime: '4',
 };
 
 // Util function to parse a version string into something easier to test
@@ -33,9 +30,8 @@ test('calculate version string', (t) => {
   t.is(
     str,
     `Versions for step step-1:
-    ▸ node.js     1
-    ▸ worker      2
-    ▸ engine      3`
+    ▸ node.js   1
+    ▸ worker    2`
   );
 });
 
@@ -46,7 +42,6 @@ test('helper should parse a version string and return the correct order', (t) =>
   t.deepEqual(parsed, [
     ['node.js', '1'],
     ['worker', '2'],
-    ['engine', '3'],
   ]);
 });
 
@@ -58,7 +53,6 @@ test("show unknown if a version isn't passed", (t) => {
   t.deepEqual(parsed, [
     ['node.js', 'unknown'],
     ['worker', 'unknown'],
-    ['engine', 'unknown'],
   ]);
 });
 
@@ -67,9 +61,8 @@ test('show adaptors last', (t) => {
     '@openfn/language-common': '1.0.0',
     ...versions,
   });
-
   const parsed = parse(str);
-  const common = parsed[3];
+  const common = parsed[2];
   t.deepEqual(common, ['@openfn/language-common', '1.0.0']);
 });
 
@@ -83,9 +76,9 @@ test('sort and list multiple adaptors', (t) => {
 
   const parsed = parse(str);
 
-  const a = parsed[3];
-  const j = parsed[4];
-  const z = parsed[5];
+  const a = parsed[2];
+  const j = parsed[3];
+  const z = parsed[4];
 
   t.deepEqual(a, ['a', '1']);
   t.deepEqual(j, ['j', '2']);


### PR DESCRIPTION
This PR tidies version output in the CLI and Worker

* When running a job in the CLI, you should only see versions for node, the CLI and the adaptor
* If running out of the monorepo, the version will be listed as "monorepo"
* `openfn --version` should still list the versions of the inner components (ie, runtime and engine)
* When running in the Worker, we should only log node, the worker and the adaptor versions

Closes #588