### PR TITLE
Verify run token

### DIFF
--- a/.changeset/grumpy-candles-applaud.md
+++ b/.changeset/grumpy-candles-applaud.md
@@ -1,0 +1,5 @@
+---
+'@openfn/lightning-mock': minor
+---
+
+Optionally mock the run token

--- a/.changeset/yellow-peaches-melt.md
+++ b/.changeset/yellow-peaches-melt.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': minor
+---
+
+Validate the run token

--- a/integration-tests/worker/src/init.ts
+++ b/integration-tests/worker/src/init.ts
@@ -1,17 +1,17 @@
 import path from 'node:path';
 import crypto from 'node:crypto';
 
-import createLightningServer from '@openfn/lightning-mock';
+import createLightningServer, { toBase64 } from '@openfn/lightning-mock';
 import createEngine from '@openfn/engine-multi';
 import createWorkerServer from '@openfn/ws-worker';
 import createLogger, { createMockLogger } from '@openfn/logger';
 
 export const randomPort = () => Math.round(2000 + Math.random() * 1000);
 
-export const initLightning = (port = 4000) => {
+export const initLightning = (port = 4000, privateKey?: string) => {
   // TODO the lightning mock right now doesn't use the secret
   // but we may want to add tests against this
-  return createLightningServer({ port });
+  return createLightningServer({ port, runPrivateKey: toBase64(privateKey) });
 };
 
 export const initWorker = async (

--- a/integration-tests/worker/src/init.ts
+++ b/integration-tests/worker/src/init.ts
@@ -11,7 +11,12 @@ export const randomPort = () => Math.round(2000 + Math.random() * 1000);
 export const initLightning = (port = 4000, privateKey?: string) => {
   // TODO the lightning mock right now doesn't use the secret
   // but we may want to add tests against this
-  return createLightningServer({ port, runPrivateKey: toBase64(privateKey) });
+  const opts = { port };
+  if (privateKey) {
+    // @ts-ignore
+    opts.runPrivateKey = toBase64(privateKey);
+  }
+  return createLightningServer(opts);
 };
 
 export const initWorker = async (

--- a/integration-tests/worker/test/autoinstall.test.ts
+++ b/integration-tests/worker/test/autoinstall.test.ts
@@ -20,6 +20,7 @@ let worker;
 const run = async (attempt) => {
   return new Promise<any>(async (done, reject) => {
     lightning.on('run:complete', (evt) => {
+      console.log('>', evt);
       if (attempt.id === evt.runId) {
         done(lightning.getResult(attempt.id));
       }

--- a/integration-tests/worker/test/autoinstall.test.ts
+++ b/integration-tests/worker/test/autoinstall.test.ts
@@ -1,9 +1,6 @@
-// stress test for autoinstall
-// this could evolve  into stress testing, benchmarking or artillery generally?
-// Also I may skip this in CI after the issue is fixed
-
 import test from 'ava';
 import path from 'node:path';
+import { generateKeys } from '@openfn/lightning-mock';
 
 import { initLightning, initWorker } from '../src/init';
 import { createRun, createJob } from '../src/factories';
@@ -33,13 +30,20 @@ const run = async (attempt) => {
 };
 
 test.before(async () => {
+  const keys = await generateKeys();
   const lightningPort = 4321;
 
-  lightning = initLightning(lightningPort);
+  lightning = initLightning(lightningPort, keys.private);
 
-  ({ worker } = await initWorker(lightningPort, {
-    repoDir: path.resolve('tmp/repo/autoinstall'),
-  }));
+  ({ worker } = await initWorker(
+    lightningPort,
+    {
+      repoDir: path.resolve('tmp/repo/autoinstall'),
+    },
+    {
+      runPublicKey: keys.public,
+    }
+  ));
 });
 
 test.after(async () => {

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -2,6 +2,7 @@ import test from 'ava';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import Koa from 'koa';
+import { generateKeys } from '@openfn/lightning-mock';
 
 import { initLightning, initWorker, randomPort } from '../src/init';
 
@@ -12,13 +13,21 @@ let engineLogger;
 let lightningPort;
 
 test.before(async () => {
+  const keys = await generateKeys();
   lightningPort = randomPort();
-  lightning = initLightning(lightningPort);
-  ({ worker, engine, engineLogger } = await initWorker(lightningPort, {
+  lightning = initLightning(lightningPort, keys.private);
+
+  const engineArgs = {
     maxWorkers: 1,
-    purge: false,
     repoDir: path.resolve('tmp/repo/integration'),
-  }));
+  };
+  const workerArgs = { runPublicKey: keys.public };
+
+  ({ worker, engine, engineLogger } = await initWorker(
+    lightningPort,
+    engineArgs,
+    workerArgs
+  ));
 });
 
 test.afterEach(() => {
@@ -472,12 +481,64 @@ test('stateful adaptor should create a new client for each attempt', (t) => {
     const engineArgs = {
       repoDir: path.resolve('./dummy-repo'),
       maxWorkers: 1,
-      purge: false,
     };
     await initWorker(lightningPort, engineArgs);
 
     lightning.enqueueRun(attempt1);
     lightning.enqueueRun(attempt2);
+  });
+});
+
+test('worker should exit if it has an invalid key', (t) => {
+  return new Promise(async (done) => {
+    if (!worker.destroyed) {
+      await worker.destroy();
+    }
+
+    // generate a new, invalid, public key
+    const keys = await generateKeys();
+
+    ({ worker } = await initWorker(
+      lightningPort,
+      {
+        maxWorkers: 1,
+        repoDir: path.resolve('tmp/repo/integration'),
+      },
+      {
+        runPublicKey: keys.public,
+      }
+    ));
+
+    const run = {
+      id: crypto.randomUUID(),
+      jobs: [
+        {
+          adaptor: '@openfn/language-http@latest',
+          body: `fn((s) => s`,
+        },
+      ],
+    };
+
+    // This should NOT run because the worker should
+    // not verify the token and destroy itself
+    lightning.once('run:start', () => {
+      t.fail('invalid run was start');
+      done();
+    });
+    lightning.once('run:complete', () => {
+      t.fail('invalid run was completed');
+      done();
+    });
+
+    // TODO this run will, at the moment, be LOST to Lightning
+    lightning.enqueueRun(run);
+
+    t.false(worker.destroyed);
+    setTimeout(() => {
+      // Ensure that the worker is destroyed after a brief interval
+      t.true(worker.destroyed);
+      done();
+    }, 500);
   });
 });
 

--- a/integration-tests/worker/test/runs.test.ts
+++ b/integration-tests/worker/test/runs.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
 import path from 'node:path';
+import { generateKeys } from '@openfn/lightning-mock';
 
 import {
   createRun,
@@ -13,13 +14,20 @@ let lightning;
 let worker;
 
 test.before(async () => {
+  const keys = await generateKeys();
   const lightningPort = 4321;
 
-  lightning = initLightning(lightningPort);
+  lightning = initLightning(lightningPort, keys.private);
 
-  ({ worker } = await initWorker(lightningPort, {
-    repoDir: path.resolve('tmp/repo/attempts'),
-  }));
+  ({ worker } = await initWorker(
+    lightningPort,
+    {
+      repoDir: path.resolve('tmp/repo/attempts'),
+    },
+    {
+      runPublicKey: keys.public,
+    }
+  ));
 });
 
 test.afterEach(async () => {

--- a/packages/lightning-mock/src/api-sockets.ts
+++ b/packages/lightning-mock/src/api-sockets.ts
@@ -39,6 +39,7 @@ import {
   STEP_COMPLETE,
   STEP_START,
 } from './events';
+import { generateRunToken } from './tokens';
 import { extractRunId, stringify } from './util';
 import type { ServerState } from './server';
 
@@ -101,8 +102,8 @@ const createSocketAPI = (
   });
 
   wss.registerEvents('worker:queue', {
-    [CLAIM]: (ws, event: PhoenixEvent<ClaimPayload>) => {
-      const { runs } = pullClaim(state, ws, event);
+    [CLAIM]: async (ws, event: PhoenixEvent<ClaimPayload>) => {
+      const { runs } = await pullClaim(state, ws, event);
       state.events.emit(CLAIM, {
         payload: runs,
         state: clone(state),
@@ -165,13 +166,13 @@ const createSocketAPI = (
   // pull claim will try and pull a claim off the queue,
   // and reply with the response
   // the reply ensures that only the calling worker will get the run
-  function pullClaim(
+  async function pullClaim(
     state: ServerState,
     ws: DevSocket,
     evt: PhoenixEvent<ClaimPayload>
   ) {
     const { ref, join_ref, topic } = evt;
-    const { queue } = state;
+    const { queue, options } = state;
     let count = 1;
 
     const runs: ClaimRun[] = [];
@@ -184,9 +185,12 @@ const createSocketAPI = (
       // TODO assign the worker id to the run
       // Not needed by the mocks at the moment
       const next = queue.shift();
-      // TODO the token in the mock is trivial because we're not going to do any validation on it yet
-      // TODO need to save the token associated with this run
-      runs.push({ id: next!, token: 'x.y.z' });
+
+      // TODO this is not well tested inside this repo
+      // (although tests in the worker rely on it)
+      const token = await generateRunToken(next!, options.runPrivateKey);
+
+      runs.push({ id: next!, token });
       count -= 1;
 
       startRun(next!);

--- a/packages/lightning-mock/src/api-sockets.ts
+++ b/packages/lightning-mock/src/api-sockets.ts
@@ -186,8 +186,6 @@ const createSocketAPI = (
       // Not needed by the mocks at the moment
       const next = queue.shift();
 
-      // TODO this is not well tested inside this repo
-      // (although tests in the worker rely on it)
       const token = await generateRunToken(next!, options.runPrivateKey);
 
       runs.push({ id: next!, token });

--- a/packages/lightning-mock/src/index.ts
+++ b/packages/lightning-mock/src/index.ts
@@ -1,2 +1,4 @@
 import createLightningServer from './server';
 export default createLightningServer;
+
+export { toBase64, generateKeys } from './util';

--- a/packages/lightning-mock/src/server.ts
+++ b/packages/lightning-mock/src/server.ts
@@ -7,13 +7,13 @@ import createLogger, {
   LogLevel,
   Logger,
 } from '@openfn/logger';
+import type { StepId } from '@openfn/lexicon';
+import type { RunLogPayload, LightningPlan } from '@openfn/lexicon/lightning';
 
 import createWebSocketAPI from './api-sockets';
 import createDevAPI from './api-dev';
-import type { StepId } from '@openfn/lexicon';
-import type { RunLogPayload, LightningPlan } from '@openfn/lexicon/lightning';
+import { fromBase64 } from './util';
 import type { DevServer } from './types';
-import { toBase64 } from './util';
 
 type JobId = string;
 
@@ -65,7 +65,7 @@ const createLightningServer = (options: LightningOptions = {}) => {
 
   // decode the incoming private key from base 64
   const runPrivateKey = options.runPrivateKey
-    ? toBase64(options.runPrivateKey)
+    ? fromBase64(options.runPrivateKey)
     : undefined;
 
   const state = {

--- a/packages/lightning-mock/src/tokens.ts
+++ b/packages/lightning-mock/src/tokens.ts
@@ -1,0 +1,52 @@
+import * as jose from 'jose';
+import crypto from 'node:crypto';
+
+export const generateRunToken = async (
+  runId: string,
+  privateKey?: string
+): Promise<string> => {
+  if (privateKey) {
+    const alg = 'RS256';
+
+    const key = crypto.createPrivateKey(privateKey);
+
+    const jwt = await new jose.SignJWT({ id: runId })
+      .setProtectedHeader({ alg })
+      .setIssuedAt()
+      .setIssuer('Lightning')
+      .setExpirationTime('2h')
+      .sign(key);
+
+    return jwt;
+  } else {
+    return 'x.y.z';
+  }
+};
+
+/*
+
+// Joken.Signer.create("RS256", %{"pem" => pem})
+
+  |> add_claim("iss", fn -> "Lightning" end, &(&1 == "Lightning"))
+      |> add_claim("id", nil, fn id, _claims, context ->
+        is_binary(id) and id == Map.get(context, :id)
+      end)
+      |> add_claim(
+        "nbf",
+        fn -> Lightning.current_time() |> DateTime.to_unix() end,
+        fn nbf, _claims, %{current_time: current_time} ->
+          current_time |> DateTime.to_unix() >= nbf
+        end
+      )
+      |> add_claim(
+        "exp",
+        fn ->
+          Lightning.current_time()
+          |> DateTime.add(Lightning.Config.grace_period())
+          |> DateTime.to_unix()
+        end,
+        fn exp, _claims, %{current_time: current_time} ->
+          current_time |> DateTime.to_unix() < exp
+        end
+      )
+      */

--- a/packages/lightning-mock/src/tokens.ts
+++ b/packages/lightning-mock/src/tokens.ts
@@ -6,47 +6,24 @@ export const generateRunToken = async (
   privateKey?: string
 ): Promise<string> => {
   if (privateKey) {
-    const alg = 'RS256';
+    try {
+      const alg = 'RS256';
 
-    const key = crypto.createPrivateKey(privateKey);
+      const key = crypto.createPrivateKey(privateKey);
 
-    const jwt = await new jose.SignJWT({ id: runId })
-      .setProtectedHeader({ alg })
-      .setIssuedAt()
-      .setIssuer('Lightning')
-      .setExpirationTime('2h')
-      .sign(key);
-
-    return jwt;
-  } else {
-    return 'x.y.z';
+      const jwt = await new jose.SignJWT({ id: runId })
+        .setProtectedHeader({ alg })
+        .setIssuedAt()
+        .setIssuer('Lightning')
+        .setExpirationTime('2h')
+        .sign(key);
+      return jwt;
+    } catch (e) {
+      console.error('ERROR IN MOCK LIGHTNING SERVER');
+      console.error('Failed to generate JWT token for run ', runId);
+      console.error(e);
+    }
   }
+
+  return 'x.y.z';
 };
-
-/*
-
-// Joken.Signer.create("RS256", %{"pem" => pem})
-
-  |> add_claim("iss", fn -> "Lightning" end, &(&1 == "Lightning"))
-      |> add_claim("id", nil, fn id, _claims, context ->
-        is_binary(id) and id == Map.get(context, :id)
-      end)
-      |> add_claim(
-        "nbf",
-        fn -> Lightning.current_time() |> DateTime.to_unix() end,
-        fn nbf, _claims, %{current_time: current_time} ->
-          current_time |> DateTime.to_unix() >= nbf
-        end
-      )
-      |> add_claim(
-        "exp",
-        fn ->
-          Lightning.current_time()
-          |> DateTime.add(Lightning.Config.grace_period())
-          |> DateTime.to_unix()
-        end,
-        fn exp, _claims, %{current_time: current_time} ->
-          current_time |> DateTime.to_unix() < exp
-        end
-      )
-      */

--- a/packages/lightning-mock/src/util.ts
+++ b/packages/lightning-mock/src/util.ts
@@ -1,9 +1,9 @@
 import fss from 'fast-safe-stringify';
+import * as jose from 'jose';
 
 export const RUN_PREFIX = 'run:';
 
-export const extractRunId = (topic: string) =>
-  topic.substr(RUN_PREFIX.length);
+export const extractRunId = (topic: string) => topic.substr(RUN_PREFIX.length);
 
 // This is copied out of ws-worker and untested here
 export const stringify = (obj: any): string =>
@@ -13,3 +13,18 @@ export const stringify = (obj: any): string =>
     }
     return value;
   });
+
+// TODO should these be base64 encoded?
+// Depends. The env vars should be in base64, and the top level server args
+// But they should be decoded almost immediately for internal use
+export const generateKeys = async () => {
+  const { publicKey, privateKey } = await jose.generateKeyPair('RS256');
+  return {
+    // @ts-ignore export function
+    publicKey: publicKey.export({ type: 'pkcs1', format: 'pem' }),
+    // @ts-ignore export function
+    privateKey: privateKey.export({ type: 'pkcs1', format: 'pem' }),
+  };
+};
+
+export const toBase64 = (key: string) => Buffer.from(key).toString('base64');

--- a/packages/lightning-mock/src/util.ts
+++ b/packages/lightning-mock/src/util.ts
@@ -14,9 +14,6 @@ export const stringify = (obj: any): string =>
     return value;
   });
 
-// TODO should these be base64 encoded?
-// Depends. The env vars should be in base64, and the top level server args
-// But they should be decoded almost immediately for internal use
 export const generateKeys = async () => {
   const { publicKey, privateKey } = await jose.generateKeyPair('RS256');
   return {

--- a/packages/lightning-mock/src/util.ts
+++ b/packages/lightning-mock/src/util.ts
@@ -28,3 +28,6 @@ export const generateKeys = async () => {
 };
 
 export const toBase64 = (key: string) => Buffer.from(key).toString('base64');
+
+export const fromBase64 = (key: string) =>
+  Buffer.from(key, 'base64').toString();

--- a/packages/lightning-mock/src/util.ts
+++ b/packages/lightning-mock/src/util.ts
@@ -21,9 +21,9 @@ export const generateKeys = async () => {
   const { publicKey, privateKey } = await jose.generateKeyPair('RS256');
   return {
     // @ts-ignore export function
-    publicKey: publicKey.export({ type: 'pkcs1', format: 'pem' }),
+    public: publicKey.export({ type: 'pkcs1', format: 'pem' }),
     // @ts-ignore export function
-    privateKey: privateKey.export({ type: 'pkcs1', format: 'pem' }),
+    private: privateKey.export({ type: 'pkcs1', format: 'pem' }),
   };
 };
 

--- a/packages/lightning-mock/test/tokens.test.ts
+++ b/packages/lightning-mock/test/tokens.test.ts
@@ -17,11 +17,7 @@ const verify = async (token: string, publicKey: string) => {
 };
 
 test.before(async () => {
-  const result = await generateKeys();
-
-  // Note that these keys are not base64 encoded
-  keys.public = result.publicKey;
-  keys.private = result.privateKey;
+  keys = await generateKeys();
 });
 
 test('generate a placeholder token if no key passed', async (t) => {

--- a/packages/lightning-mock/test/tokens.test.ts
+++ b/packages/lightning-mock/test/tokens.test.ts
@@ -1,0 +1,60 @@
+import test from 'ava';
+import * as jose from 'jose';
+import crypto from 'node:crypto';
+
+import { generateRunToken } from '../src/tokens';
+import { generateKeys } from '../src/util';
+
+let keys = { public: '.', private: '.' };
+
+// util function to verify a token against a public key
+const verify = async (token: string, publicKey: string) => {
+  const key = crypto.createPublicKey(publicKey);
+
+  const { payload } = await jose.jwtVerify(token, key);
+
+  return payload;
+};
+
+test.before(async () => {
+  const result = await generateKeys();
+
+  // Note that these keys are not base64 encoded
+  keys.public = result.publicKey;
+  keys.private = result.privateKey;
+});
+
+test('generate a placeholder token if no key passed', async (t) => {
+  const result = await generateRunToken('.');
+  t.is(result, 'x.y.z');
+});
+
+test('generate a real token if a key is passed', async (t) => {
+  const result = await generateRunToken('.', keys.private);
+  t.true(result.length > 100);
+});
+
+test('token should be verified with the public key', async (t) => {
+  const result = await generateRunToken('.', keys.private);
+
+  // Basically testing that this doesn't throw
+  const payload = await verify(result, keys.public);
+  t.log(payload);
+  t.truthy(payload);
+});
+
+test('token claims should include the run id', async (t) => {
+  const result = await generateRunToken('23', keys.private);
+
+  const { id } = await verify(result, keys.public);
+  t.is(id, '23');
+});
+
+test('token claims should include the issuer: Lightning', async (t) => {
+  const result = await generateRunToken('23', keys.private);
+
+  const { iss } = await verify(result, keys.public);
+  t.is(iss, 'Lightning');
+});
+
+// TODO - claim should include exp and nbf

--- a/packages/ws-worker/src/api/claim.ts
+++ b/packages/ws-worker/src/api/claim.ts
@@ -14,7 +14,6 @@ const verifyToken = async (token: string, publicKey: string) => {
 
   const { payload } = await jose.jwtVerify(token, key, {
     issuer: 'Lightning',
-    // TODO id
   });
 
   if (payload) {

--- a/packages/ws-worker/src/api/claim.ts
+++ b/packages/ws-worker/src/api/claim.ts
@@ -1,14 +1,49 @@
+import * as jose from 'jose';
 import { Logger, createMockLogger } from '@openfn/logger';
 import { ClaimPayload, ClaimReply } from '@openfn/lexicon/lightning';
 import { CLAIM } from '../events';
 
 import type { ServerApp } from '../server';
 
+import { KeyObject } from 'node:crypto';
+
 const mockLogger = createMockLogger();
 
+const verifyToken = async (token: string, secret: string) => {
+  console.log(' >>> VERIFY TOKEN');
+  console.log('secret:', secret);
+  console.log('token:', token);
+  // TODO encode this further upstream
+  // We should encode the same secret once at use it for both channels
+  const encodedSecret = new TextEncoder().encode(secret || '');
+
+  const keyObject = KeyObject.from(secret);
+  const { payload } = await jose.jwtVerify(token, keyObject);
+  console.log(payload);
+  if (payload) {
+    return true;
+  }
+  // TODO we probably need to kill the worker at this point?
+  // We also need to un-claim the token, which we have no mechanism for
+  console.error('>> INVALID SECRET');
+  process.exit(1);
+  throw new Error('invalid_secret');
+};
+
+type ClaimOptions = {
+  secret?: string;
+  maxWorkers?: number;
+};
+
 // TODO: this needs standalone unit tests now that it's bene moved
-const claim = (app: ServerApp, logger: Logger = mockLogger, maxWorkers = 5) => {
+const claim = (
+  app: ServerApp,
+  logger: Logger = mockLogger,
+  options: ClaimOptions = {}
+) => {
   return new Promise<void>((resolve, reject) => {
+    const { secret, maxWorkers = 5 } = options;
+
     const activeWorkers = Object.keys(app.workflows).length;
     if (activeWorkers >= maxWorkers) {
       return reject(new Error('Server at capacity'));
@@ -31,7 +66,14 @@ const claim = (app: ServerApp, logger: Logger = mockLogger, maxWorkers = 5) => {
           return reject(new Error('No runs returned'));
         }
 
-        runs.forEach((run) => {
+        runs.forEach(async (run) => {
+          if (secret) {
+            // TODO need to verify the token here right
+            // if we fail we need to unclaim somehow?
+            // or send a message back?
+            // maybe for now we'll process.exit
+            await verifyToken(run.token, secret);
+          }
           logger.debug('starting run', run.id);
           app.execute(run);
           resolve();

--- a/packages/ws-worker/src/api/claim.ts
+++ b/packages/ws-worker/src/api/claim.ts
@@ -20,6 +20,7 @@ const verifyToken = async (token: string, publicKey: string) => {
 
   const { payload } = await jose.jwtVerify(token, key, {
     issuer: 'Lightning',
+    // TODO id
   });
 
   if (payload) {

--- a/packages/ws-worker/src/api/claim.ts
+++ b/packages/ws-worker/src/api/claim.ts
@@ -65,7 +65,9 @@ const claim = (
             } catch (e) {
               logger.error('Error validating run token');
               logger.error(e);
-              return reject();
+              reject();
+              app.destroy();
+              return;
             }
           } else {
             logger.debug('skipping run token validation for', run.id);

--- a/packages/ws-worker/src/api/claim.ts
+++ b/packages/ws-worker/src/api/claim.ts
@@ -26,7 +26,6 @@ type ClaimOptions = {
   maxWorkers?: number;
 };
 
-// TODO: this needs standalone unit tests now that it's bene moved
 const claim = (
   app: ServerApp,
   logger: Logger = mockLogger,

--- a/packages/ws-worker/src/api/workloop.ts
+++ b/packages/ws-worker/src/api/workloop.ts
@@ -10,17 +10,25 @@ const startWorkloop = (
   logger: Logger,
   minBackoff: number,
   maxBackoff: number,
-  maxWorkers?: number
+  maxWorkers?: number,
+  secret?: string
 ) => {
   let promise: CancelablePromise;
   let cancelled = false;
 
   const workLoop = () => {
     if (!cancelled) {
-      promise = tryWithBackoff(() => claim(app, logger, maxWorkers), {
-        min: minBackoff,
-        max: maxBackoff,
-      });
+      promise = tryWithBackoff(
+        () =>
+          claim(app, logger, {
+            secret,
+            maxWorkers,
+          }),
+        {
+          min: minBackoff,
+          max: maxBackoff,
+        }
+      );
       // TODO this needs more unit tests I think
       promise.then(() => {
         if (!cancelled) {

--- a/packages/ws-worker/src/api/workloop.ts
+++ b/packages/ws-worker/src/api/workloop.ts
@@ -10,8 +10,7 @@ const startWorkloop = (
   logger: Logger,
   minBackoff: number,
   maxBackoff: number,
-  maxWorkers?: number,
-  secret?: string
+  maxWorkers?: number
 ) => {
   let promise: CancelablePromise;
   let cancelled = false;
@@ -21,7 +20,6 @@ const startWorkloop = (
       promise = tryWithBackoff(
         () =>
           claim(app, logger, {
-            secret,
             maxWorkers,
           }),
         {

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -19,7 +19,7 @@ import type { Server } from 'http';
 import type { RuntimeEngine } from '@openfn/engine-multi';
 import type { Socket, Channel } from './types';
 
-type ServerOptions = {
+export type ServerOptions = {
   maxWorkflows?: number;
   port?: number;
   lightning?: string; // url to lightning instance

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -80,7 +80,8 @@ function connect(app: ServerApp, logger: Logger, options: ServerOptions = {}) {
         logger,
         options.backoff?.min || MIN_BACKOFF,
         options.backoff?.max || MAX_BACKOFF,
-        options.maxWorkflows
+        options.maxWorkflows,
+        options.secret
       );
     } else {
       logger.break();
@@ -192,7 +193,10 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
   // Debug API to manually trigger a claim
   router.post('/claim', async (ctx) => {
     logger.info('triggering claim from POST request');
-    return claim(app, logger, options.maxWorkflows)
+    return claim(app, logger, {
+      secret: options.secret,
+      maxWorkers: options.maxWorkflows,
+    })
       .then(() => {
         logger.info('claim complete: 1 run claimed');
         ctx.body = 'complete';

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -5,7 +5,7 @@ import createLogger, { LogLevel } from '@openfn/logger';
 
 import createRTE from '@openfn/engine-multi';
 import createMockRTE from './mock/runtime-engine';
-import createWorker from './server';
+import createWorker, { ServerOptions } from './server';
 
 type Args = {
   _: string[];
@@ -140,13 +140,7 @@ const [minBackoff, maxBackoff] = args.backoff
 function engineReady(engine: any) {
   logger.debug('Creating worker server...');
 
-  if (args.lightningPublicKey) {
-    logger.info(
-      'Lightning public key found: run tokens from Lightning will be verified by this worker'
-    );
-  }
-
-  const workerOptions = {
+  const workerOptions: ServerOptions = {
     port: args.port,
     lightning: args.lightning,
     logger,
@@ -158,8 +152,18 @@ function engineReady(engine: any) {
       max: maxBackoff,
     },
     maxWorkflows: args.capacity,
-    runPublicKey: args.lightningPublicKey,
   };
+
+  if (args.lightningPublicKey) {
+    logger.info(
+      'Lightning public key found: run tokens from Lightning will be verified by this worker'
+    );
+    workerOptions.runPublicKey = Buffer.from(
+      args.lightningPublicKey,
+      'base64'
+    ).toString();
+  }
+
   const {
     logger: _l,
     secret: _s,

--- a/packages/ws-worker/src/util/worker-token.ts
+++ b/packages/ws-worker/src/util/worker-token.ts
@@ -26,8 +26,7 @@ const generateWorkerToken = async (
   const jwt = await new jose.SignJWT(claims)
     .setProtectedHeader({ alg })
     .setIssuedAt()
-    .setIssuer('urn:example:issuer')
-    .setAudience('urn:example:audience')
+    .setIssuer('urn:openfn:worker')
     .sign(encodedSecret);
   // .setExpirationTime('2h') // ??
 

--- a/packages/ws-worker/test/lightning.test.ts
+++ b/packages/ws-worker/test/lightning.test.ts
@@ -28,15 +28,12 @@ const urls = {
 };
 
 test.before(async () => {
-  const rawKeys = await generateKeys();
-
-  keys.public = rawKeys.publicKey;
-  keys.private = toBase64(rawKeys.privateKey);
+  keys = await generateKeys();
 
   const engine = await createMockRTE();
   lng = createLightningServer({
     port: 7654,
-    runPrivateKey: keys.private,
+    runPrivateKey: toBase64(keys.private),
   });
 
   worker = createWorkerServer(engine, {


### PR DESCRIPTION
The PR verifies the run token (JWT) that Lightning sends with each claim.

Verification means checking the signature against the public key and asserting the `iss` (and `id` TODO) claims.

Support has been added to the lightning mock to generate a real JWT token, which is then used in testing.

I don't have very good explicit testing around this - but some tests do now rely on the tokens being set properly. Integration tests now use tokens, and there is a test to ensure the server is destroyed after a token is rejected. So that's not bad.

Closes #399