### PR TITLE
Worker: Better error handling for credential errors

### DIFF
--- a/.changeset/twelve-ravens-listen.md
+++ b/.changeset/twelve-ravens-listen.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': patch
+---
+
+Add a CredentialLoadError

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -304,6 +304,35 @@ test.skip('run a job with credentials', (t) => {
   });
 });
 
+test('run a job with bad credentials', (t) => {
+  return new Promise<void>(async (done) => {
+    const attempt = {
+      id: crypto.randomUUID(),
+      dataclip_id: 's1',
+      jobs: [
+        {
+          adaptor: '@openfn/language-common@latest',
+          body: 'fn((s) => s)',
+          credential: 'zzz',
+        },
+      ],
+    };
+
+    const initialState = { name: 'Professor X' };
+
+    lightning.addDataclip('s1', initialState);
+
+    lightning.once('run:complete', ({ payload }) => {
+      t.is(payload.reason, 'exception');
+      t.is(payload.error_type, 'CredentialLoadError');
+      t.regex(payload.error_message, /Failed to load credential zzz for step/);
+      done();
+    });
+
+    lightning.enqueueRun(attempt);
+  });
+});
+
 test('blacklist a non-openfn adaptor', (t) => {
   return new Promise(async (done) => {
     const attempt = {

--- a/packages/engine-multi/src/api/execute.ts
+++ b/packages/engine-multi/src/api/execute.ts
@@ -40,7 +40,8 @@ const execute = async (context: ExecutionContext) => {
       // TODO catch and "throw" nice clean credentials issues
       await preloadCredentials(
         state.plan as any,
-        options.resolvers?.credential
+        options.resolvers?.credential,
+        logger
       );
     }
 

--- a/packages/engine-multi/src/api/preload-credentials.ts
+++ b/packages/engine-multi/src/api/preload-credentials.ts
@@ -1,17 +1,34 @@
 import { ExecutionPlan, Job } from '@openfn/lexicon';
+import type { Logger } from '@openfn/logger';
+import { CredentialErrorObj, CredentialLoadError } from '../errors';
 
 export default async (
   plan: ExecutionPlan,
-  loader: (id: string) => Promise<any>
+  loader: (id: string) => Promise<any>,
+  logger?: Logger
 ) => {
   const loaders: Promise<void>[] = [];
+
+  const errors: CredentialErrorObj[] = [];
 
   Object.values(plan.workflow.steps).forEach((step) => {
     const job = step as Job;
     if (typeof job.configuration === 'string') {
+      const config = job.configuration as string;
       loaders.push(
         new Promise(async (resolve) => {
-          job.configuration = await loader(job.configuration as string);
+          logger?.debug(`Loading credential ${config} for step ${job.id}`);
+          try {
+            job.configuration = await loader(config as string);
+            logger?.debug(`Credential ${config} loaded OK (${config})`);
+          } catch (e: any) {
+            logger?.debug(`Error loading credential ${config}`);
+            errors.push({
+              id: config,
+              step: step.id!,
+              error: e?.message || e?.toString() || e,
+            });
+          }
           resolve();
         })
       );
@@ -19,5 +36,8 @@ export default async (
   });
 
   await Promise.all(loaders);
+  if (errors.length) {
+    throw new CredentialLoadError(errors);
+  }
   return plan;
 };

--- a/packages/engine-multi/src/errors.ts
+++ b/packages/engine-multi/src/errors.ts
@@ -100,4 +100,20 @@ export class ExitError extends EngineError {
   }
 }
 
-// CredentialsError (exception)
+export type CredentialErrorObj = { id: string; step: string; error: string };
+
+// Error lazy-loading a credenial
+export class CredentialLoadError extends EngineError {
+  severity = 'exception';
+  type = 'CredentialLoadError';
+  name = 'CredentialLoadError';
+  message;
+
+  original: any; // this is the original error
+  constructor(errors: CredentialErrorObj[]) {
+    super();
+    this.message = errors
+      .map((e) => `Failed to load credential ${e.id} for step ${e.step}`)
+      .join('\n');
+  }
+}

--- a/packages/engine-multi/test/api/preload-credentials.test.ts
+++ b/packages/engine-multi/test/api/preload-credentials.test.ts
@@ -13,7 +13,7 @@ test('handle a plan with no credentials', async (t) => {
   };
 
   const plan = {
-    id: 'a',
+    id: t.title,
     workflow: {
       steps: [
         {
@@ -46,7 +46,7 @@ test('handle a plan with credentials', async (t) => {
   };
 
   const plan = {
-    id: 'a',
+    id: t.title,
     workflow: {
       steps: [
         {
@@ -72,4 +72,67 @@ test('handle a plan with credentials', async (t) => {
   t.is((plan.workflow.steps[0] as Job).configuration, 'loaded-a');
   t.is((plan.workflow.steps[1] as Job).configuration, 'loaded-b');
   t.is((plan.workflow.steps[2] as Job).configuration, 'loaded-c');
+});
+
+test('throw if one credential fails to load', async (t) => {
+  const loader = async () => {
+    throw new Error('err');
+  };
+
+  const plan = {
+    id: t.title,
+    workflow: {
+      steps: [
+        {
+          id: 'z',
+          expression: '.',
+          configuration: 'a',
+        },
+      ],
+    },
+    options: {},
+  } as ExecutionPlan;
+
+  try {
+    await preloadCredentials(plan, loader);
+  } catch (e: any) {
+    t.is(e.name, 'CredentialLoadError');
+    t.is(e.message, `Failed to load credential a for step z`);
+  }
+});
+
+test('throw if several credentials fail to load', async (t) => {
+  const loader = async () => {
+    throw new Error('err');
+  };
+
+  const plan = {
+    id: t.title,
+    workflow: {
+      steps: [
+        {
+          id: 'j',
+          expression: '.',
+          configuration: 'a',
+        },
+        {
+          id: 'k',
+          expression: '.',
+          configuration: 'a',
+        },
+      ],
+    },
+    options: {},
+  } as ExecutionPlan;
+
+  try {
+    await preloadCredentials(plan, loader);
+  } catch (e: any) {
+    t.is(e.name, 'CredentialLoadError');
+    t.is(
+      e.message,
+      `Failed to load credential a for step j
+Failed to load credential a for step k`
+    );
+  }
 });

--- a/packages/lightning-mock/src/api-dev.ts
+++ b/packages/lightning-mock/src/api-dev.ts
@@ -155,7 +155,7 @@ const setupRestAPI = (app: DevServer, state: ServerState, logger: Logger) => {
 
     // convert credentials and dataclips
     run.jobs.forEach((job) => {
-      if (job.credential) {
+      if (job.credential && typeof job.credential !== 'string') {
         const cid = crypto.randomUUID();
         state.credentials[cid] = job.credential;
         job.credential = cid;

--- a/packages/lightning-mock/src/api-sockets.ts
+++ b/packages/lightning-mock/src/api-sockets.ts
@@ -250,16 +250,27 @@ const createSocketAPI = (
     evt: PhoenixEvent<GetCredentialPayload>
   ) {
     const { ref, join_ref, topic, payload } = evt;
-    const response = state.credentials[payload.id];
-    // console.log(topic, event, response);
+    const cred = state.credentials[payload.id];
+
+    let response;
+    if (cred) {
+      response = {
+        status: 'ok',
+        response: cred,
+      };
+    } else {
+      response = {
+        status: 'error',
+        response: 'not_found',
+      };
+    }
+
     ws.reply<GetCredentialReply>({
       ref,
       join_ref,
       topic,
-      payload: {
-        status: 'ok',
-        response,
-      },
+      // @ts-ignore
+      payload: response,
     });
   }
 

--- a/packages/lightning-mock/test/channels/run.test.ts
+++ b/packages/lightning-mock/test/channels/run.test.ts
@@ -139,6 +139,23 @@ test.serial('get credential through the run channel', async (t) => {
   });
 });
 
+test.serial(
+  'get credential should error if the credential does not exist',
+  async (t) => {
+    return new Promise(async (done) => {
+      server.startRun(run1.id);
+
+      const channel = await join(`run:${run1.id}`, { token: 'a.b.c' });
+      channel
+        .push(GET_CREDENTIAL, { id: 'unknown' })
+        .receive('error', (result: any) => {
+          t.is(result, 'not_found');
+          done();
+        });
+    });
+  }
+);
+
 test.serial('get dataclip through the run channel', async (t) => {
   return new Promise(async (done) => {
     server.startRun(run1.id);
@@ -155,7 +172,7 @@ test.serial('get dataclip through the run channel', async (t) => {
 });
 
 test.serial(
-  'get dataclip should throw if the dataclip does not exist',
+  'get dataclip should error if the dataclip does not exist',
   async (t) => {
     return new Promise(async (done) => {
       server.startRun(run1.id);

--- a/packages/ws-worker/src/events/run-error.ts
+++ b/packages/ws-worker/src/events/run-error.ts
@@ -29,7 +29,7 @@ export default async function onRunError(
 
     onFinish({ reason });
   } catch (e: any) {
-    logger.error('ERROR in workflow-error handler:', e.message);
+    logger.error('ERROR in run-error handler:', e.message);
     logger.error(e);
 
     onFinish({});

--- a/packages/ws-worker/test/lightning.test.ts
+++ b/packages/ws-worker/test/lightning.test.ts
@@ -218,36 +218,6 @@ test.serial(
 );
 
 test.serial(
-  `events: lightning should receive an exception reason if ${e.GET_CREDENTIAL} event fails`,
-  (t) => {
-    return new Promise((done) => {
-      const run = getRun({}, [
-        {
-          id: 'some-job',
-          credential_id: 'zzz',
-          adaptor: '@openfn/language-common@1.0.0',
-          body: 'fn(() => ({ answer: 42 }))',
-        },
-      ]);
-
-      let didCallEvent = false;
-      lng.onSocketEvent(e.GET_CREDENTIAL, run.id, () => {
-        // again there's no way to check the right credential was returned
-        didCallEvent = true;
-      });
-
-      lng.onSocketEvent(e.RUN_COMPLETE, run.id, () => {
-        console.log('>> RUN COMPLETE');
-        t.true(didCallEvent);
-        done();
-      });
-
-      lng.enqueueRun(run);
-    });
-  }
-);
-
-test.serial(
   `events: lightning should receive a ${e.GET_DATACLIP} event`,
   (t) => {
     return new Promise((done) => {

--- a/packages/ws-worker/test/reasons.test.ts
+++ b/packages/ws-worker/test/reasons.test.ts
@@ -12,6 +12,7 @@ import {
   RUN_LOG,
   RUN_START,
   RUN_COMPLETE,
+  GET_CREDENTIAL,
 } from '../src/events';
 import { ExecutionPlan } from '@openfn/lexicon';
 
@@ -49,6 +50,9 @@ const execute = async (plan: ExecutionPlan, input = {}, options = {}) =>
       [RUN_LOG]: async () => true,
       [STEP_COMPLETE]: async () => true,
       [RUN_COMPLETE]: async () => true,
+      [GET_CREDENTIAL]: async () => {
+        throw new Error('err');
+      },
     });
 
     const onFinish = (result: any) => {
@@ -219,6 +223,20 @@ test('exception: autoinstall error', async (t) => {
     reason.error_message,
     'Error installing @openfn/language-common@1.0.0: not the way to amarillo'
   );
+});
+
+test('exception: failed to load credential', async (t) => {
+  const plan = createPlan({
+    id: 'aa',
+    expression: 'export default [() => s]',
+    configuration: 'zzz',
+  });
+
+  const { reason } = await execute(plan);
+
+  t.is(reason.reason, 'exception');
+  t.is(reason.error_type, 'CredentialLoadError');
+  t.is(reason.error_message, 'Failed to load credential zzz for step aa');
 });
 
 test('kill: timeout', async (t) => {


### PR DESCRIPTION
Closes #600 

This is actually a fix down in the engine.

When loading credentials from Lighting, if any credentials fail to load, we  catch and report the error, and throw in the main validation function.

Previously, because of how credentials are loaded in nested promises, this case resulted in an uncaught exception and everything would blow up. It's more stable now - and we should get a nice error message to explain the fail reason!