### PR TITLE
Allow a workflow to support multiple adaptor versions

### DIFF
--- a/.changeset/calm-books-care.md
+++ b/.changeset/calm-books-care.md
@@ -1,0 +1,6 @@
+---
+'@openfn/engine-multi': minor
+'@openfn/runtime': minor
+---
+
+Support workflows with different versions of the same adaptor

--- a/integration-tests/worker/test/runs.test.ts
+++ b/integration-tests/worker/test/runs.test.ts
@@ -215,7 +215,7 @@ test.serial('run a http adaptor job', async (t) => {
   });
 });
 
-test.serial('use different versions of the same adaptor', async (t) => {
+test.serial.only('use different versions of the same adaptor', async (t) => {
   // http@5 exported an axios global - so run this job and validate that the global is there
   const job1 = createJob({
     body: `import { axios } from "@openfn/language-http";
@@ -223,7 +223,7 @@ test.serial('use different versions of the same adaptor', async (t) => {
       if (!axios) {
         throw new Error('AXIOS NOT FOUND')
       }
-      return x;
+      return s;
     })`,
     adaptor: '@openfn/language-http@5.0.4',
   });
@@ -235,7 +235,7 @@ test.serial('use different versions of the same adaptor', async (t) => {
       if (axios) {
         throw new Error('AXIOS FOUND')
       }
-      return x;
+      return s;
     })`,
     adaptor: '@openfn/language-http@6.0.0',
   });

--- a/integration-tests/worker/test/runs.test.ts
+++ b/integration-tests/worker/test/runs.test.ts
@@ -194,7 +194,7 @@ test.serial('run parallel jobs', async (t) => {
   // });
 });
 
-test('run a http adaptor job', async (t) => {
+test.serial('run a http adaptor job', async (t) => {
   const job = createJob({
     adaptor: '@openfn/language-http@5.0.4',
     body: `get("https://jsonplaceholder.typicode.com/todos/1");

--- a/integration-tests/worker/test/runs.test.ts
+++ b/integration-tests/worker/test/runs.test.ts
@@ -215,7 +215,7 @@ test.serial('run a http adaptor job', async (t) => {
   });
 });
 
-test.serial.only('use different versions of the same adaptor', async (t) => {
+test.serial('use different versions of the same adaptor', async (t) => {
   // http@5 exported an axios global - so run this job and validate that the global is there
   const job1 = createJob({
     body: `import { axios } from "@openfn/language-http";

--- a/integration-tests/worker/test/runs.test.ts
+++ b/integration-tests/worker/test/runs.test.ts
@@ -44,6 +44,8 @@ const humanMb = (sizeInBytes: number) => Math.round(sizeInBytes / 1024 / 1024);
 const run = async (t, attempt) => {
   return new Promise<any>(async (done, reject) => {
     lightning.on('step:complete', ({ payload }) => {
+      t.is(payload.reason, 'success');
+
       // TODO friendlier job names for this would be nice (rather than run ids)
       t.log(
         `run ${payload.step_id} done in ${payload.duration / 1000}s [${humanMb(
@@ -211,4 +213,38 @@ test('run a http adaptor job', async (t) => {
     title: 'delectus aut autem',
     completed: false,
   });
+});
+
+test.serial('use different versions of the same adaptor', async (t) => {
+  // http@5 exported an axios global - so run this job and validate that the global is there
+  const job1 = createJob({
+    body: `import { axios } from "@openfn/language-http";
+    fn((s) => {
+      if (!axios) {
+        throw new Error('AXIOS NOT FOUND')
+      }
+      return x;
+    })`,
+    adaptor: '@openfn/language-http@5.0.4',
+  });
+
+  // http@6 no longer exports axios - so throw an error if we see it
+  const job2 = createJob({
+    body: `import { axios } from "@openfn/language-http";
+    fn((s) => {
+      if (axios) {
+        throw new Error('AXIOS FOUND')
+      }
+      return x;
+    })`,
+    adaptor: '@openfn/language-http@6.0.0',
+  });
+
+  // Just for fun, run each job a couple of times to make sure that there's no wierd caching or ordering anything
+  const steps = [job1, job2, job1, job2];
+  const attempt = createRun([], steps, []);
+
+  const result = await run(t, attempt);
+  t.log(result);
+  t.falsy(result.errors);
 });

--- a/packages/engine-multi/src/api/autoinstall.ts
+++ b/packages/engine-multi/src/api/autoinstall.ts
@@ -112,8 +112,6 @@ const autoinstall = async (context: ExecutionContext): Promise<ModulePaths> => {
   }
 
   if (!skipRepoValidation && !didValidateRepo) {
-    // TODO what if this throws?
-    // Whole server probably needs to crash, so throwing is probably appropriate
     // TODO do we need to do it on EVERY call? Can we not cache it?
     await ensureRepo(repoDir, logger);
     didValidateRepo = true;
@@ -140,15 +138,28 @@ const autoinstall = async (context: ExecutionContext): Promise<ModulePaths> => {
     // Write the adaptor version to the context
     // This is a reasonably accurate, but not totally bulletproof, report
     // @ts-ignore
+    // TODO need to remove this soon as it's basically lying
     context.versions[name] = v;
 
-    paths[name] = {
+    paths[a] = {
       path: `${repoDir}/node_modules/${alias}`,
       version: v,
     };
 
     if (!(await isInstalledFn(a, repoDir, logger))) {
       adaptorsToLoad.push(a);
+    }
+  }
+
+  // Write linker arguments back to the plan
+  for (const step of plan.workflow.steps) {
+    const job = step as unknown as Job;
+    if (paths[job.adaptor!]) {
+      const { name } = getNameAndVersion(job.adaptor);
+      // @ts-ignore
+      job.linker = {
+        [name]: paths[job.adaptor!],
+      };
     }
   }
 

--- a/packages/engine-multi/src/api/autoinstall.ts
+++ b/packages/engine-multi/src/api/autoinstall.ts
@@ -155,7 +155,7 @@ const autoinstall = async (context: ExecutionContext): Promise<ModulePaths> => {
   for (const step of plan.workflow.steps) {
     const job = step as unknown as Job;
     if (paths[job.adaptor!]) {
-      const { name } = getNameAndVersion(job.adaptor);
+      const { name } = getNameAndVersion(job.adaptor!);
       // @ts-ignore
       job.linker = {
         [name]: paths[job.adaptor!],

--- a/packages/engine-multi/src/api/execute.ts
+++ b/packages/engine-multi/src/api/execute.ts
@@ -50,7 +50,6 @@ const execute = async (context: ExecutionContext) => {
     const runOptions = {
       statePropsToRemove: options.statePropsToRemove,
       whitelist,
-      repoDir: options.repoDir,
     } as RunOptions;
 
     const workerOptions = {
@@ -108,6 +107,7 @@ const execute = async (context: ExecutionContext) => {
         jobError(context, evt);
       },
       [workerEvents.LOG]: (evt: workerEvents.LogEvent) => {
+        // console.log(evt.log.name, evt.log.message);
         log(context, evt);
       },
       // TODO this is also untested

--- a/packages/engine-multi/src/api/execute.ts
+++ b/packages/engine-multi/src/api/execute.ts
@@ -15,14 +15,13 @@ import {
 } from './lifecycle';
 import preloadCredentials from './preload-credentials';
 import { ExecutionError } from '../errors';
+import type { RunOptions } from '../worker/thread/run';
 
 const execute = async (context: ExecutionContext) => {
   const { state, callWorker, logger, options } = context;
   try {
-    // TODO catch and "throw" nice clean autoinstall errors
-    const adaptorPaths = await autoinstall(context);
+    await autoinstall(context);
 
-    // TODO catch and "throw" nice clean compile errors
     try {
       await compile(context);
     } catch (e: any) {
@@ -49,10 +48,10 @@ const execute = async (context: ExecutionContext) => {
     const whitelist = options.whitelist?.map((w) => w.toString());
 
     const runOptions = {
-      adaptorPaths,
-      whitelist,
       statePropsToRemove: options.statePropsToRemove,
-    };
+      whitelist,
+      repoDir: options.repoDir,
+    } as RunOptions;
 
     const workerOptions = {
       memoryLimitMb: options.memoryLimitMb,
@@ -116,6 +115,7 @@ const execute = async (context: ExecutionContext) => {
         error(context, { workflowId: state.plan.id, error: evt.error });
       },
     };
+
     return callWorker(
       'run',
       [state.plan, state.input || {}, runOptions || {}],

--- a/packages/engine-multi/src/worker/thread/run.ts
+++ b/packages/engine-multi/src/worker/thread/run.ts
@@ -10,8 +10,8 @@ import { execute, createLoggers } from './helpers';
 import serializeError from '../../util/serialize-error';
 import { JobErrorPayload } from '../../events';
 
-type RunOptions = {
-  adaptorPaths: Record<string, { path: string }>;
+export type RunOptions = {
+  repoDir: string;
   whitelist?: RegExp[];
   sanitize: SanitizePolicies;
   statePropsToRemove?: string[];
@@ -26,8 +26,7 @@ const eventMap = {
 
 register({
   run: (plan: ExecutionPlan, input: State, runOptions: RunOptions) => {
-    const { adaptorPaths, whitelist, sanitize, statePropsToRemove } =
-      runOptions;
+    const { repoDir, whitelist, sanitize, statePropsToRemove } = runOptions;
     const { logger, jobLogger, adaptorLogger } = createLoggers(
       plan.id!,
       sanitize,
@@ -52,7 +51,7 @@ register({
       logger,
       jobLogger,
       linker: {
-        modules: adaptorPaths,
+        repo: repoDir,
         whitelist,
         cacheKey: plan.id,
       },

--- a/packages/engine-multi/test/api/autoinstall.test.ts
+++ b/packages/engine-multi/test/api/autoinstall.test.ts
@@ -77,8 +77,9 @@ test('Autoinstall basically works', async (t) => {
   const context = createContext(autoinstallOpts);
 
   const paths = await autoinstall(context);
+  t.log(paths);
   t.deepEqual(paths, {
-    '@openfn/language-common': {
+    '@openfn/language-common@1.0.0': {
       path: 'tmp/repo/node_modules/@openfn/language-common_1.0.0',
       version: '1.0.0',
     },
@@ -263,7 +264,7 @@ test('autoinstall: handle two seperate, non-overlapping installs', async (t) => 
 
   const p1 = await autoinstall(c1);
   t.deepEqual(p1, {
-    '@openfn/language-dhis2': {
+    '@openfn/language-dhis2@1.0.0': {
       path: 'tmp/repo/node_modules/@openfn/language-dhis2_1.0.0',
       version: '1.0.0',
     },
@@ -271,7 +272,7 @@ test('autoinstall: handle two seperate, non-overlapping installs', async (t) => 
 
   const p2 = await autoinstall(c2);
   t.deepEqual(p2, {
-    '@openfn/language-http': {
+    '@openfn/language-http@1.0.0': {
       path: 'tmp/repo/node_modules/@openfn/language-http_1.0.0',
       version: '1.0.0',
     },
@@ -329,10 +330,53 @@ test.serial('autoinstall: return a map to modules', async (t) => {
   const result = await autoinstall(context);
 
   t.deepEqual(result, {
+    '@openfn/language-common@1.0.0': {
+      path: 'tmp/repo/node_modules/@openfn/language-common_1.0.0',
+      version: '1.0.0',
+    },
+    '@openfn/language-http@1.0.0': {
+      path: 'tmp/repo/node_modules/@openfn/language-http_1.0.0',
+      version: '1.0.0',
+    },
+  });
+});
+
+test.serial('autoinstall: write linker options back to the plan', async (t) => {
+  const jobs = [
+    {
+      adaptor: '@openfn/language-common@1.0.0',
+    },
+    {
+      adaptor: '@openfn/language-common@2.0.0',
+    },
+    {
+      adaptor: '@openfn/language-http@1.0.0',
+    },
+  ];
+
+  const autoinstallOpts = {
+    skipRepoValidation: true,
+    handleInstall: async () => {},
+    handleIsInstalled: async () => false,
+  };
+  const context = createContext(autoinstallOpts, jobs);
+
+  await autoinstall(context);
+
+  const [a, b, c] = context.state.plan.workflow.steps as Job[];
+  t.deepEqual(a.linker, {
     '@openfn/language-common': {
       path: 'tmp/repo/node_modules/@openfn/language-common_1.0.0',
       version: '1.0.0',
     },
+  });
+  t.deepEqual(b.linker, {
+    '@openfn/language-common': {
+      path: 'tmp/repo/node_modules/@openfn/language-common_2.0.0',
+      version: '2.0.0',
+    },
+  });
+  t.deepEqual(c.linker, {
     '@openfn/language-http': {
       path: 'tmp/repo/node_modules/@openfn/language-http_1.0.0',
       version: '1.0.0',
@@ -363,7 +407,7 @@ test.serial('autoinstall: support custom whitelist', async (t) => {
   const result = await autoinstall(context);
 
   t.deepEqual(result, {
-    y: {
+    'y@1.0.0': {
       path: 'tmp/repo/node_modules/y_1.0.0',
       version: '1.0.0',
     },

--- a/packages/lexicon/core.d.ts
+++ b/packages/lexicon/core.d.ts
@@ -31,6 +31,17 @@ export interface Job extends Step {
   expression: Expression;
   configuration?: object | string;
   state?: Omit<State, 'configuration'> | string;
+
+  // Internal use only
+  // Allow module paths and versions to be overriden in the linker
+  // Maps to runtime.ModuleInfoMapo
+  linker?: Record<
+    string,
+    {
+      path?: string;
+      version?: string;
+    }
+  >;
 }
 
 /**

--- a/packages/runtime/src/execute/compile-plan.ts
+++ b/packages/runtime/src/execute/compile-plan.ts
@@ -7,6 +7,7 @@ import type {
 import compileFunction from '../modules/compile-function';
 import { conditionContext, Context } from './context';
 import { ExecutionPlan, Job, StepEdge, Workflow } from '@openfn/lexicon';
+import { getNameAndVersion } from '../modules/repo';
 
 const compileEdges = (
   from: string,
@@ -126,6 +127,12 @@ export default (plan: ExecutionPlan) => {
       'configuration',
       'name',
     ]);
+
+    if ((step as Job).adaptor) {
+      const job = step as Job;
+      const { name, version } = getNameAndVersion(job.adaptor!);
+      newStep.linker = { [name]: { version: version! } };
+    }
 
     if (step.next) {
       trapErrors(() => {

--- a/packages/runtime/src/execute/compile-plan.ts
+++ b/packages/runtime/src/execute/compile-plan.ts
@@ -116,6 +116,7 @@ export default (plan: ExecutionPlan) => {
   };
 
   for (const step of workflow.steps) {
+    const job = step as Job;
     const stepId = step.id!;
     const newStep: CompiledStep = {
       id: stepId,
@@ -128,7 +129,9 @@ export default (plan: ExecutionPlan) => {
       'name',
     ]);
 
-    if ((step as Job).adaptor) {
+    if (job.linker) {
+      newStep.linker = job.linker;
+    } else if (job.adaptor) {
       const job = step as Job;
       const { name, version } = getNameAndVersion(job.adaptor!);
       newStep.linker = { [name]: { version: version! } };

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -127,6 +127,20 @@ export const wrapOperation = (
   };
 };
 
+export const mergeLinkerOptions = (
+  options: ModuleInfoMap = {},
+  overrides: ModuleInfoMap = {}
+) => {
+  const opts: ModuleInfoMap = {};
+  for (const specifier in options) {
+    opts[specifier] = options[specifier];
+  }
+  for (const specifier in overrides) {
+    opts[specifier] = Object.assign({}, opts[specifier], overrides[specifier]);
+  }
+  return opts;
+};
+
 const prepareJob = async (
   expression: string | Operation[],
   context: Context,
@@ -137,8 +151,7 @@ const prepareJob = async (
     const exports = await loadModule(expression, {
       ...opts.linker,
       // allow module paths and versions to be overriden from the defaults
-      // TODO I think this is too harsh and path information will be lost
-      modules: Object.assign({}, opts.linker?.modules, moduleOverrides),
+      modules: mergeLinkerOptions(opts.linker?.modules, moduleOverrides),
       context,
       log: opts.logger,
     });

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -137,6 +137,7 @@ const prepareJob = async (
     const exports = await loadModule(expression, {
       ...opts.linker,
       // allow module paths and versions to be overriden from the defaults
+      // TODO I think this is too harsh and path information will be lost
       modules: Object.assign({}, opts.linker?.modules, moduleOverrides),
       context,
       log: opts.logger,

--- a/packages/runtime/src/execute/step.ts
+++ b/packages/runtime/src/execute/step.ts
@@ -121,13 +121,17 @@ const executeStep = async (
 
     const timerId = `step-${jobId}`;
     logger.timer(timerId);
+
+    // TODO can we include the adaptor version here?
+    // How would we get it?
     logger.info(`Starting step ${jobName}`);
 
     const startTime = Date.now();
     try {
       // TODO include the upstream job?
       notify(NOTIFY_JOB_START, { jobId });
-      result = await executeExpression(ctx, job.expression, state);
+
+      result = await executeExpression(ctx, job.expression, state, step.linker);
     } catch (e: any) {
       didError = true;
       if (e.hasOwnProperty('error') && e.hasOwnProperty('state')) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,6 @@
-import run from './runtime';
+import run, { Options } from './runtime';
 export default run;
+export type { Options };
 
 import type { ModuleInfo, ModuleInfoMap } from './modules/linker';
 export type { ModuleInfo, ModuleInfoMap };

--- a/packages/runtime/src/modules/linker.ts
+++ b/packages/runtime/src/modules/linker.ts
@@ -91,6 +91,7 @@ const linker: Linker = async (specifier, context, options = {}) => {
 
 // Loads a module as a general specifier or from a specific path
 const loadActualModule = async (specifier: string, options: LinkerOptions) => {
+  console.debug(' >> load');
   const log = options.log || defaultLogger;
   const prefix = process.platform == 'win32' ? 'file://' : '';
 
@@ -108,8 +109,12 @@ const loadActualModule = async (specifier: string, options: LinkerOptions) => {
   let path;
   let version;
 
+  console.log('SPECIFIER:', specifier);
+  console.log('MODULES:', options.modules);
+  console.log(options.repo);
   if (options.modules?.[specifier]) {
     ({ path, version } = options.modules?.[specifier]);
+    console.log(path, options.repo);
   }
 
   if (path || options.repo) {
@@ -152,7 +157,7 @@ const loadActualModule = async (specifier: string, options: LinkerOptions) => {
       );
     }
   }
-
+  console.log(' *** WAH ***');
   // Generic error (we should never get here)
   throw new ImportError(`Failed to import module "${specifier}"`);
 };

--- a/packages/runtime/src/modules/linker.ts
+++ b/packages/runtime/src/modules/linker.ts
@@ -91,7 +91,6 @@ const linker: Linker = async (specifier, context, options = {}) => {
 
 // Loads a module as a general specifier or from a specific path
 const loadActualModule = async (specifier: string, options: LinkerOptions) => {
-  console.debug(' >> load');
   const log = options.log || defaultLogger;
   const prefix = process.platform == 'win32' ? 'file://' : '';
 
@@ -109,12 +108,8 @@ const loadActualModule = async (specifier: string, options: LinkerOptions) => {
   let path;
   let version;
 
-  console.log('SPECIFIER:', specifier);
-  console.log('MODULES:', options.modules);
-  console.log(options.repo);
   if (options.modules?.[specifier]) {
     ({ path, version } = options.modules?.[specifier]);
-    console.log(path, options.repo);
   }
 
   if (path || options.repo) {
@@ -157,7 +152,7 @@ const loadActualModule = async (specifier: string, options: LinkerOptions) => {
       );
     }
   }
-  console.log(' *** WAH ***');
+
   // Generic error (we should never get here)
   throw new ImportError(`Failed to import module "${specifier}"`);
 };

--- a/packages/runtime/src/modules/module-loader.ts
+++ b/packages/runtime/src/modules/module-loader.ts
@@ -31,7 +31,6 @@ export default async (
   opts: Options = {}
 ): Promise<ModuleExports> => {
   validate(src);
-
   const context = opts.context || vm.createContext();
   const linker = opts.linker || mainLinker;
 

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -11,6 +11,7 @@ import {
   NOTIFY_INIT_START,
   NOTIFY_STATE_LOAD,
 } from './events';
+import { ModuleInfoMap } from './modules/linker';
 
 export type CompiledEdge =
   | boolean
@@ -22,6 +23,10 @@ export type CompiledEdge =
 export type CompiledStep = Omit<Step, 'next'> & {
   id: StepId;
   next?: Record<StepId, CompiledEdge>;
+
+  // custom overrides for the linker
+  // This lets us set version or even path per job
+  linker?: ModuleInfoMap;
 
   [other: string]: any;
 };

--- a/packages/runtime/test/execute/compile-plan.test.ts
+++ b/packages/runtime/test/execute/compile-plan.test.ts
@@ -201,6 +201,31 @@ test('should reset job ids for each call', (t) => {
   t.is(second.workflow.steps['job-1'].expression, 'x');
 });
 
+test('should write adaptor versions', (t) => {
+  const plan = {
+    workflow: {
+      steps: [
+        {
+          id: 'x',
+          expression: '.',
+          adaptor: 'x@1.0',
+        },
+        {
+          id: 'y',
+          expression: '.',
+          adaptor: 'y@1.0',
+        },
+      ],
+    },
+    options: {},
+  };
+
+  const { workflow } = compilePlan(plan);
+  const { x, y } = workflow.steps;
+  t.deepEqual(x.linker, { x: { version: '1.0' } });
+  t.deepEqual(y.linker, { y: { version: '1.0' } });
+});
+
 test('should set the start to steps[0]', (t) => {
   const plan: ExecutionPlan = {
     workflow: {

--- a/packages/runtime/test/execute/compile-plan.test.ts
+++ b/packages/runtime/test/execute/compile-plan.test.ts
@@ -226,6 +226,30 @@ test('should write adaptor versions', (t) => {
   t.deepEqual(y.linker, { y: { version: '1.0' } });
 });
 
+test('should preserve linker options', (t) => {
+  const plan = {
+    workflow: {
+      steps: [
+        {
+          id: 'x',
+          expression: '.',
+          adaptor: 'x@1.0',
+          linker: {
+            x: {
+              path: 'a/b/c',
+            },
+          },
+        },
+      ],
+    },
+    options: {},
+  };
+
+  const { workflow } = compilePlan(plan);
+  const { x } = workflow.steps;
+  t.deepEqual(x.linker, { x: { path: 'a/b/c' } });
+});
+
 test('should set the start to steps[0]', (t) => {
   const plan: ExecutionPlan = {
     workflow: {

--- a/packages/runtime/test/modules/module-loader.test.ts
+++ b/packages/runtime/test/modules/module-loader.test.ts
@@ -45,7 +45,7 @@ test('load a module with an import', async (t) => {
   t.assert(m.default === 20);
 });
 
-test('load a module with aribtrary exports', async (t) => {
+test('load a module with aribitrary exports', async (t) => {
   const src = 'export const x = 10; export const y = 20;';
 
   const m = await loadModule(src);

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -598,6 +598,106 @@ test('run from an adaptor', async (t) => {
   t.deepEqual(result, { data: 22 });
 });
 
+test('run a workflow using the repo and load the default version', async (t) => {
+  const expression = `
+    import result from 'ultimate-answer';
+    export default [() => result];
+  `;
+  const plan = {
+    workflow: {
+      steps: [
+        {
+          id: 'a',
+          expression,
+        },
+      ],
+    },
+  };
+
+  const result: any = await run(
+    plan,
+    {},
+    {
+      linker: {
+        repo: path.resolve('test/__repo__'),
+      },
+    }
+  );
+
+  t.deepEqual(result, 43);
+});
+
+test('run a workflow using the repo using a specific version', async (t) => {
+  const expression = `
+    import result from 'ultimate-answer';
+    export default [() => result];
+  `;
+  const plan = {
+    workflow: {
+      steps: [
+        {
+          id: 'a',
+          expression,
+        },
+      ],
+    },
+  };
+
+  const result: any = await run(
+    plan,
+    {},
+    {
+      linker: {
+        repo: path.resolve('test/__repo__'),
+        modules: {
+          'ultimate-answer': { version: '1.0.0' },
+        },
+      },
+    }
+  );
+
+  t.deepEqual(result, 42);
+});
+
+test('run a workflow using the repo with multiple versions of the same adaptor', async (t) => {
+  const plan = {
+    workflow: {
+      steps: [
+        {
+          id: 'a',
+          expression: `import result from 'ultimate-answer';
+          export default [(s) => { s.data.a = result; return s;}];`,
+          adaptor: 'ultimate-answer@1.0.0',
+          next: { b: true },
+        },
+        {
+          id: 'b',
+          expression: `import result from 'ultimate-answer';
+          export default [(s) => { s.data.b = result; return s;}];`,
+          adaptor: 'ultimate-answer@2.0.0',
+        },
+      ],
+    },
+  };
+
+  const result: any = await run(
+    plan,
+    {},
+    {
+      linker: {
+        repo: path.resolve('test/__repo__'),
+      },
+    }
+  );
+
+  t.deepEqual(result, {
+    data: {
+      a: 42,
+      b: 43,
+    },
+  });
+});
+
 // https://github.com/OpenFn/kit/issues/520
 test('run from an adaptor with error', async (t) => {
   const expression = `


### PR DESCRIPTION
Closes #268

Bit tricky this one! But I think I've got it.

Every step in a workflow gets compiled by the runtime manager (the CLI or the Engine) and is given an import statement `import { fn } from '@openfn/language-common'`.

It's up to the linker, deep inside the runtime, to decide how how resolve this import. Should we look in the repo? Were we given an explicit mapping? What version do we want?

What usually happens is that the runtime manager (the CLI or worker) will pre-parse the workflow and make a bunch of decisions about these imports. In the CLI, for example, the user might add an explicit path to `language-common`. Or if someone asked for `@latest`, the CLI will maybe autoinstall and replace `@latest` with an actual version (I think).

The problem is that one list of adaptor-version mappings is compiled for the whole workflow, and that one list is shared by the linker. So if we decide that `language-common` is 1.0, all steps will load 1.0 regardless of what was asked for.

What _this_ PR does is calculate this module map for each step inside the runtime based on the original input, and passes this "localised" map into the linker for each step.

It seems to work.

Sadly I can't get unit tests very close to the code without making major changes. It's actually very small tweak in a glue layer and I can't intercept in the right place.

## TODO

* [x] Add some integration tests around this
* [x] Ensure autoinstall works with multiple versions
* [x] Maybe move the adaptor version reporting so that it better reflects what is actually loaded