### PR TITLE
Update CLI Deploy Readme

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -192,6 +192,8 @@ Example config file:
 
   // Optional: defaults to OpenFn.org's API, can be overridden or set with
   // `OPENFN_ENDPOINT` env var
+  // If you're running Lightning locally, you may need to use your local IP address (e.g., 127.0.0.1) instead of localhost,
+  // depending on the version of Node.js and your system.
   "endpoint": "https://app.openfn.org"
 }
 ```


### PR DESCRIPTION
## Short Description

This PR updates the CLI deploy readme to address an issue where deploying a project using CLI deploy in a  local Lightning instance fails on certain systems and Node.js versions if the endpoint uses 'localhost'. To resolve this, users should use the IP address (e.g., 127.0.0.1) as the endpoint.

## Related issue

Fixes #

## Implementation Details

## QA Notes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added unit tests
- [ ] Changesets have been added (if there are production code changes)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
