### PR TITLE
Fix pull without workflows

### DIFF
--- a/.changeset/light-dancers-wink.md
+++ b/.changeset/light-dancers-wink.md
@@ -1,0 +1,5 @@
+---
+'@openfn/deploy': patch
+---
+
+Fix an issue pulling a project with no workflows

--- a/.changeset/light-dancers-wink.md
+++ b/.changeset/light-dancers-wink.md
@@ -1,5 +1,0 @@
----
-'@openfn/deploy': patch
----
-
-Fix an issue pulling a project with no workflows

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/cli
 
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [6d52ddf]
+  - @openfn/deploy@0.4.4
+
 ## 1.1.1
 
 ### Patch Changes
@@ -9,6 +16,7 @@
   - @openfn/compiler@0.0.41
   - @openfn/deploy@0.4.3
   - @openfn/runtime@1.0.1
+
 ## 1.1.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/deploy/CHANGELOG.md
+++ b/packages/deploy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/deploy
 
+## 0.4.4
+
+### Patch Changes
+
+- 6d52ddf: Fix an issue pulling a project with no workflows
+
 ## 0.4.3
 
 ### Patch Changes

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/deploy",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Deploy projects to Lightning instances",
   "type": "module",
   "exports": {

--- a/packages/deploy/src/validator.ts
+++ b/packages/deploy/src/validator.ts
@@ -47,7 +47,12 @@ export function parseAndValidate(input: string): {
   }
 
   function validateWorkflows(workflows: any) {
-    if (isMap(workflows)) {
+    if (typeof workflows === 'undefined') {
+      // allow workflows to be unspecified, but ensure there is an empty
+      // map to avoid errors downstream
+      doc.setIn(['workflows'], {})
+    }
+    else if (isMap(workflows)) {
       for (const workflow of workflows.items) {
         if (isPair(workflow)) {
           pushUniqueKey(workflow, (workflow as any).key.value);

--- a/packages/deploy/test/validator.test.ts
+++ b/packages/deploy/test/validator.test.ts
@@ -76,3 +76,19 @@ workflows:
     ].condition_expression === 'true'
   );
 });
+
+
+test('allow empty workflows', (t) => {
+  let doc = `
+name: project-name
+  `;
+
+  let result = parseAndValidate(doc);
+
+  t.is(result.errors.length, 0)
+
+  t.deepEqual(result.doc, {
+    name: 'project-name',
+    workflows: {}
+  })
+});


### PR DESCRIPTION
This PR fixes an issue where pulling a project without any workflows throws an error.

The fix is:
a) make the validator lenient if a workflow has no workflows
b) default the workflows map to prevent errors downstream

Versions are bumped and this can be merged for release immediately.