### PR TITLE
Lazy State Operator

### DIFF
--- a/.changeset/nice-kids-itch.md
+++ b/.changeset/nice-kids-itch.md
@@ -1,0 +1,5 @@
+---
+'@openfn/compiler': minor
+---
+
+Basic support for lazy state ($) operator

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -5,6 +5,7 @@ import createLogger, { Logger } from '@openfn/logger';
 
 import addImports, { AddImportsOptions } from './transforms/add-imports';
 import ensureExports from './transforms/ensure-exports';
+import lazyState from './transforms/lazy-state';
 import topLevelOps, {
   TopLevelOpsOptions,
 } from './transforms/top-level-operations';
@@ -13,7 +14,8 @@ export type TransformerName =
   | 'add-imports'
   | 'ensure-exports'
   | 'top-level-operations'
-  | 'test';
+  | 'test'
+  | 'lazy-state';
 
 type TransformFunction = (
   path: NodePath<any, any>,
@@ -36,6 +38,7 @@ export type TransformOptions = {
   ['ensure-exports']?: boolean;
   ['top-level-operations']?: TopLevelOpsOptions | boolean;
   ['test']?: any;
+  ['lazy-state']?: any;
 };
 
 const defaultLogger = createLogger();
@@ -46,7 +49,7 @@ export default function transform(
   options: TransformOptions = {}
 ) {
   if (!transformers) {
-    transformers = [ensureExports, topLevelOps, addImports] as Transformer[];
+    transformers = [lazyState, ensureExports, topLevelOps, addImports] as Transformer[];
   }
   const logger = options.logger || defaultLogger;
   const transformerIndex = indexTransformers(transformers, options);

--- a/packages/compiler/src/transforms/add-imports.ts
+++ b/packages/compiler/src/transforms/add-imports.ts
@@ -15,6 +15,8 @@ import type { Transformer } from '../transform';
 import type { Logger } from '@openfn/logger';
 
 const globals = [
+  '\\$', // TMP hack to fix a problem with lazy-state (needs double escaping to work)
+
   'AggregateError',
   'Array',
   'ArrayBuffer',

--- a/packages/compiler/src/transforms/lazy-state.ts
+++ b/packages/compiler/src/transforms/lazy-state.ts
@@ -1,0 +1,46 @@
+/*
+ * Convert $.a.b.c references into (state) => state.a.b.c
+ * Should this only run at top level?
+ * Ideally it would run on all arguments to operations - but we probably don't really know what an operation is
+ * So for now, first pass, it's only top level.
+ * (alternatively I guess it just dumbly converts everything and if it breaks, it breaks)
+ * 
+ * TODO (maybe):
+ *  - only convert $-expressions which are arguments to operations (needs type defs)
+ *  - warn if converting a non-top-level $-expression
+ *  - if not top level, convert to state.a.b.c (ie don't wrap the function)
+ */
+import { builders as b, namedTypes } from 'ast-types';
+import type { NodePath } from 'ast-types/lib/node-path';
+import type { Transformer } from '../transform';
+
+function visitor(path: NodePath<namedTypes.MemberExpression>) {
+  let first = path.node.object;
+  while(first.hasOwnProperty('object')) {
+    first = (first as namedTypes.MemberExpression).object;
+  }
+
+  let firstIdentifer = first as namedTypes.Identifier;
+  
+  if (first && firstIdentifer.name === "$") {
+    // rename $ to state
+    firstIdentifer.name = "state";
+
+    // Now nest the whole thing in an arrow
+    const params = b.identifier('state')
+    const arrow = b.arrowFunctionExpression(
+      [params],
+      path.node
+    )
+    path.replace(arrow)
+  }
+
+  // Stop parsing this member expression
+  return;
+}
+
+export default {
+  id: 'lazy-state',
+  types: ['MemberExpression'],
+  visitor,
+} as Transformer;

--- a/packages/compiler/test/compile.test.ts
+++ b/packages/compiler/test/compile.test.ts
@@ -135,3 +135,22 @@ test('compile a lazy state ($) expression', (t) => {
   const result = compile(source);
   t.assert(result === expected);
 });
+
+
+test('compile a lazy state ($) expression with dumb imports', (t) => {
+  const options = {
+    'add-imports': {
+      adaptor: {
+        name: '@openfn/language-common',
+        exportAll: true,
+      },
+    },
+  };
+  const source = 'get($.data.endpoint);';
+  const expected = `import { get } from "@openfn/language-common";
+export * from "@openfn/language-common";
+export default [get(state => state.data.endpoint)];`
+
+  const result = compile(source, options);
+  t.assert(result === expected);
+});

--- a/packages/compiler/test/compile.test.ts
+++ b/packages/compiler/test/compile.test.ts
@@ -128,3 +128,10 @@ test('compile with nullish coalescence', (t) => {
   const result = compile(source);
   t.assert(result === expected);
 });
+
+test('compile a lazy state ($) expression', (t) => {
+  const source = 'get($.data.endpoint);';
+  const expected = 'export default [get(state => state.data.endpoint)];';
+  const result = compile(source);
+  t.assert(result === expected);
+});

--- a/packages/compiler/test/transforms/lazy-state.test.ts
+++ b/packages/compiler/test/transforms/lazy-state.test.ts
@@ -1,0 +1,76 @@
+import test, { ExecutionContext } from 'ava';
+import { print } from 'recast';
+import { namedTypes, NodePath, builders as b } from 'ast-types';
+
+import parse from '../../src/parse';
+
+import transform from '../../src/transform';
+import visitors from '../../src/transforms/lazy-state';
+
+test('convert a simple dollar reference', (t) => {
+  const ast = parse('get($.data)');
+
+  const transformed = transform(ast, [visitors]);
+  const { code } = print(transformed)
+  t.log(code)
+
+  t.is(code, 'get(state => state.data)')
+})
+
+test('convert a chained dollar reference', (t) => {
+  const ast = parse('get($.a.b.c.d)');
+
+  const transformed = transform(ast, [visitors]);
+  const { code } = print(transformed)
+  t.log(code)
+
+  t.is(code, 'get(state => state.a.b.c.d)')
+})
+
+test('ignore a regular chain reference', (t) => {
+  const ast = parse('get(a.b.c.d)');
+
+  const transformed = transform(ast, [visitors]);
+  const { code } = print(transformed)
+  t.log(code)
+
+  t.is(code, 'get(a.b.c.d)')
+})
+
+test('ignore a string', (t) => {
+  const ast = parse('get("$.a.b")');
+
+  const transformed = transform(ast, [visitors]);
+  const { code } = print(transformed)
+  t.log(code)
+
+  t.is(code, 'get("$.a.b")')
+})
+
+// TODO do we want to support this?
+test('convert a nested dollar reference', (t) => {
+  const ast = parse(`fn(() => {
+  get($.data)
+})`);
+
+  const transformed = transform(ast, [visitors]);
+  const { code } = print(transformed)
+  t.log(code)
+
+  // syntax starts getting a but picky at this level,
+  // better to do ast tests
+  t.is(code, `fn(() => {
+  get(state => state.data)
+})`)
+})
+
+// TODO does our compiler not support optional chaining??
+test.skip('convert an optional chained simple dollar reference', (t) => {
+  const ast = parse('get($.a?.b.c.d)');
+
+  // const transformed = transform(ast, [visitors]);
+  // const { code } = print(transformed)
+  // t.log(code)
+
+  // t.is(code, 'get(state => state.a?.b.c.d)')
+})


### PR DESCRIPTION
## Overview

Add support for a lazy-state operator `$`, which allows state references to be lazily evaluated.

```
get($.data.url)
```

It should be a straight replacement for any `dataValue()` call, or any simple `(state) => state.data.x` reference.

## Issue

This is a great solution to https://github.com/OpenFn/adaptors/issues/483

## Details

Any reference to  JSON-path like expressions like`$.a.b.c` will be compiled into arrow references, like `(state) => state.a.b.c`. This is syntactic sugar to make it easier to safely pass values from state into operations.

## Examples
From the doc site. This:
```
create(
  'Patient__c',
  fields(
    field('Name', dataValue('form.surname')),
    field('Other Names', dataValue('form.firstName')),
    field('Age__c', dataValue('form.ageInYears')),
    field('Is_Enrolled__c', true),
    field('Enrollment_Status__c', 3)
  )
);
```
Becomes this:
```
create(
  'Patient__c',
  fields(
    field('Name', $.data.form.surname),
    field('Other Names', $.data.form.firstName),
    field('Age__c', $.data.form.ageInYears),
    field('Is_Enrolled__c', true),
    field('Enrollment_Status__c', 3)
  )
);
```

Or even this:
```
create(
  'Patient__c',
  {
    'Name':  $.form.surname,
    'Other Names': $.data.form.firstName,
    'Age__c': $.data.form.ageInYears,
    'Is_Enrolled__c': true,
    'Enrollment_Status__c': 3,
  }
);
```
## TODO

This is a very basic implementation of this feature. Probably good enough to release as an alpha feature.

There is very little intelligence, robustness or error handling on this. It is brittle.

At the moment, any `$a.b.c` reference  will be converted. If you do `const $ = {}; get($.a.b.c)`, the compiler will still convert the dollar reference.

Probably we should only do this on arguments to operations, maybe even only at the top level (so that `fn((state) => get($.data.url)(state))` would fail). But it'll all be compiled right now and will likely break in job code.

Maybe I could print a console warning that this is an experimental feature :thinking: 