### PR TITLE
Fix lazy state

### DIFF
--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/integration-tests-worker
 
+## 1.0.38
+
+### Patch Changes
+
+- @openfn/engine-multi@1.1.3
+- @openfn/lightning-mock@2.0.3
+- @openfn/ws-worker@1.1.3
+
 ## 1.0.37
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/cli
 
+## 1.1.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/compiler@0.1.1
+
 ## 1.1.3
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/compiler
 
+## 0.1.1
+
+### Patch Changes
+
+- Ignore lazy state operator ($) for locally declared variables
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/compiler",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Compiler and language tooling for openfn jobs.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/compiler/test/transforms/lazy-state.test.ts
+++ b/packages/compiler/test/transforms/lazy-state.test.ts
@@ -12,7 +12,6 @@ test('convert a simple dollar reference', (t) => {
 
   const transformed = transform(ast, [visitors]);
   const { code } = print(transformed)
-  t.log(code)
 
   t.is(code, 'get(state => state.data)')
 })
@@ -22,7 +21,6 @@ test('convert a chained dollar reference', (t) => {
 
   const transformed = transform(ast, [visitors]);
   const { code } = print(transformed)
-  t.log(code)
 
   t.is(code, 'get(state => state.a.b.c.d)')
 })
@@ -32,7 +30,6 @@ test('ignore a regular chain reference', (t) => {
 
   const transformed = transform(ast, [visitors]);
   const { code } = print(transformed)
-  t.log(code)
 
   t.is(code, 'get(a.b.c.d)')
 })
@@ -42,7 +39,6 @@ test('ignore a string', (t) => {
 
   const transformed = transform(ast, [visitors]);
   const { code } = print(transformed)
-  t.log(code)
 
   t.is(code, 'get("$.a.b")')
 })
@@ -55,7 +51,6 @@ test('convert a nested dollar reference', (t) => {
 
   const transformed = transform(ast, [visitors]);
   const { code } = print(transformed)
-  t.log(code)
 
   // syntax starts getting a but picky at this level,
   // better to do ast tests
@@ -64,13 +59,37 @@ test('convert a nested dollar reference', (t) => {
 })`)
 })
 
-// TODO does our compiler not support optional chaining??
-test.skip('convert an optional chained simple dollar reference', (t) => {
+test('do not convert a $ var (param)', (t) => {
+  const src = `fn(($) => {
+    return $.a.b;
+  })`
+  const ast = parse(src);
+
+  const transformed = transform(ast, [visitors]);
+  const { code } = print(transformed)
+
+  t.is(code, src)
+})
+
+test('do not convert a $ var (const)', (t) => {
+  const src = `fn((s) => {
+    const $ = 10;
+    s.data = $.a.b
+    return s;
+  })`
+  const ast = parse(src);
+
+  const transformed = transform(ast, [visitors]);
+  const { code } = print(transformed)
+
+  t.is(code, src)
+})
+
+test('convert an optional chained simple dollar reference', (t) => {
   const ast = parse('get($.a?.b.c.d)');
 
-  // const transformed = transform(ast, [visitors]);
-  // const { code } = print(transformed)
-  // t.log(code)
+  const transformed = transform(ast, [visitors]);
+  const { code } = print(transformed)
 
-  // t.is(code, 'get(state => state.a?.b.c.d)')
+  t.is(code, 'get(state => state.a?.b.c.d)')
 })

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # engine-multi
 
+## 1.1.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/compiler@0.1.1
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/lightning-mock
 
+## 2.0.3
+
+### Patch Changes
+
+- @openfn/engine-multi@1.1.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ws-worker
 
+## 1.1.3
+
+### Patch Changes
+
+- @openfn/engine-multi@1.1.3
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
The lazy state operator `$` is causing trouble if you try to use `$` as a variable, a la:

```
parseXML(state.data, $ => {
    const inner = $.load(response.text()); // error
 });
```

This PR adds a bit of intelligence to the is-this-a-lazy-state-reference heuristic to ignore $ variable declared in the source. See the unit tests for details.