### PR TITLE
better error message for state/spec mismatch on deploy

### DIFF
--- a/.changeset/eleven-colts-march.md
+++ b/.changeset/eleven-colts-march.md
@@ -1,5 +1,0 @@
----
-'@openfn/deploy': patch
----
-
-Error message for when workflow found in 'state' but not 'spec' during deploy

--- a/.changeset/eleven-colts-march.md
+++ b/.changeset/eleven-colts-march.md
@@ -1,0 +1,5 @@
+---
+'@openfn/deploy': patch
+---
+
+Error message for when workflow found in 'state' but not 'spec' during deploy

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/cli
 
+## 1.2.2
+
+### Patch Changes
+
+- Updated dependencies [adfb661]
+  - @openfn/deploy@0.4.5
+
 ## 1.2.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/deploy/CHANGELOG.md
+++ b/packages/deploy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/deploy
 
+## 0.4.5
+
+### Patch Changes
+
+- adfb661: Error message for when workflow found in 'state' but not 'spec' during deploy
+
 ## 0.4.4
 
 ### Patch Changes

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/deploy",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Deploy projects to Lightning instances",
   "type": "module",
   "exports": {

--- a/packages/deploy/src/stateTransform.ts
+++ b/packages/deploy/src/stateTransform.ts
@@ -216,6 +216,17 @@ export function mergeSpecIntoState(
           ];
         }
 
+        if (!specWorkflow && !isEmpty(stateWorkflow || {})) {
+          console.log(
+            'Workflow found in project state but not spec.',
+            `Spec: ${specWorkflow}`,
+            `State: ${stateWorkflow}`
+          );
+          throw new Error(
+            'Cannot continue: workflow from state not found in spec.'
+          );
+        }
+
         return [
           workflowKey,
           {


### PR DESCRIPTION
This provides a better error message when the deploy fails because a workflow is found in `state.json` but not `spec.yaml`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added unit tests
- [x] Changesets have been added (if there are production code changes)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
