### PR TITLE
Fixing Issue:#192 Allow auto-installing metadata for CLI

### DIFF
--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -32,8 +32,5 @@
   "files": [
     "dist",
     "README.md"
-  ],
-  "devDependencies": {
-    "@types/koa": "^2.15.0"
-  }
+  ]
 }

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -32,5 +32,8 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "devDependencies": {
+    "@types/koa": "^2.15.0"
+  }
 }

--- a/packages/cli/src/metadata/command.ts
+++ b/packages/cli/src/metadata/command.ts
@@ -3,7 +3,7 @@ import { build, ensure } from '../util/command-builders';
 import type { Opts } from '../options';
 import * as o from '../options';
 
-export type MetadataOpts = Required<Pick<Opts, 'adaptors' | 'repoDir'>> &
+export type MetadataOpts = Required<Pick<Opts, 'adaptors' | 'repoDir' | 'autoinstall'>> &
   Pick<
     Opts,
     | 'expandAdaptors'
@@ -19,13 +19,14 @@ const options = [
   o.expandAdaptors, // order is important
 
   o.adaptors,
+  o.autoinstall,
   o.force,
   o.log,
   o.logJson,
   o.repoDir,
   o.statePath,
   o.stateStdin,
-  o.useAdaptorsMonorepo,
+  o.useAdaptorsMonorepo
 ];
 
 export default {

--- a/packages/cli/src/metadata/handler.ts
+++ b/packages/cli/src/metadata/handler.ts
@@ -49,7 +49,7 @@ export const getAdaptorPath = async (
 };
 
 const metadataHandler = async (options: MetadataOpts, logger: Logger) => {
-  const { repoDir, adaptors } = options;
+  const { repoDir, adaptors, autoinstall } = options;
   const adaptor = adaptors[0];
 
   const state = await loadState({} as ExecutionPlan, options, logger);
@@ -84,6 +84,21 @@ const metadataHandler = async (options: MetadataOpts, logger: Logger) => {
     // Import the adaptor
     const adaptorPath = await getAdaptorPath(adaptor, logger, options.repoDir);
     const mod = await import(adaptorPath!);
+
+    // Check if auto-installation is enabled
+    if (autoinstall) {
+      // Auto-install metadata
+      logger.info('Auto-installing metadata...');
+
+      if (mod.installMetadata) {
+        // If the adaptor supports installation of metadata, call the installMetadata function
+        await mod.installMetadata(config);
+        logger.success("Installed metadata")
+      } else {
+        logger.error('Metadata auto-installation not supported by the adaptor');
+        process.exit(1);
+      }
+    }
 
     // Does it export a metadata function?
     if (mod.metadata) {


### PR DESCRIPTION
## Short Description

The code changes allow auto-installing metadata for CLI using flags in commands.

## Related issue

Fixes #192

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added unit tests
