### PR TITLE
Fix worker death

### DIFF
--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openfn/integration-tests-worker
 
+## 1.0.40
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/engine-multi@1.1.5
+  - @openfn/lightning-mock@2.0.5
+  - @openfn/ws-worker@1.1.5
+
 ## 1.0.39
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -506,6 +506,68 @@ test.serial("Don't send adaptor logs to stdout", (t) => {
   });
 });
 
+// https://github.com/OpenFn/kit/pull/668
+// This test relies on a capacity of 1
+test.serial(
+  'keep claiming work after a run with an uncaught exception',
+  (t) => {
+    return new Promise(async (done) => {
+      const finished: Record<string, true> = {};
+
+      const onComplete = (evt) => {
+        const id = evt.runId;
+        finished[id] = true;
+
+        if (id === 'a20') {
+          t.is(evt.payload.reason, 'crash');
+        }
+        if (id === 'a21') {
+          t.is(evt.payload.reason, 'success');
+        }
+
+        if (finished.a20 && finished.a21) {
+          t.pass('both runs completed');
+          done();
+        }
+      };
+
+      lightning.on('run:complete', onComplete);
+
+      const body = `
+fn(
+  () => new Promise(() => {
+    setTimeout(() => {
+      throw new Error('uncaught')
+    }, 1)
+  })
+)
+`;
+
+      lightning.enqueueRun({
+        id: 'a20',
+        jobs: [
+          {
+            id: 'j1',
+            adaptor: '@openfn/language-common@latest',
+            body,
+          },
+        ],
+      });
+
+      lightning.enqueueRun({
+        id: 'a21',
+        jobs: [
+          {
+            id: 'j2',
+            adaptor: '@openfn/language-common@latest',
+            body: 'fn(() => ({ data: { answer: 42} }))',
+          },
+        ],
+      });
+    });
+  }
+);
+
 test.serial(
   'stateful adaptor should create a new client for each attempt',
   (t) => {

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # engine-multi
 
+## 1.1.5
+
+### Patch Changes
+
+- Fix an issue where failed steps might not error correctly, stopping the pool from reclaiming the slot
+
 ## 1.1.4
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/engine-multi/src/api/call-worker.ts
+++ b/packages/engine-multi/src/api/call-worker.ts
@@ -51,5 +51,5 @@ export default function initWorkers(
 
   const closeWorkers = async (instant?: boolean) => workers.destroy(instant);
 
-  return { callWorker, closeWorkers };
+  return { callWorker, closeWorkers, workers };
 }

--- a/packages/engine-multi/src/api/lifecycle.ts
+++ b/packages/engine-multi/src/api/lifecycle.ts
@@ -148,7 +148,6 @@ export const error = (
   event: internalEvents.ErrorEvent
 ) => {
   const { threadId = '-', error } = event;
-
   context.emit(externalEvents.WORKFLOW_ERROR, {
     threadId,
     // @ts-ignore

--- a/packages/engine-multi/src/engine.ts
+++ b/packages/engine-multi/src/engine.ts
@@ -121,7 +121,7 @@ const createEngine = async (
 
   const engine = new Engine() as EngineAPI;
 
-  const { callWorker, closeWorkers } = initWorkers(
+  const { callWorker, closeWorkers, workers } = initWorkers(
     resolvedWorkerPath,
     {
       maxWorkers: options.maxWorkers,
@@ -239,6 +239,7 @@ const createEngine = async (
     execute: executeWrapper,
     listen,
     destroy,
+    workers,
   });
 };
 

--- a/packages/engine-multi/src/worker/pool.ts
+++ b/packages/engine-multi/src/worker/pool.ts
@@ -93,9 +93,9 @@ function createPool(script: string, options: PoolOptions = {}, logger: Logger) {
       // Note: Ok, now I have visibility on the stdout stream
       // I don't think I want to send this to gpc
       // This might be strictly local debug
-      child.stdout!.on('data', (data) => {
-        console.log(' >>>', data.toString());
-      });
+      // child.stdout!.on('data', (data) => {
+      //   console.log(data.toString());
+      // });
 
       logger.debug('pool: Created new child process', child.pid);
       allWorkers[child.pid!] = child;

--- a/packages/engine-multi/src/worker/pool.ts
+++ b/packages/engine-multi/src/worker/pool.ts
@@ -87,7 +87,14 @@ function createPool(script: string, options: PoolOptions = {}, logger: Logger) {
         env: options.env || {},
 
         // This pipes the stderr stream onto the child, so we can read it later
-        stdio: ['ipc', 'ignore', 'pipe'],
+        stdio: ['ipc', 'pipe', 'pipe'],
+      });
+
+      // Note: Ok, now I have visibility on the stdout stream
+      // I don't think I want to send this to gpc
+      // This might be strictly local debug
+      child.stdout!.on('data', (data) => {
+        console.log(' >>>', data.toString());
       });
 
       logger.debug('pool: Created new child process', child.pid);
@@ -158,7 +165,6 @@ function createPool(script: string, options: PoolOptions = {}, logger: Logger) {
           } catch (e) {
             // do nothing
           }
-
           reject(new ExitError(code));
           finish(worker);
         }

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/lightning-mock
 
+## 2.0.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/engine-multi@1.1.5
+
 ## 2.0.4
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ws-worker
 
+## 1.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/engine-multi@1.1.5
+
 ## 1.1.4
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Short Description

This PR fixes an issue where the worker doesn't close down pooled child processes after uncaught exceptions, resulting in the worker refusing to work.

## Related issue

Fixes #664 

## Implementation Details

What's basically happening is:

- The engine is correctly catching uncaught exceptions (and I think process.exits) when they occur
- And it is correctly sending error events out (these errors may be rubbish but I do think they are sending)
- BUT the engine doesn't properly resolve the promise for that run, so the engine still thinks the workflow is executing
- That means the child process pool doesn't allocate new resources for future work, and so chokes up

The engine should eventually be timing out the runs, but by this point lightning thinks they're dead and isn't listening to events. But I think the backlog will very slowly clear.

Anyway, as result of the fix, the error is handled gracefully, the pool re-allocates the worker thread, and everyone is happy.

## QA Notes

I've added two integration tests, both of which  reproduce very similar errors to main. And they both fail on main.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added unit tests
- [x] Changesets have been added (if there are production code changes)

