### PR TITLE
Add support for `console.table` in logger

### DIFF
--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -41,6 +41,7 @@ export type LogFns =
   | 'log'
   | 'warn'
   | 'error'
+  | 'table'
   | 'success'
   | 'always';
 
@@ -68,6 +69,7 @@ export interface Logger extends Console {
   debug(...args: any[]): void;
   warn(...args: any[]): void;
   error(...args: any[]): void;
+  table(...args: any[]): void;
   success(...args: any[]): void;
   always(...args: any[]): void;
 

--- a/packages/logger/src/mock.ts
+++ b/packages/logger/src/mock.ts
@@ -33,18 +33,25 @@ const mockLogger = <T = StringLog>(
     ...console,
   } as LogEmitter;
 
-  ['log', 'info', 'success', 'always', 'debug', 'warn', 'error'].forEach(
-    (l) => {
-      const level = l as LogFns;
-      logger[level] = (...out: any[]) => {
-        if (opts.json) {
-          history.push(out[0] as T);
-        } else {
-          history.push([level, ...out] as T);
-        }
-      };
-    }
-  );
+  [
+    'log',
+    'info',
+    'success',
+    'always',
+    'debug',
+    'warn',
+    'error',
+    'table',
+  ].forEach((l) => {
+    const level = l as LogFns;
+    logger[level] = (...out: any[]) => {
+      if (opts.json) {
+        history.push(out[0] as T);
+      } else {
+        history.push([level, ...out] as T);
+      }
+    };
+  });
 
   const m: unknown = createLogger(name, {
     logger,


### PR DESCRIPTION
## Short Description

This PR add support for `console.table` to the logger. which will make it easy to log data as a table.

This function takes one mandatory argument data, which must be an array or an object, and one additional optional parameter columns.

## Still to do
- [ ] Unit test
- [ ] Add table arguments types ?


## QA Notes

List any considerations/cases/advice for testing/QA here.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added unit tests
- [ ] Changesets have been added (if there are production code changes)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
