### PR TITLE
Worker: ensure workers are released after an error on run:complete

### DIFF
--- a/.changeset/tidy-gorillas-own.md
+++ b/.changeset/tidy-gorillas-own.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Fix an issue where workers may not be returned to the pool if run:complete throws

--- a/.changeset/tidy-gorillas-own.md
+++ b/.changeset/tidy-gorillas-own.md
@@ -1,5 +1,0 @@
----
-'@openfn/ws-worker': patch
----
-
-Fix an issue where workers may not be returned to the pool if run:complete throws

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/integration-tests-worker
 
+## 1.0.42
+
+### Patch Changes
+
+- Updated dependencies [bdff4b2]
+  - @openfn/ws-worker@1.1.7
+
 ## 1.0.41
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ws-worker
 
+## 1.1.7
+
+### Patch Changes
+
+- bdff4b2: Fix an issue where workers may not be returned to the pool if run:complete throws
+
 ## 1.1.6
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/ws-worker/src/api/claim.ts
+++ b/packages/ws-worker/src/api/claim.ts
@@ -35,10 +35,12 @@ const claim = (
 
     const activeWorkers = Object.keys(app.workflows).length;
     if (activeWorkers >= maxWorkers) {
+      logger.debug('skipping claim attempt: server at capacity');
       return reject(new Error('Server at capacity'));
     }
 
     if (!app.queueChannel) {
+      logger.debug('skipping claim attempt: websocket unavailable');
       return reject(new Error('No websocket available'));
     }
 

--- a/packages/ws-worker/src/channels/run.ts
+++ b/packages/ws-worker/src/channels/run.ts
@@ -46,7 +46,21 @@ const joinRunChannel = (
       .receive('error', (err: any) => {
         logger.error(`error connecting to ${channelName}`, err);
         reject(err);
+      })
+      .receive('timeout', (err: any) => {
+        logger.error(`Timeout for ${channelName}`, err);
+        reject(err);
       });
+    channel.onClose(() => {
+      // channel was explicitly closed by the client or server
+      logger.debug(`Leaving ${channelName}`);
+    });
+    channel.onError((e: any) => {
+      // Error occured on the channel
+      // (the socket will try to reconnect with backoff)
+      logger.debug(`Error in ${channelName}`);
+      logger.debug(e);
+    });
   });
 };
 

--- a/packages/ws-worker/src/channels/run.ts
+++ b/packages/ws-worker/src/channels/run.ts
@@ -56,7 +56,7 @@ const joinRunChannel = (
       logger.debug(`Leaving ${channelName}`);
     });
     channel.onError((e: any) => {
-      // Error occured on the channel
+      // Error occurred on the channel
       // (the socket will try to reconnect with backoff)
       logger.debug(`Error in ${channelName}`);
       logger.debug(e);

--- a/packages/ws-worker/src/events/run-complete.ts
+++ b/packages/ws-worker/src/events/run-complete.ts
@@ -10,7 +10,7 @@ export default async function onWorkflowComplete(
   context: Context,
   _event: WorkflowCompletePayload
 ) {
-  const { state, channel, onFinish } = context;
+  const { state, channel, onFinish, logger } = context;
 
   // TODO I dont think the run final dataclip IS the last job dataclip
   // Especially not in parallelisation
@@ -19,10 +19,17 @@ export default async function onWorkflowComplete(
   const reason = calculateRunExitReason(state);
   await logFinalReason(context, reason);
 
-  await sendEvent<RunCompletePayload>(channel, RUN_COMPLETE, {
-    final_dataclip_id: state.lastDataclipId!,
-    ...reason,
-  });
+  try {
+    await sendEvent<RunCompletePayload>(channel, RUN_COMPLETE, {
+      final_dataclip_id: state.lastDataclipId!,
+      ...reason,
+    });
+  } catch (e) {
+    logger.error(
+      `${state.plan.id} failed to send ${RUN_COMPLETE} event. This run will be lost!`
+    );
+    logger.error(e);
+  }
 
   onFinish({ reason, state: result });
 }

--- a/packages/ws-worker/src/mock/sockets.ts
+++ b/packages/ws-worker/src/mock/sockets.ts
@@ -66,6 +66,8 @@ export const mockChannel = (
       return receive;
     },
     leave: () => {},
+    onClose: () => {},
+    onError: () => {},
   };
   return c;
 };

--- a/packages/ws-worker/src/mock/sockets.ts
+++ b/packages/ws-worker/src/mock/sockets.ts
@@ -22,6 +22,8 @@ export const mockChannel = (
           } catch (e) {
             responses.error?.(e);
           }
+        } else {
+          responses.timeout?.('timeout');
         }
       }, 1);
 

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -180,6 +180,7 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
 
       // Callback to be triggered when the work is done (including errors)
       const onFinish = () => {
+        logger.debug(`workflow ${id} complete: releasing worker`);
         delete app.workflows[id];
         runChannel.leave();
 


### PR DESCRIPTION
## Short Description

If the run:complete event error happens to throw, the worker will not close out a Run properly, ie will not free up capacity and claim another run.

This is causing the worker to "jam" silently.

I do not know WHY `run:complete` is timing out on us right now (see [these logs](https://console.cloud.google.com/logs/query;cursorTimestamp=2024-05-10T00:06:42.140836231Z;query=labels.%22k8s-pod%2Fapp%22%3D%22global-worker%22%0Atimestamp%3D%222024-05-10T00:06:42.140836231Z%22%0AinsertId%3D%22pgvd1lgqsoczh9gr%22?organizationId=189089165982&project=platform-test-267207)). And we'll have to work that out. But at least the worker shouldn't die silently any more.

I've also added a little bit more logging around this stuff. Most of the time it's junk but it may help us diagnose when the worker isn't releasing threads from the pool.

## Related issue

None raised, see [slack](https://openfn.slack.com/archives/C0394D0GBUN/p1715326454971499).
