### PR TITLE
Worker timeout tests

### DIFF
--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -695,7 +695,7 @@ test.serial('worker should exit if it has an invalid key', (t) => {
   });
 });
 
-test('set a default timeout on the worker', (t) => {
+test.serial('set a default timeout on the worker', (t) => {
   return new Promise(async (done) => {
     if (!worker.destroyed) {
       await worker.destroy();

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -695,5 +695,57 @@ test.serial('worker should exit if it has an invalid key', (t) => {
   });
 });
 
+test('set a default timeout on the worker', (t) => {
+  return new Promise(async (done) => {
+    if (!worker.destroyed) {
+      await worker.destroy();
+    }
+
+    ({ worker } = await initWorker(lightningPort, {
+      maxWorkers: 1,
+      // use the dummy repo to remove autoinstall
+      repoDir: path.resolve('./dummy-repo'),
+      runTimeoutMs: 100,
+    }));
+
+    const run = {
+      id: crypto.randomUUID(),
+      jobs: [
+        {
+          adaptor: '@openfn/test-adaptor@1.0.0',
+          // this will never return
+          body: `fn((s) => new Promise(resolve => {}))`,
+        },
+      ],
+    };
+
+    // let startTime;
+    // lightning.once('run:start', (evt) => {
+    //   startTime = Date.now();
+    // });
+
+    lightning.once('run:complete', (evt) => {
+      const { reason, error_type, error_message } = evt.payload;
+      t.is(reason, 'kill');
+      t.is(error_type, 'TimeoutError');
+      t.is(error_message, 'Workflow failed to return within 100ms');
+
+      // TODO I'd like a better test on exactly how long the workflow ran before returnuing
+      // But that's really hard because there's a lot of async stuff in the way
+
+      // const endTime = Date.now();
+      // t.true(endTime - startTime >= 40);
+      // t.true(endTime - startTime <= 80); // be generous with this
+
+      done();
+    });
+
+    lightning.enqueueRun(run);
+  });
+});
+
+// create a new worker, set the timeout super high, run a job with a timeout on options, job should timeout
+test.todo('set a timeout on a run');
+
 // REMEMBER the default worker was destroyed at this point!
 // If you want to use a worker, you'll have to create your own

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,6 +415,8 @@ importers:
         specifier: ^5.1.6
         version: 5.1.6
 
+  packages/engine-multi/tmp/a/b/c: {}
+
   packages/engine-multi/tmp/repo: {}
 
   packages/lexicon:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,9 @@
 packages:
-  # exclude the integration test repo
+  # exclude the integration test repos
   - '!integration-tests/worker/dummy-repo/**'
   - '!integration-tests/worker/tmp/**'
+  - '!integration-tests/cli/tmp/**'
+  - '!integration-tests/cli/repo/**'
 
   # all packages in subdirs of packages/ and components/
   - 'packages/**'


### PR DESCRIPTION
This PR adds a couple of integration tests to the worker.

These tests ensure that:
a) the default timeout on the worker, set the env var, is respected
b) a timeout can be set on a run and that will overidde the default

One thing that is NOT covered is the env var itself. But I have manually checked that the env var is being passed through correctly, and server startup logs should verify the actual value being used (note that this is an ENGINE option, not a WORKER option)

No release necessary, we can just merge this.

Closes #686 