### PR TITLE
Runtime: remove the default timeout

### DIFF
--- a/packages/cli/src/execute/execute.ts
+++ b/packages/cli/src/execute/execute.ts
@@ -38,6 +38,7 @@ export default async (
           }
         },
       },
+      defaultRunTimeoutMs: 5 * 60 * 1000, // 5 minutes
     });
     return result;
   } catch (e: any) {

--- a/packages/engine-multi/src/worker/thread/run.ts
+++ b/packages/engine-multi/src/worker/thread/run.ts
@@ -45,7 +45,7 @@ register({
 
     // TODO I would like to pull these options out of here
     const options = {
-      // disable the run/step timeout
+      // disable the runtime's own timeout
       timeout: 0,
       strict: false,
       logger,

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -38,7 +38,7 @@ export default (
     let duration = Date.now();
     const { logger, plan, opts = {} } = ctx;
     try {
-      const timeout = plan.options?.timeout ?? DEFAULT_TIMEOUT_MS;
+      const timeout = plan.options?.timeout ?? ctx.opts.defaultRunTimeoutMs;
 
       // Setup an execution context
       const context = buildContext(input, opts);

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -5,8 +5,6 @@ import type { LinkerOptions } from './modules/linker';
 import executePlan from './execute/plan';
 import { defaultState, parseRegex, clone } from './util/index';
 
-export const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
-
 export type Options = {
   logger?: Logger;
   jobLogger?: Logger;
@@ -28,6 +26,8 @@ export type Options = {
   globals?: any;
 
   statePropsToRemove?: string[];
+
+  defaultRunTimeoutMs?: number;
 };
 
 type RawOptions = Omit<Options, 'linker'> & {


### PR DESCRIPTION
In the Worker, the runtime is currently always defaulting the timeout to its own native default.

This is confusing and misleading and wrong and will cause an early exit if the run timeout is longer than the default runtime timeout.

This PR:
* Removes the runtime's default entirely
* Adds a default timeout option which can be passed in externally
* Moves the old default to the CLI to ensure the same behaviour

Quick note as well at the engine used to pass in `timeout:0` to the runtime to disable the default - but that actually just wasn't working since I moved the timeout to the plan options.

This is not well tested - I suggest we add a bunch of tests around this in #414
