### PR TITLE
deploy: improve error messages

### DIFF
--- a/packages/deploy/src/index.ts
+++ b/packages/deploy/src/index.ts
@@ -111,7 +111,7 @@ export async function deploy(config: DeployConfig, logger: Logger) {
 
   logger.debug('spec', spec);
   if (spec.errors.length > 0) {
-    spec.errors.forEach((e: any) => logger.warn(e.message));
+    spec.errors.forEach((e: any) => logger.warn(`${e.path} :: ${e.message}`));
     throw new DeployError(`${config.specPath} has errors`, 'VALIDATION_ERROR');
   }
   const nextState = mergeSpecIntoState(state, spec.doc);

--- a/packages/deploy/src/validator.ts
+++ b/packages/deploy/src/validator.ts
@@ -15,9 +15,9 @@ export function parseAndValidate(input: string): {
   let errors: Error[] = [];
   const doc = YAML.parseDocument(input);
 
-  function pushUniqueKey(key: string, arr: string[]) {
+  function ensureUniqueId(key: string, arr: string[]) {
     if (arr.includes(key)) {
-      throw `duplicate key: ${key}`;
+      throw `duplicate id: ${key}`;
     } else {
       arr.push(key);
     }
@@ -36,7 +36,7 @@ export function parseAndValidate(input: string): {
           if (isPair(job)) {
             const jobName = (job as any).key.value;
             try {
-              pushUniqueKey(jobName, jobKeys);
+              ensureUniqueId(jobName, jobKeys);
             } catch (err: any) {
               errors.push({
                 path: `${workflowName}/${jobName}`,
@@ -68,7 +68,7 @@ export function parseAndValidate(input: string): {
           const workflowName = (workflow as any).key.value;
           const jobKeys: string[] = [];
           try {
-            pushUniqueKey(workflowName, workflowKeys);
+            ensureUniqueId(workflowName, workflowKeys);
           } catch (err: any) {
             errors.push({
               path: `${workflowName}`,
@@ -82,7 +82,7 @@ export function parseAndValidate(input: string): {
           } else {
             errors.push({
               context: workflowValue,
-              message: `workflow '${workflowName}': must be a map`,
+              message: `${workflowName}: must be a map`,
               path: 'workflowName',
             });
           }
@@ -91,7 +91,7 @@ export function parseAndValidate(input: string): {
     } else {
       errors.push({
         context: workflows,
-        message: 'workflows: must be a map',
+        message: 'must be a map',
         path: 'workflows',
       });
     }

--- a/packages/deploy/test/validator.test.ts
+++ b/packages/deploy/test/validator.test.ts
@@ -15,7 +15,7 @@ test('Workflows must be a map', (t) => {
 
   const results = parseAndValidate(doc);
 
-  const err = findError(results.errors, 'workflows: must be a map');
+  const err = findError(results.errors, 'must be a map');
 
   t.truthy(err);
   t.is(err.path, 'workflows');

--- a/packages/deploy/test/validator.test.ts
+++ b/packages/deploy/test/validator.test.ts
@@ -5,90 +5,103 @@ function findError(errors: any[], message: string) {
   return errors.find((e) => e.message === message);
 }
 
-test('validator', (t) => {
-  let doc = `
-name: project-name
-workflows:
-  - name: workflow-one
-  - name: workflow-two
+test('Workflows must be a map', (t) => {
+  const doc = `
+    name: project-name
+    workflows:
+      - name: workflow-one
+      - name: workflow-two
+    `;
+
+  const results = parseAndValidate(doc);
+
+  const err = findError(results.errors, 'workflows: must be a map');
+
+  t.truthy(err);
+  t.is(err.path, 'workflows');
+});
+
+test('Workflows must have unique ids', (t) => {
+  const doc = `
+    name: project-name
+    workflows:
+      workflow-one:
+        name: workflow one
+      workflow-one:
+        name: workflow two
+      workflow-three:
+        name: workflow three
   `;
 
-  let results = parseAndValidate(doc);
+  const results = parseAndValidate(doc);
 
-  t.truthy(
-    results.errors.find((e) => e.message === 'workflows: must be a map')
-  );
+  const err = findError(results.errors, 'duplicate key: workflow-one');
+  t.truthy(err);
+  t.is(err.path, 'workflow-one');
+});
 
-  // disallow two workflows with same name
-  doc = `
-name: project-name
-workflows:
-  workflow-one:
-    name: workflow one
-  workflow-one:
-    name: workflow two
-    jobs:
-      foo:
-  workflow-three:
-    name: workflow three
-    jobs:
-      foo:
-  workflow-four:
-    jobs:
-      - 1
-      - 2
+test('Jobs must have unique ids within a workflow', (t) => {
+  const doc = `
+    name: project-name
+    workflows:
+      workflow-two:
+        name: workflow two
+        jobs:
+          foo:
+          foo:
+          bar:
+    `;
+
+  const results = parseAndValidate(doc);
+
+  const err = findError(results.errors, 'duplicate key: foo');
+  t.is(err.path, 'workflow-two/foo');
+  t.truthy(err);
+});
+
+test('Job ids can duplicate across workflows', (t) => {
+  const doc = `
+    name: project-name
+    workflows:
+      workflow-one:
+        name: workflow one
+        jobs:
+          foo:
+      workflow-two:
+        name: workflow two
+        jobs:
+          foo:
+    `;
+
+  const results = parseAndValidate(doc);
+
+  t.is(results.errors.length, 0);
+});
+
+test('Workflow edges are parsed correctly', (t) => {
+  const doc = `
+    name: project-name
+    workflows:
+      workflow-one:
+        name: workflow one
+        jobs:
+          Transform-data-to-FHIR-standard:
+            name: Transform data to FHIR standard
+            adaptor: '@openfn/language-http@latest'
+            body: |
+              fn(state => state);
+
+        triggers:
+          webhook:
+            type: webhook
+            enabled: true
+        edges:
+          webhook->Transform-data-to-FHIR-standard:
+            condition_type: js_expression
+            condition_expression: true
   `;
 
-  results = parseAndValidate(doc);
-
-  t.truthy(findError(results.errors, 'duplicate key: workflow-one')); 
-
-  t.truthy(findError(results.errors, 'jobs: must be a map'));
-  
-  // disallow two jobs of the same name in the same workflow
-  doc = `
-name: project-name
-workflows:
-  workflow-one:
-    name: workflow one
-  workflow-two:
-    name: workflow two
-    jobs:
-      foo:
-      foo:
-  workflow-three:
-    name: workflow three
-    jobs:
-      bar:
-  `;
-
-  results = parseAndValidate(doc);
-
-  t.truthy(findError(results.errors, 'duplicate key: foo'));
-
-  doc = `
-name: project-name
-workflows:
-  workflow-one:
-    name: workflow one
-    jobs:
-      Transform-data-to-FHIR-standard:
-        name: Transform data to FHIR standard
-        adaptor: '@openfn/language-http@latest'
-        body: |
-          fn(state => state);
-
-    triggers:
-      webhook:
-        type: webhook
-        enabled: true
-    edges:
-      webhook->Transform-data-to-FHIR-standard:
-        condition_type: js_expression
-        condition_expression: true
-  `;
-
-  results = parseAndValidate(doc);
+  const results = parseAndValidate(doc);
 
   t.assert(
     results.doc.workflows['workflow-one'].edges![
@@ -97,18 +110,17 @@ workflows:
   );
 });
 
-
 test('allow empty workflows', (t) => {
   let doc = `
-name: project-name
+    name: project-name
   `;
 
-  let result = parseAndValidate(doc);
+  const result = parseAndValidate(doc);
 
-  t.is(result.errors.length, 0)
+  t.is(result.errors.length, 0);
 
   t.deepEqual(result.doc, {
     name: 'project-name',
-    workflows: {}
-  })
+    workflows: {},
+  });
 });

--- a/packages/deploy/test/validator.test.ts
+++ b/packages/deploy/test/validator.test.ts
@@ -35,7 +35,7 @@ test('Workflows must have unique ids', (t) => {
 
   const results = parseAndValidate(doc);
 
-  const err = findError(results.errors, 'duplicate key: workflow-one');
+  const err = findError(results.errors, 'duplicate id: workflow-one');
   t.truthy(err);
   t.is(err.path, 'workflow-one');
 });
@@ -54,7 +54,7 @@ test('Jobs must have unique ids within a workflow', (t) => {
 
   const results = parseAndValidate(doc);
 
-  const err = findError(results.errors, 'duplicate key: foo');
+  const err = findError(results.errors, 'duplicate id: foo');
   t.is(err.path, 'workflow-two/foo');
   t.truthy(err);
 });


### PR DESCRIPTION
I'm trying to improve the error messaging when validating project.yaml files

So far I've not been able to make much improvement actually. I think the problems are coming out of the native yaml parser and we're not doing a good job of reporting those.

I've also managed to introduce lots of random errors by indenting the yaml at various places. these trigger blowups without any useful context. Not really sure what to do about these yet.

This might be a much bigger deal than I first thought

Maybe closes OpenFn/lightning#2140

Implementation notes:

* I've refactored the validation tests
* I've refactored "duplicate key" to "duplicate id", which is more user friendly
* I'm ensuring a simple string path on an error object (this may wrong, I may have to revert to an array for consistency with the yaml validator)