### PR TITLE
Engine: support multiple inputs to a step

### DIFF
--- a/integration-tests/cli/test/errors.test.ts
+++ b/integration-tests/cli/test/errors.test.ts
@@ -106,21 +106,6 @@ test.serial('circular workflow', async (t) => {
   t.regex(error.message[0].message, /circular dependency: b <-> a/i);
 });
 
-test.serial('multiple inputs', async (t) => {
-  const { stdout, err } = await run(
-    `openfn ${jobsPath}/multiple-inputs.json --log-json`
-  );
-  t.is(err.code, 1);
-
-  const stdlogs = extractLogs(stdout);
-
-  assertLog(t, stdlogs, /Error validating execution plan/i);
-  assertLog(t, stdlogs, /Workflow failed/i);
-
-  const error = stdlogs.find((l) => l.message[0].name === 'ValidationError');
-  t.regex(error.message[0].message, /multiple dependencies detected for: c/i);
-});
-
 test.serial('invalid start on workflow (not found)', async (t) => {
   const { stdout, err } = await run(
     `openfn ${jobsPath}/invalid-start.json --log-json`

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/integration-tests-worker
 
+## 1.0.46
+
+### Patch Changes
+
+- @openfn/engine-multi@1.1.9
+- @openfn/lightning-mock@2.0.9
+- @openfn/ws-worker@1.1.11
+
 ## 1.0.45
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.45",
+  "version": "1.0.46",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 1.3.2
+
+### Patch Changes
+
+- Enable a step to have multiple inputs
+- Updated dependencies
+  - @openfn/runtime@1.2.0
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # engine-multi
 
+## 1.1.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/runtime@1.2.0
+
 ## 1.1.8
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/lightning-mock
 
+## 2.0.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/runtime@1.2.0
+  - @openfn/engine-multi@1.1.9
+
 ## 2.0.8
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/runtime
 
+## 1.2.0
+
+### Minor Changes
+
+- Enable a step to have multiple inputs
+
 ## 1.1.3
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Job processing runtime.",
   "type": "module",
   "exports": {

--- a/packages/runtime/src/execute/plan.ts
+++ b/packages/runtime/src/execute/plan.ts
@@ -65,8 +65,8 @@ const executePlan = async (
 
     const step = workflow.steps[stepName];
 
-    if (!counts[stepName]) {
-      counts[stepName] = 1;
+    if (isNaN(counts[stepName])) {
+      counts[stepName] = 0;
     } else {
       counts[stepName] += 1;
     }
@@ -74,7 +74,7 @@ const executePlan = async (
     // create a unique step id
     // leave the first step as just the step name to preserve legacy stuff
     const stepId =
-      counts[stepName] === 1 ? stepName : `${step.id}-${counts[stepName]}`;
+      counts[stepName] === 0 ? stepName : `${step.id}-${counts[stepName]}`;
 
     const result = await executeStep(ctx, step, prevState);
 

--- a/packages/runtime/src/execute/step.ts
+++ b/packages/runtime/src/execute/step.ts
@@ -90,7 +90,6 @@ const executeStep = async (
   let result: any = input;
   let next: string[] = [];
   let didError = false;
-
   if (step.expression) {
     const job = step as Job;
     const jobId = job.id!;

--- a/packages/runtime/src/util/validate-plan.ts
+++ b/packages/runtime/src/util/validate-plan.ts
@@ -15,7 +15,6 @@ export default (plan: ExecutionPlan) => {
 
   const model = buildModel(plan);
   assertNoCircularReferences(model);
-  assertSingletonDependencies(model);
 
   return true;
 };
@@ -102,18 +101,5 @@ const assertNoCircularReferences = (model: Model) => {
   for (const id in model) {
     search(id, id, 'down');
     search(id, id, 'up'); // TODO do we even need to do this?
-  }
-};
-
-// This ensures that each step only has a single upstream edge,
-// ie, each step only has a single input
-// This is importand for the `--cache` functionality in the CLI,
-// which assumes this rule when working out the input to a custom start node
-const assertSingletonDependencies = (model: Model) => {
-  for (const id in model) {
-    const node = model[id];
-    if (Object.keys(node.up).length > 1) {
-      throw new ValidationError(`Multiple dependencies detected for: ${id}`);
-    }
   }
 };

--- a/packages/runtime/test/execute/plan.test.ts
+++ b/packages/runtime/test/execute/plan.test.ts
@@ -437,7 +437,7 @@ test('Return multiple results for leaf step that executes multiple times', async
   const result = await executePlan(plan, {}, {}, mockLogger);
   t.deepEqual(result, {
     x: ['data', 'a', 'configuration'],
-    'x-2': ['data', 'b', 'configuration'],
+    'x-1': ['data', 'b', 'configuration'],
   });
 });
 
@@ -489,7 +489,7 @@ test('Downstream nodes get executed multiple times', async (t) => {
   t.is(callCount, 2);
   t.deepEqual(result, {
     y: ['data', 'a', 'x', 'configuration'],
-    'y-2': ['data', 'b', 'x', 'configuration'],
+    'y-1': ['data', 'b', 'x', 'configuration'],
   });
 });
 

--- a/packages/runtime/test/util/validate-plan.test.ts
+++ b/packages/runtime/test/util/validate-plan.test.ts
@@ -86,7 +86,7 @@ test('throws for an indirect circular dependency', (t) => {
   });
 });
 
-test('throws for a multiple inputs', (t) => {
+test('allows for a multiple inputs', (t) => {
   const plan: ExecutionPlan = {
     options: {},
     workflow: {
@@ -99,9 +99,8 @@ test('throws for a multiple inputs', (t) => {
     },
   };
 
-  t.throws(() => validate(plan), {
-    message: 'Multiple dependencies detected for: z',
-  });
+  validate(plan);
+  t.pass();
 });
 
 test('throws for a an unknown job', (t) => {

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # ws-worker
 
+## 1.1.11
+
+### Patch Changes
+
+- Enable a step to have multiple inputs
+- Updated dependencies
+  - @openfn/runtime@1.2.0
+  - @openfn/engine-multi@1.1.9
+
 ## 1.1.10
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
This PR enables the runtime call each step multiple times.

Each time a step is called, it passes its output to any downstream steps, and so the downstream steps are run multiple times.

It basically treats a repeated step as if it were a unique step in the workflow. So if step `x` is run twice, the runtime basically runs `x-0` and `x-1` as if there were defined on the plan. Note that actually call `x-0` `x`, because otherwise 8 million tests break. And I think it's a bit cleaner?

## Issue

Closes #698

## Changes

* Removed a validation step that looks for steps with multiple inputs and throws
* Adjust the core runtime to ensure that a step can have multiple inputs AND outputs
* Update unit tests

## Important Behavioural notes

These are the rules of this feature:

* Execution is in SERIES and BREADTH FIRST. If start goes to a and b, and a and b go to x, the execution order is `start -> a -> b -> x -> x`
* State is isolated between steps. So when x is called twice, it is with two different state objects. This is what you want, but might not be what you expect. You cannot aggregate stuff in x.
* If a leaf node runs multiple times, each output will be given a unique id
* A leaf node which returns no state is ignored
* If run ends with only a single leaf step returning state, that state will be the run output. So the output will be like `{ data: {} }`
* If a run end with multiple leaf steps returning state, each step will report its own output (this includes one step returning multiple outputs). So the output will be like `{ a: { data: {}, b: { data: {}, 'b-1': { data: {} } }`