### PR TITLE
CLI: allow file paths for state and data in a workflow

### DIFF
--- a/ava.config.js
+++ b/ava.config.js
@@ -13,5 +13,5 @@ module.exports = {
     '--experimental-vm-modules',
   ],
 
-  files: ['test/**/*test.ts'],
+  files: ['test/util/*test.ts'],
 };

--- a/ava.config.js
+++ b/ava.config.js
@@ -13,5 +13,5 @@ module.exports = {
     '--experimental-vm-modules',
   ],
 
-  files: ['test/util/*test.ts'],
+  files: ['test/**/*test.ts'],
 };

--- a/packages/cli/src/util/load-plan.ts
+++ b/packages/cli/src/util/load-plan.ts
@@ -19,7 +19,6 @@ const loadPlan = async (
     | 'adaptors'
     | 'baseDir'
     | 'expandAdaptors'
-    | 'statePath'
   >,
   logger: Logger
 ): Promise<ExecutionPlan> => {
@@ -224,7 +223,6 @@ const importExpressions = async (
       );
       job.configuration = JSON.parse(configString!);
     }
-
     if (stateStr && isPath(stateStr)) {
       const stateString = await fetchFile(
         job.id || `${idx}`,

--- a/packages/cli/src/util/load-plan.ts
+++ b/packages/cli/src/util/load-plan.ts
@@ -232,17 +232,6 @@ const importExpressions = async (
       );
       job.state = JSON.parse(stateString!);
     }
-
-    const state = job.state
-    if (typeof state === 'object' && state !== null) {
-      const keys = Object.keys(state);
-      for (const key of keys) {
-        if (typeof state[key] === 'string' && isPath(state[key])) {
-          const fileContent = await fetchFile(job.id || `${idx}`, rootDir, state[key], log);
-          state[key] = JSON.parse(fileContent);
-        }
-      }
-    }
   }
 };
 

--- a/packages/cli/test/util/load-plan.test.ts
+++ b/packages/cli/test/util/load-plan.test.ts
@@ -48,7 +48,7 @@ test.serial('expression: load a plan from an expression.js', async (t) => {
     plan: {},
   };
 
-  const plan = await loadPlan(opts as Opts, logger);
+  const plan = await loadPlan(opts as unknown as Opts, logger);
 
   t.truthy(plan);
   t.deepEqual(plan.options, {});
@@ -118,7 +118,7 @@ test.serial('xplan: load a plan from workflow path', async (t) => {
     plan: {},
   };
 
-  const plan = await loadPlan(opts as Opts, logger);
+  const plan = await loadPlan(opts as unknown as Opts, logger);
 
   t.truthy(plan);
   t.deepEqual(plan, sampleXPlan);
@@ -143,7 +143,7 @@ test.serial('xplan: expand adaptors', async (t) => {
     'test/wf.json': JSON.stringify(plan),
   });
 
-  const result = await loadPlan(opts as Opts, logger);
+  const result = await loadPlan(opts as unknown as Opts, logger);
   t.truthy(result);
 
   const step = result.workflow.steps[0] as Job;
@@ -169,7 +169,7 @@ test.serial('xplan: do not expand adaptors', async (t) => {
     'test/wf.json': JSON.stringify(plan),
   });
 
-  const result = await loadPlan(opts as Opts, logger);
+  const result = await loadPlan(opts as unknown as Opts, logger);
   t.truthy(result);
 
   const step = result.workflow.steps[0] as Job;
@@ -197,7 +197,7 @@ test.serial('xplan: set timeout from CLI', async (t) => {
     'test/wf.json': JSON.stringify(plan),
   });
 
-  const { options } = await loadPlan(opts as Opts, logger);
+  const { options } = await loadPlan(opts as unknown as Opts, logger);
   t.is(options.timeout, 666);
 });
 
@@ -222,7 +222,7 @@ test.serial('xplan: set start from CLI', async (t) => {
     'test/wf.json': JSON.stringify(plan),
   });
 
-  const { options } = await loadPlan(opts as Opts, logger);
+  const { options } = await loadPlan(opts as unknown as Opts, logger);
   t.is(options.start, 'b');
 });
 
@@ -259,7 +259,7 @@ test.serial('old-workflow: load a plan from workflow path', async (t) => {
     plan: {},
   };
 
-  const plan = await loadPlan(opts as Opts, logger);
+  const plan = await loadPlan(opts as unknown as Opts, logger);
 
   t.deepEqual(plan.options, {
     start: 'a',
@@ -269,5 +269,37 @@ test.serial('old-workflow: load a plan from workflow path', async (t) => {
   t.deepEqual(plan.workflow.steps[0], {
     id: 'a',
     expression: 'x()',
+  });
+});
+
+test.serial('step: allow file paths for state and data', async (t) => {
+  const opts = {
+    workflowPath: 'test/wf.json',
+    plan: {},
+  };
+
+  const plan = createPlan([
+    {
+      id: 'a',
+      expression: '.',
+      state: './state.json',
+    },
+  ]);
+
+  mock({
+    'test/data.json': JSON.stringify({ x: 1 }),
+    'test/state.json': JSON.stringify({
+      data: "./data.json"
+    }),
+    'test/wf.json': JSON.stringify(plan),
+  });
+  const result = await loadPlan(opts as unknown as Opts, logger);
+  t.truthy(result);
+
+  const step = result.workflow.steps[0] as Job;
+  t.deepEqual(step.state, {
+    data: {
+      x: 1
+    }
   });
 });

--- a/packages/cli/test/util/load-plan.test.ts
+++ b/packages/cli/test/util/load-plan.test.ts
@@ -304,34 +304,3 @@ test.serial('step: allow file paths for state', async (t) => {
     }
   });
 });
-
-test.serial('step: allow file paths for data', async (t) => {
-  const opts = {
-    workflowPath: 'test/wf.json',
-    plan: {},
-  };
-
-  const plan = createPlan([
-    {
-      id: 'a',
-      expression: '.',
-      state: {
-        data: "./data.json"
-      },
-    },
-  ]);
-
-  mock({
-    'test/data.json': JSON.stringify({ x: 1 }),
-    'test/wf.json': JSON.stringify(plan),
-  });
-  const result = await loadPlan(opts, logger);
-  t.truthy(result);
-
-  const step = result.workflow.steps[0] as Job;
-  t.deepEqual(step.state, {
-    data: {
-      x: 1
-    }
-  });
-});

--- a/packages/cli/test/util/load-plan.test.ts
+++ b/packages/cli/test/util/load-plan.test.ts
@@ -48,7 +48,7 @@ test.serial('expression: load a plan from an expression.js', async (t) => {
     plan: {},
   };
 
-  const plan = await loadPlan(opts as unknown as Opts, logger);
+  const plan = await loadPlan(opts, logger);
 
   t.truthy(plan);
   t.deepEqual(plan.options, {});
@@ -118,7 +118,7 @@ test.serial('xplan: load a plan from workflow path', async (t) => {
     plan: {},
   };
 
-  const plan = await loadPlan(opts as unknown as Opts, logger);
+  const plan = await loadPlan(opts, logger);
 
   t.truthy(plan);
   t.deepEqual(plan, sampleXPlan);
@@ -143,7 +143,7 @@ test.serial('xplan: expand adaptors', async (t) => {
     'test/wf.json': JSON.stringify(plan),
   });
 
-  const result = await loadPlan(opts as unknown as Opts, logger);
+  const result = await loadPlan(opts, logger);
   t.truthy(result);
 
   const step = result.workflow.steps[0] as Job;
@@ -169,7 +169,7 @@ test.serial('xplan: do not expand adaptors', async (t) => {
     'test/wf.json': JSON.stringify(plan),
   });
 
-  const result = await loadPlan(opts as unknown as Opts, logger);
+  const result = await loadPlan(opts, logger);
   t.truthy(result);
 
   const step = result.workflow.steps[0] as Job;
@@ -197,7 +197,7 @@ test.serial('xplan: set timeout from CLI', async (t) => {
     'test/wf.json': JSON.stringify(plan),
   });
 
-  const { options } = await loadPlan(opts as unknown as Opts, logger);
+  const { options } = await loadPlan(opts, logger);
   t.is(options.timeout, 666);
 });
 
@@ -222,7 +222,7 @@ test.serial('xplan: set start from CLI', async (t) => {
     'test/wf.json': JSON.stringify(plan),
   });
 
-  const { options } = await loadPlan(opts as unknown as Opts, logger);
+  const { options } = await loadPlan(opts, logger);
   t.is(options.start, 'b');
 });
 
@@ -259,7 +259,7 @@ test.serial('old-workflow: load a plan from workflow path', async (t) => {
     plan: {},
   };
 
-  const plan = await loadPlan(opts as unknown as Opts, logger);
+  const plan = await loadPlan(opts, logger);
 
   t.deepEqual(plan.options, {
     start: 'a',
@@ -272,7 +272,7 @@ test.serial('old-workflow: load a plan from workflow path', async (t) => {
   });
 });
 
-test.serial('step: allow file paths for state and data', async (t) => {
+test.serial('step: allow file paths for state', async (t) => {
   const opts = {
     workflowPath: 'test/wf.json',
     plan: {},
@@ -287,13 +287,45 @@ test.serial('step: allow file paths for state and data', async (t) => {
   ]);
 
   mock({
-    'test/data.json': JSON.stringify({ x: 1 }),
     'test/state.json': JSON.stringify({
-      data: "./data.json"
+      data: {
+        x: 1
+      }
     }),
     'test/wf.json': JSON.stringify(plan),
   });
-  const result = await loadPlan(opts as unknown as Opts, logger);
+  const result = await loadPlan(opts, logger);
+  t.truthy(result);
+
+  const step = result.workflow.steps[0] as Job;
+  t.deepEqual(step.state, {
+    data: {
+      x: 1
+    }
+  });
+});
+
+test.serial('step: allow file paths for data', async (t) => {
+  const opts = {
+    workflowPath: 'test/wf.json',
+    plan: {},
+  };
+
+  const plan = createPlan([
+    {
+      id: 'a',
+      expression: '.',
+      state: {
+        data: "./data.json"
+      },
+    },
+  ]);
+
+  mock({
+    'test/data.json': JSON.stringify({ x: 1 }),
+    'test/wf.json': JSON.stringify(plan),
+  });
+  const result = await loadPlan(opts, logger);
   t.truthy(result);
 
   const step = result.workflow.steps[0] as Job;


### PR DESCRIPTION
## Short Description

Allows the user to add file paths to the `state` and `data` in a workflow. 

## Related issue

Fixes #639 

## Implementation Details

I have added a function that checks if the `state` is a file path. If it is, the function reads the file. Additionally, if the `data` (or any key inside `state`) is a file path, it will read that file and update the key with the file's content.

For example, if we have
`workflow.json`:

```
{
    "workflow": {
        "steps": [
            {
                "id": "1",
                "adaptor": "common",
                "state": "./state.json",
                "expression": "./expression.js"
            }
        ]
    }
}
```
`state.json`:

```
{
    "data":"./data.json"
}
```
`data.json`:

```
{
    "x": 1
}
```

It will compile the workflow as:

```
{
  "workflow": {
    "steps": [
      {
        "id": "1",
        "adaptor": "@openfn/language-common",
        "state": {
          "data": {
            "x": 1
          }
        },
        "expression": "import { fn } from \"@openfn/language-common\";\nexport * from \"@openfn/language-common\";\nexport default [fn((state) => state)];"
      }
    ],
    "name": "input"
  },
  "options": {}
}
```
## QA Notes

Added a test to verify that the file paths are identified, and the file content is successfully copied to the required key. Also tested it locally for different cases.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added unit tests
- [ ] Changesets have been added (if there are production code changes)
