### PR TITLE
Support promises

### DIFF
--- a/.changeset/flat-emus-shout.md
+++ b/.changeset/flat-emus-shout.md
@@ -1,6 +1,0 @@
----
-'@openfn/compiler': minor
----
-
-Add promises transformer
-Don't try and import variables declared in other import statements

--- a/.changeset/flat-emus-shout.md
+++ b/.changeset/flat-emus-shout.md
@@ -1,0 +1,6 @@
+---
+'@openfn/compiler': minor
+---
+
+Add promises transformer
+Don't try and import variables declared in other import statements

--- a/.changeset/late-plants-juggle.md
+++ b/.changeset/late-plants-juggle.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+Allow the linker to directly import some whitelisted packages

--- a/.changeset/late-plants-juggle.md
+++ b/.changeset/late-plants-juggle.md
@@ -1,5 +1,0 @@
----
-'@openfn/runtime': patch
----
-
-Allow the linker to directly import some whitelisted packages

--- a/integration-tests/execute/CHANGELOG.md
+++ b/integration-tests/execute/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @openfn/integration-tests-execute
+
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies [40fd45b]
+- Updated dependencies [40fd45b]
+  - @openfn/compiler@0.2.0
+  - @openfn/runtime@1.4.1

--- a/integration-tests/execute/package.json
+++ b/integration-tests/execute/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@openfn/integration-tests-execute",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Job execution tests",
+  "author": "Open Function Group <admin@openfn.org>",
+  "license": "ISC",
+  "type": "module",
+  "scripts": {
+    "test": "pnpm ava"
+  },
+  "dependencies": {
+    "@openfn/compiler": "workspace:^",
+    "@openfn/language-common": "1.7.7",
+    "@openfn/runtime": "workspace:^",
+    "@types/node": "^18.15.13",
+    "ava": "5.3.1",
+    "date-fns": "^2.30.0",
+    "rimraf": "^3.0.2",
+    "ts-node": "10.8.1",
+    "tslib": "^2.4.0",
+    "typescript": "^5.1.6"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "devDependencies": {
+    "@types/rimraf": "^3.0.2"
+  }
+}

--- a/integration-tests/execute/package.json
+++ b/integration-tests/execute/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-execute",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Job execution tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/integration-tests/execute/package.json
+++ b/integration-tests/execute/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@openfn/compiler": "workspace:^",
     "@openfn/language-common": "1.7.7",
+    "@openfn/language-http": "6.4.0",
     "@openfn/runtime": "workspace:^",
     "@types/node": "^18.15.13",
     "ava": "5.3.1",

--- a/integration-tests/execute/readme.md
+++ b/integration-tests/execute/readme.md
@@ -1,0 +1,5 @@
+This is a suite of examples of jobs.
+
+We don't really have a place where we can just write and test arbtirary job code with compilation.
+
+You can do it through the CLI or worker but they have significant overheads.

--- a/integration-tests/execute/src/execute.ts
+++ b/integration-tests/execute/src/execute.ts
@@ -2,18 +2,18 @@ import path from 'node:path';
 import run from '@openfn/runtime';
 import compiler from '@openfn/compiler';
 
-const execute = async (job: string, state: any) => {
+const execute = async (job: string, state: any, adaptor = 'common') => {
   // compile with common and dumb imports
   const options = {
     'add-imports': {
       adaptor: {
-        name: '@openfn/language-common',
+        name: `@openfn/language-${adaptor}`,
         exportAll: true,
       },
     },
   };
   const compiled = compiler(job, options);
-  console.log(compiled);
+  // console.log(compiled);
 
   const result = await run(compiled, state, {
     // preload the linker with some locally installed modules
@@ -21,6 +21,9 @@ const execute = async (job: string, state: any) => {
       modules: {
         '@openfn/language-common': {
           path: path.resolve('node_modules/@openfn/language-common'),
+        },
+        '@openfn/language-http': {
+          path: path.resolve('node_modules/@openfn/language-http'),
         },
       },
     },

--- a/integration-tests/execute/src/execute.ts
+++ b/integration-tests/execute/src/execute.ts
@@ -1,0 +1,32 @@
+import path from 'node:path';
+import runtime from '@openfn/runtime';
+import compiler from '@openfn/compiler';
+
+const execute = async (job: string, state: any) => {
+  // compile with common and dumb imports
+  const options = {
+    'add-imports': {
+      adaptor: {
+        name: '@openfn/language-common',
+        exportAll: true,
+      },
+    },
+  };
+  const compiled = compiler(job, options);
+  console.log(compiled);
+
+  const result = await runtime(compiled, state, {
+    // preload the linker with some locally installed modules
+    linker: {
+      modules: {
+        '@openfn/language-common': {
+          path: path.resolve('node_modules/@openfn/language-common'),
+        },
+      },
+    },
+  });
+
+  return result;
+};
+
+export default execute;

--- a/integration-tests/execute/src/execute.ts
+++ b/integration-tests/execute/src/execute.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import runtime from '@openfn/runtime';
+import run from '@openfn/runtime';
 import compiler from '@openfn/compiler';
 
 const execute = async (job: string, state: any) => {
@@ -13,9 +13,9 @@ const execute = async (job: string, state: any) => {
     },
   };
   const compiled = compiler(job, options);
-  // console.log(compiled);
+  console.log(compiled);
 
-  const result = await runtime(compiled, state, {
+  const result = await run(compiled, state, {
     // preload the linker with some locally installed modules
     linker: {
       modules: {

--- a/integration-tests/execute/src/execute.ts
+++ b/integration-tests/execute/src/execute.ts
@@ -13,7 +13,7 @@ const execute = async (job: string, state: any) => {
     },
   };
   const compiled = compiler(job, options);
-  console.log(compiled);
+  // console.log(compiled);
 
   const result = await runtime(compiled, state, {
     // preload the linker with some locally installed modules

--- a/integration-tests/execute/src/index.ts
+++ b/integration-tests/execute/src/index.ts
@@ -1,0 +1,3 @@
+import execute from './execute';
+
+export default execute;

--- a/integration-tests/execute/test/execute.test.ts
+++ b/integration-tests/execute/test/execute.test.ts
@@ -13,8 +13,7 @@ test.serial('should return state', async (t) => {
   t.deepEqual(state, result);
 });
 
-// This fails because the compiler can't handle it
-test.serial.skip('should use .then()', async (t) => {
+test.serial('should use .then()', async (t) => {
   const state = { data: { x: 1 } };
 
   const job = `
@@ -27,5 +26,21 @@ test.serial.skip('should use .then()', async (t) => {
   `;
   const result = await execute(job, state);
 
-  t.deepEqual(state, { data: { x: 33 } });
+  t.deepEqual(result, { data: { x: 33 } });
+});
+
+test.serial('should chain .then() with state', async (t) => {
+  const state = { data: { x: 1 } };
+
+  const job = `
+    fn(s => ({ x: 1 }))
+      .then((s) =>
+        ({
+          x: s.x + 1
+        })
+      )
+  `;
+  const result = await execute(job, state);
+
+  t.deepEqual(result, { x: 2 });
 });

--- a/integration-tests/execute/test/execute.test.ts
+++ b/integration-tests/execute/test/execute.test.ts
@@ -1,0 +1,31 @@
+import test from 'ava';
+
+import execute from '../src/execute';
+
+test.serial('should return state', async (t) => {
+  const state = { data: { x: 1 } };
+
+  const job = `
+    fn(s => s)
+  `;
+  const result = await execute(job, state);
+
+  t.deepEqual(state, result);
+});
+
+// This fails because the compiler can't handle it
+test.serial.skip('should use .then()', async (t) => {
+  const state = { data: { x: 1 } };
+
+  const job = `
+    fn(s => s)
+      .then((s) =>
+        ({
+          data: { x: 33 }
+        })
+      )
+  `;
+  const result = await execute(job, state);
+
+  t.deepEqual(state, { data: { x: 33 } });
+});

--- a/integration-tests/execute/test/execute.test.ts
+++ b/integration-tests/execute/test/execute.test.ts
@@ -44,3 +44,14 @@ test.serial('should chain .then() with state', async (t) => {
 
   t.deepEqual(result, { x: 2 });
 });
+
+test.serial('should use .then() as an argument', async (t) => {
+  const state = {};
+
+  const job = `fn(
+    fn(() => ({ x: 5 })).then((s) => ({ x: s.x + 1}))
+  )`;
+  const result = await execute(job, state);
+
+  t.deepEqual(result, { x: 6 });
+});

--- a/integration-tests/execute/test/execute.test.ts
+++ b/integration-tests/execute/test/execute.test.ts
@@ -108,6 +108,21 @@ test.serial('catch an error and re-throw it', async (t) => {
   t.is(result.errors['job-1'].type, 'JobError');
 });
 
+test.serial('catch an error and return state', async (t) => {
+  const state = {
+    data: {
+      x: 22,
+    },
+  };
+
+  const job = `fn(() => {
+    throw { err: true }
+  }).catch((e, s) => s)`;
+
+  const result = await execute(job, state);
+  t.deepEqual(result, state);
+});
+
 test.serial('each with then ', async (t) => {
   const state = {
     ids: [1, 2, 3],

--- a/integration-tests/execute/test/execute.test.ts
+++ b/integration-tests/execute/test/execute.test.ts
@@ -101,11 +101,12 @@ test.serial('catch an error and re-throw it', async (t) => {
   };
 
   const job = `fn(() => {
-    throw { err: true }
+    throw new Error('err')
   }).catch(e => { throw e })`;
 
   const result = await execute(job, state);
-  t.is(result.errors['job-1'].type, 'JobError');
+  t.is(result.errors['job-1'].name, 'JobError');
+  t.is(result.errors['job-1'].message, 'err');
 });
 
 test.serial('catch an error and return state', async (t) => {

--- a/integration-tests/execute/test/execute.test.ts
+++ b/integration-tests/execute/test/execute.test.ts
@@ -2,6 +2,13 @@ import test from 'ava';
 
 import execute from '../src/execute';
 
+const wait = `function wait() {
+  return (state) =>
+    new Promise((resolve) => {
+      setTimeout(() => resolve(state), 2);
+    });
+};`;
+
 test.serial('should return state', async (t) => {
   const state = { data: { x: 1 } };
 
@@ -54,4 +61,34 @@ test.serial('should use .then() as an argument', async (t) => {
   const result = await execute(job, state);
 
   t.deepEqual(result, { x: 6 });
+});
+
+test.serial('use then() with wait()', async (t) => {
+  const state = {
+    data: {
+      x: 22,
+    },
+  };
+
+  const job = `${wait}
+  wait().then(fn(s => s))`;
+
+  const result = await execute(job, state);
+
+  t.deepEqual(result.data, { x: 22 });
+});
+
+test.serial('catch an error and return it', async (t) => {
+  const state = {
+    data: {
+      x: 22,
+    },
+  };
+
+  const job = `fn(() => {
+    throw { err: true }
+  }).catch(e => e)`;
+
+  const result = await execute(job, state);
+  t.deepEqual(result, { err: true });
 });

--- a/integration-tests/execute/tsconfig.json
+++ b/integration-tests/execute/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "ts-node": {
+    "experimentalSpecifierResolution": "node"
+  },
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  }
+}

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openfn/integration-tests-worker
 
+## 1.0.51
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/engine-multi@1.2.0
+  - @openfn/ws-worker@1.4.0
+  - @openfn/lightning-mock@2.0.14
+
 ## 1.0.50
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @openfn/cli
 
+## 1.7.0
+
+### Minor Changes
+
+- Allow operations to behave like promises (ie, support fn().then())
+
+### Patch Changes
+
+- Updated dependencies [40fd45b]
+- Updated dependencies [40fd45b]
+  - @openfn/compiler@0.2.0
+  - @openfn/runtime@1.4.1
+
 ## 1.6.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/compiler
 
+## 0.2.0
+
+### Minor Changes
+
+- 40fd45b: Add promises transformer
+  Don't try and import variables declared in other import statements
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/compiler",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Compiler and language tooling for openfn jobs.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -6,6 +6,7 @@ import createLogger, { Logger } from '@openfn/logger';
 import addImports, { AddImportsOptions } from './transforms/add-imports';
 import ensureExports from './transforms/ensure-exports';
 import lazyState from './transforms/lazy-state';
+import promises from './transforms/promises';
 import topLevelOps, {
   TopLevelOpsOptions,
 } from './transforms/top-level-operations';
@@ -38,6 +39,7 @@ export type TransformOptions = {
   ['top-level-operations']?: TopLevelOpsOptions | boolean;
   ['test']?: any;
   ['lazy-state']?: any;
+  ['promises']?: any;
 };
 
 const defaultLogger = createLogger();
@@ -50,6 +52,7 @@ export default function transform(
   if (!transformers) {
     transformers = [
       lazyState,
+      promises,
       ensureExports,
       topLevelOps,
       addImports,

--- a/packages/compiler/src/transforms/add-imports.ts
+++ b/packages/compiler/src/transforms/add-imports.ts
@@ -108,6 +108,11 @@ export function findAllDanglingIdentifiers(ast: ASTNode) {
   const result: IdentifierList = {};
   visit(ast, {
     visitIdentifier: function (path) {
+      // If this is part of an import statement, do nothing
+      if (n.ImportSpecifier.check(path.parent.node)) {
+        return false;
+      }
+
       // undefined and NaN are treated as a regular identifier
       if (path.node.name === 'undefined' || path.node.name === 'NaN') {
         return false;

--- a/packages/compiler/src/transforms/promises.ts
+++ b/packages/compiler/src/transforms/promises.ts
@@ -1,3 +1,8 @@
+import * as acorn from 'acorn';
+import { namedTypes as n, builders as b } from 'ast-types';
+
+import type { NodePath } from 'ast-types/lib/node-path';
+
 type State = any;
 
 // Defer will take an operation with a promise chain
@@ -29,14 +34,102 @@ export function defer(
   };
 }
 
+const assertDeferDeclaration = (program: NodePath<n.Program>) => {
+  for (const node of program.node.body) {
+    if (n.FunctionDeclaration.check(node)) {
+      if (node.id.name === 'defer') {
+        return true;
+      }
+    }
+  }
+
+  throw new Error('No defer declaration found');
+};
+
 const DEFER_SOURCE = defer.toString();
 
+// TODO only do this once
+const injectDeferFunction = (root: NodePath<n.Program>) => {
+  try {
+    assertDeferDeclaration(root);
+  } catch (e) {
+    const newAST = acorn.parse(DEFER_SOURCE, {
+      sourceType: 'module',
+      ecmaVersion: 10,
+      locations: false,
+    });
 
+    // TODO work out the index of the first none import/export line
+    const idx = -1;
+    root.node.body.splice(idx + 1, 0, ...newAST.body);
+  }
+};
+
+// This function will take a promise chain, a.then(x).catch(y),
+// and convert it into defer(a, x, y)
+export const wrapFn = (expr: NodePath<n.CallExpression>) => {
+  // pull out the callee, then and catch expressions
+
+  // Pull out the the Operation being chained
+  const op = expr.node.callee.object;
+
+  const children = [op];
+
+  // not sure how well this wil scale tbh
+  if (expr.node.callee.property.name === 'then') {
+    children.push(expr.node.arguments[0]);
+  } else if (expr.node.callee.property.name === 'catch') {
+    children.push(b.identifier('undefined'));
+    children.push(expr.node.arguments[0]);
+  }
+
+  const defer = b.callExpression(b.identifier('defer'), children);
+
+  expr.replace(defer);
+
+  return defer;
+};
+
+const isTopScope = (path: NodePath<any>) => {
+  let parent = path.parent;
+  while (parent) {
+    if (n.Program.check(parent)) {
+      return true;
+    }
+    if (
+      n.ArrowFunctionExpression.check(parent) ||
+      n.FunctionDeclaration.check(parent) ||
+      n.FunctionExpression.check(parent) ||
+      n.BlockStatement.check(parent)
+      // TODO more?
+    ) {
+      return false;
+    }
+    parent = parent.parent;
+  }
+  return true;
+};
+
+const visitor = (path: NodePath<n.CallExpression>) => {
+  let root: NodePath<n.Program> = path;
+  while (!n.Program.check(root.node)) {
+    root = root.parent;
+  }
+
+  // any Call expression with then|catch which is not in a nested scope
+  if (
+    path.node.callee.property?.name?.match(/^(then|catch)$/) &&
+    isTopScope(path)
+  ) {
+    injectDeferFunction(root);
+    wrapFn(path);
+  }
+};
 
 export default {
-  id: 'lazy-state',
-  types: ['MemberExpression'],
+  id: 'promises',
+  types: ['CallExpression'],
   visitor,
-  // It's important that $ symbols are escaped before any other transformations can run
+  // this should run before top-level operations are moved into the exports array
   order: 0,
 } as Transformer;

--- a/packages/compiler/src/transforms/promises.ts
+++ b/packages/compiler/src/transforms/promises.ts
@@ -27,7 +27,9 @@ export function defer(
 ) {
   return (state: State) => {
     try {
-      return Promise.resolve(fn(state)).catch(error).then(complete);
+      //return Promise.resolve(fn(state)).catch(error).then(complete);
+
+      return Promise.resolve(fn(state)).then(complete);
     } catch (e) {
       error(e);
     }
@@ -48,7 +50,6 @@ const assertDeferDeclaration = (program: NodePath<n.Program>) => {
 
 const DEFER_SOURCE = defer.toString();
 
-// TODO only do this once
 const injectDeferFunction = (root: NodePath<n.Program>) => {
   try {
     assertDeferDeclaration(root);
@@ -67,22 +68,90 @@ const injectDeferFunction = (root: NodePath<n.Program>) => {
 
 // This function will take a promise chain, a.then(x).catch(y),
 // and convert it into defer(a, x, y)
+
+// TODO how do I explain this
+/*
+This function will replace a promise chain of the form
+
+op().then().then()
+
+With a defer function call, which breaks the operation and promise chain into two parts
+
+defer(op(), p => p.then().then())
+
+defer will lazily resolve the operation,then feed the result into the promise chain in the second argument
+
+*/
+
 export const wrapFn = (expr: NodePath<n.CallExpression>) => {
   // pull out the callee, then and catch expressions
 
   // Pull out the the Operation being chained
-  const op = expr.node.callee.object;
 
-  const children = [op];
-
-  // not sure how well this wil scale tbh
-  if (expr.node.callee.property.name === 'then') {
-    children.push(expr.node.arguments[0]);
-  } else if (expr.node.callee.property.name === 'catch') {
-    children.push(b.identifier('undefined'));
-    children.push(expr.node.arguments[0]);
+  // We've just been handed something like looks like an operation with a promise chain
+  // ie, op().then().then()
+  // Walk down the call expression tree until we find the operation that's originally called
+  let op: NodePath<n.CallExpression>;
+  let next = expr;
+  while (next) {
+    if (n.Identifier.check(next.node.callee)) {
+      op = next;
+      break;
+    }
+    if (
+      n.MemberExpression.check(next.node.callee) &&
+      !next.node.callee.property.name?.match(/^(then|catch)$/)
+    ) {
+      op = next;
+      break;
+    } else {
+      next = next.get('callee', 'object');
+    }
   }
 
+  // Save the parent then/catch exp
+  // ALWAYs move the op
+  // if the parent is a catch, take the function and add it as the third arg, then remove the catch
+  // now carry on with whatever is left in the chain
+
+  // Build the arguments to the defer array (TODO, rename deferArgs)
+  const children = [op.node];
+  let catchFn;
+
+  if (op.parent.node.property?.name === 'catch') {
+    //  If there's a catch adjacent to the operation, we need to handle that a bit differently
+    catchFn = op.parent.parent.node.arguments[0];
+  }
+
+  // In the promise chain, replace the operation call with `p`, a promise
+  op.replace(b.identifier('p'));
+
+  if (catchFn) {
+    // remove the catch from the tree
+
+    // TODO if there's a catch.then(), if if there's more than the catch
+    // then I need to prune the catch and rebuild the remaining chain from p
+    // op.parent.parent.prune();
+
+    // Otherwise, I need to force the expressuion to be undefined
+    children.push(b.identifier('undefined'));
+
+    // if there's something left, we have to graft p onto it
+  }
+
+  // What I'd like to do here is say: if there's still a then() chain,
+  // add it as the second argument
+  // Otherwise, add undefined
+  if (!catchFn) {
+    const chain = b.arrowFunctionExpression([b.identifier('p')], expr.node);
+    if (chain) {
+      children.push(chain);
+    }
+  }
+
+  if (catchFn) {
+    children.push(catchFn);
+  }
   const defer = b.callExpression(b.identifier('defer'), children);
 
   expr.replace(defer);
@@ -123,6 +192,8 @@ const visitor = (path: NodePath<n.CallExpression>) => {
   ) {
     injectDeferFunction(root);
     wrapFn(path);
+    // do not traverse this tree
+    return true;
   }
 };
 

--- a/packages/compiler/src/transforms/promises.ts
+++ b/packages/compiler/src/transforms/promises.ts
@@ -14,16 +14,16 @@ type State = any;
 // maybe later update tsconfig
 export function defer(
   fn: (s: State) => State,
-  complete = (s: State) => s,
+  complete = (p: Promise<any>) => p,
   error = (e: any): void => {
     throw e;
   }
 ) {
   return (state: State) => {
     try {
-      return Promise.resolve(fn(state)).then(complete).catch(error);
+      return complete(Promise.resolve(fn(state)).catch(error));
     } catch (e) {
-      error(e);
+      return error(e);
     }
   };
 }

--- a/packages/compiler/src/transforms/promises.ts
+++ b/packages/compiler/src/transforms/promises.ts
@@ -25,7 +25,7 @@ export const assertDeferDeclaration = (
 const injectDeferImport = (root: NodePath<n.Program>) => {
   try {
     assertDeferDeclaration(root);
-  } catch (e) {
+  } catch (e: any) {
     if (e.message === NO_DEFER_DECLARATION_ERROR) {
       const i = b.importDeclaration(
         [b.importSpecifier(b.identifier('defer'), b.identifier('_defer'))],
@@ -65,7 +65,7 @@ export const rebuildPromiseChain = (expr: NodePath<n.CallExpression>) => {
     }
     if (
       n.MemberExpression.check(next.node.callee) &&
-      !next.node.callee.property.name?.match(/^(then|catch)$/)
+      !(next.node.callee.property as any).name?.match(/^(then|catch)$/)
     ) {
       op = next;
       break;
@@ -146,14 +146,14 @@ const isTopScope = (path: NodePath<any>) => {
 };
 
 const visitor = (path: NodePath<n.CallExpression>) => {
-  let root: NodePath<n.Program> = path;
+  let root: NodePath<any> = path;
   while (!n.Program.check(root.node)) {
     root = root.parent;
   }
 
   // any Call expression with then|catch which is not in a nested scope
   if (
-    path.node.callee.property?.name?.match(/^(then|catch)$/) &&
+    (path.node.callee as any).property?.name?.match(/^(then|catch)$/) &&
     isTopScope(path)
   ) {
     injectDeferImport(root);

--- a/packages/compiler/src/transforms/promises.ts
+++ b/packages/compiler/src/transforms/promises.ts
@@ -1,0 +1,42 @@
+type State = any;
+
+// Defer will take an operation with a promise chain
+// and break it up into a deferred function call which
+// ensures the operation is a promise
+// eg, fn().then(s => s)
+// TODO what about
+// eg, fn().then(s => s).then(s => s)
+
+// TODO not a huge fan of how this stringifies
+// maybe later update tsconfig
+
+// TODO if the complete function errors, what do we do?
+// This should Just Work right?
+// eg, fn().then(s => s).catch()
+export function defer(
+  fn: (s: State) => State,
+  complete = (s: State) => s,
+  error = (e: any): void => {
+    throw e;
+  }
+) {
+  return (state: State) => {
+    try {
+      return Promise.resolve(fn(state)).catch(error).then(complete);
+    } catch (e) {
+      error(e);
+    }
+  };
+}
+
+const DEFER_SOURCE = defer.toString();
+
+
+
+export default {
+  id: 'lazy-state',
+  types: ['MemberExpression'],
+  visitor,
+  // It's important that $ symbols are escaped before any other transformations can run
+  order: 0,
+} as Transformer;

--- a/packages/compiler/src/transforms/promises.ts
+++ b/packages/compiler/src/transforms/promises.ts
@@ -141,14 +141,14 @@ export const rebuildPromiseChain = (expr: NodePath<n.CallExpression>) => {
 const isTopScope = (path: NodePath<any>) => {
   let parent = path.parent;
   while (parent) {
-    if (n.Program.check(parent)) {
+    if (n.Program.check(parent.node)) {
       return true;
     }
     if (
-      n.ArrowFunctionExpression.check(parent) ||
-      n.FunctionDeclaration.check(parent) ||
-      n.FunctionExpression.check(parent) ||
-      n.BlockStatement.check(parent)
+      n.ArrowFunctionExpression.check(parent.node) ||
+      n.FunctionDeclaration.check(parent.node) ||
+      n.FunctionExpression.check(parent.node) ||
+      n.BlockStatement.check(parent.node)
       // TODO more?
     ) {
       return false;

--- a/packages/compiler/test/compile.test.ts
+++ b/packages/compiler/test/compile.test.ts
@@ -157,32 +157,13 @@ export default [get(state => state.data.endpoint)];`;
 test('compile simple promise chain', (t) => {
   const source =
     'get($.data.endpoint).then((s => { console.log(s.data); return state;} ));';
-  const expected = `function defer(fn, complete, error) {
-  if (complete === void 0) {
-    complete = function(s) {
-      return s;
-    };
-  }
+  const expected = `import { defer as _defer } from "@openfn/runtime";
 
-  if (error === void 0) {
-    error = function(e) {
-      throw e;
-    };
-  }
-
-  return function(state) {
-    try {
-      return Promise.resolve(fn(state)).catch(error).then(complete);
-    } catch (e) {
-      error(e);
-    }
-  };
-}
-
-export default [defer(
+export default [_defer(
   get(state => state.data.endpoint),
-  s => { console.log(s.data); return state;}
+  p => p.then((s => { console.log(s.data); return state;} ))
 )];`;
+
   const result = compile(source);
   t.is(result, expected);
 });

--- a/packages/compiler/test/compile.test.ts
+++ b/packages/compiler/test/compile.test.ts
@@ -157,6 +157,7 @@ export default [get(state => state.data.endpoint)];`;
 test('compile simple promise chain', (t) => {
   const source =
     'get($.data.endpoint).then((s => { console.log(s.data); return state;} ));';
+
   const expected = `import { defer as _defer } from "@openfn/runtime";
 
 export default [_defer(
@@ -182,6 +183,5 @@ export default [each(
 )];`;
 
   const result = compile(source);
-  console.log(result);
   t.is(result, expected);
 });

--- a/packages/compiler/test/compile.test.ts
+++ b/packages/compiler/test/compile.test.ts
@@ -167,3 +167,21 @@ export default [_defer(
   const result = compile(source);
   t.is(result, expected);
 });
+
+test('compile simple promise chain with each', (t) => {
+  const source = `each(
+  "$.data[*]",
+  post("/upsert", (state) => state.data).then((s) => s)
+)`;
+
+  const expected = `import { defer as _defer } from "@openfn/runtime";
+
+export default [each(
+  "$.data[*]",
+  _defer(post("/upsert", (state) => state.data), p => p.then((s) => s))
+)];`;
+
+  const result = compile(source);
+  console.log(result);
+  t.is(result, expected);
+});

--- a/packages/compiler/test/compile.test.ts
+++ b/packages/compiler/test/compile.test.ts
@@ -7,35 +7,35 @@ test('ensure default exports is created', (t) => {
   const source = '';
   const expected = 'export default [];';
   const result = compile(source);
-  t.assert(result === expected);
+  t.is(result, expected);
 });
 
 test('do not add default exports if exports exist', (t) => {
   const source = 'export const x = 10;';
   const expected = 'export const x = 10;';
   const result = compile(source);
-  t.assert(result === expected);
+  t.is(result, expected);
 });
 
 test('compile a single operation', (t) => {
   const source = 'fn();';
   const expected = 'export default [fn()];';
   const result = compile(source);
-  t.assert(result === expected);
+  t.is(result, expected);
 });
 
 test('compile a single operation without being fussy about semicolons', (t) => {
   const source = 'fn()';
   const expected = 'export default [fn()];';
   const result = compile(source);
-  t.assert(result === expected);
+  t.is(result, expected);
 });
 
 test('compile multiple operations', (t) => {
   const source = 'fn();fn();fn();';
   const expected = 'export default [fn(), fn(), fn()];';
   const result = compile(source);
-  t.assert(result === expected);
+  t.is(result, expected);
 });
 
 test('add imports', (t) => {
@@ -50,7 +50,7 @@ test('add imports', (t) => {
   const source = 'fn();';
   const expected = `import { fn } from "@openfn/language-common";\nexport default [fn()];`;
   const result = compile(source, options);
-  t.assert(result === expected);
+  t.is(result, expected);
 });
 
 test('do not add imports', (t) => {
@@ -66,7 +66,7 @@ test('do not add imports', (t) => {
   const source = "import { fn } from '@openfn/language-common'; fn();";
   const expected = `import { fn } from '@openfn/language-common';\nexport default [fn()];`;
   const result = compile(source, options);
-  t.assert(result === expected);
+  t.is(result, expected);
 });
 
 test('dumbly add imports', (t) => {
@@ -81,7 +81,7 @@ test('dumbly add imports', (t) => {
   const source = "import { jam } from '@openfn/language-common'; jam(state);";
   const expected = `import { jam } from '@openfn/language-common';\nexport default [jam(state)];`;
   const result = compile(source, options);
-  t.assert(result === expected);
+  t.is(result, expected);
 });
 
 test('add imports with export all', (t) => {
@@ -97,7 +97,7 @@ test('add imports with export all', (t) => {
   const source = 'fn();';
   const expected = `import { fn } from "@openfn/language-common";\nexport * from "@openfn/language-common";\nexport default [fn()];`;
   const result = compile(source, options);
-  t.assert(result === expected);
+  t.is(result, expected);
 });
 
 test('twitter example', async (t) => {
@@ -119,23 +119,22 @@ test('compile with optional chaining', (t) => {
   const source = 'fn(a.b?.c);';
   const expected = 'export default [fn(a.b?.c)];';
   const result = compile(source);
-  t.assert(result === expected);
+  t.is(result, expected);
 });
 
 test('compile with nullish coalescence', (t) => {
   const source = 'fn(a ?? b);';
   const expected = 'export default [fn(a ?? b)];';
   const result = compile(source);
-  t.assert(result === expected);
+  t.is(result, expected);
 });
 
 test('compile a lazy state ($) expression', (t) => {
   const source = 'get($.data.endpoint);';
   const expected = 'export default [get(state => state.data.endpoint)];';
   const result = compile(source);
-  t.assert(result === expected);
+  t.is(result, expected);
 });
-
 
 test('compile a lazy state ($) expression with dumb imports', (t) => {
   const options = {
@@ -149,8 +148,41 @@ test('compile a lazy state ($) expression with dumb imports', (t) => {
   const source = 'get($.data.endpoint);';
   const expected = `import { get } from "@openfn/language-common";
 export * from "@openfn/language-common";
-export default [get(state => state.data.endpoint)];`
+export default [get(state => state.data.endpoint)];`;
 
   const result = compile(source, options);
-  t.assert(result === expected);
+  t.is(result, expected);
+});
+
+test('compile simple promise chain', (t) => {
+  const source =
+    'get($.data.endpoint).then((s => { console.log(s.data); return state;} ));';
+  const expected = `function defer(fn, complete, error) {
+  if (complete === void 0) {
+    complete = function(s) {
+      return s;
+    };
+  }
+
+  if (error === void 0) {
+    error = function(e) {
+      throw e;
+    };
+  }
+
+  return function(state) {
+    try {
+      return Promise.resolve(fn(state)).catch(error).then(complete);
+    } catch (e) {
+      error(e);
+    }
+  };
+}
+
+export default [defer(
+  get(state => state.data.endpoint),
+  s => { console.log(s.data); return state;}
+)];`;
+  const result = compile(source);
+  t.is(result, expected);
 });

--- a/packages/compiler/test/transforms/add-imports.test.ts
+++ b/packages/compiler/test/transforms/add-imports.test.ts
@@ -447,6 +447,34 @@ test("Don't add imports for ignored identifiers", async (t) => {
   t.assert(imports[0].imported.name === 'y');
 });
 
+test("Don't add imports from import specifiers", async (t) => {
+  const ast = b.program([
+    b.importDeclaration(
+      [
+        b.importSpecifier(b.identifier('x')),
+        b.importSpecifier(b.identifier('y'), b.identifier('_y')),
+      ],
+      b.stringLiteral('@openfn/runtime')
+    ),
+  ]);
+
+  const options = {
+    'add-imports': {
+      adaptor: {
+        name: 'test-adaptor',
+        exports: [],
+      },
+    },
+  };
+
+  const transformed = transform(ast, [addImports], options) as n.Program;
+
+  t.assert(transformed.body.length === 1);
+  const [first] = transformed.body;
+  t.assert(n.ImportDeclaration.check(first));
+  t.assert(first.source.value === '@openfn/runtime');
+});
+
 test('export everything from an adaptor', (t) => {
   const ast = b.program([b.expressionStatement(b.identifier('x'))]);
 

--- a/packages/compiler/test/transforms/promises.test.ts
+++ b/packages/compiler/test/transforms/promises.test.ts
@@ -312,3 +312,16 @@ test('transform: fn(get().then())', (t) => {
   const { code: transformedExport } = print(transformed.program.body.at(-1));
   t.is(transformedExport, result);
 });
+
+test('transform: ignore promises in a callback', (t) => {
+  const source = `fn((state) => {
+    return get().then((s) => s)
+});`;
+
+  const ast = parse(source);
+
+  const transformed = transform(ast, [promises]) as n.Program;
+
+  const { code } = print(transformed);
+  t.is(code, source);
+});

--- a/packages/compiler/test/transforms/promises.test.ts
+++ b/packages/compiler/test/transforms/promises.test.ts
@@ -183,7 +183,6 @@ _defer(fn(x), p => p.then(s => s));`;
 
   const transformed = transform(ast, [promises]) as n.File;
   const { code } = print(transformed);
-  console.log(code);
   t.is(code, result);
 });
 

--- a/packages/compiler/test/transforms/promises.test.ts
+++ b/packages/compiler/test/transforms/promises.test.ts
@@ -1,0 +1,130 @@
+import test from 'ava';
+
+import promises, { defer } from '../../src/transforms/promises';
+import parse from '../../src/parse';
+import transform from '../../src/transform';
+
+// Bunch of tests around the defer function
+
+test('defer does not execute immediately', (t) => {
+  let x = 0;
+
+  const op = () => x++;
+
+  defer(op);
+
+  t.is(x, 0);
+});
+
+test('defer: function executes when called', async (t) => {
+  let x = 0;
+
+  const op = () => x++;
+
+  const fn = defer(op);
+
+  await fn({});
+
+  t.is(x, 1);
+});
+
+test('defer: function executes an async function when called', async (t) => {
+  const op = () =>
+    new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(22);
+      }, 2);
+    });
+
+  const fn = defer(op);
+
+  const result = await fn({});
+
+  t.is(result, 22);
+});
+
+test('defer: returns a value', async (t) => {
+  const op = (s) => s * s;
+
+  const fn = defer(op);
+
+  const result = await fn(5);
+
+  t.is(result, 25);
+});
+
+test('defer: invoke the complete callback and pass state', async (t) => {
+  const op = (s) => ++s;
+
+  const fn = defer(op, (s) => (s *= 2));
+
+  const result = await fn(2);
+
+  t.is(result, 6);
+});
+
+test('defer: catch an error', async (t) => {
+  const op = () => {
+    throw 'lamine yamal';
+  };
+
+  const c = (_e: any) => {
+    t.pass('caught the error');
+  };
+
+  const fn = defer(op, undefined, c);
+
+  await fn(1);
+});
+
+test('defer: catch an async error', async (t) => {
+  const op = () =>
+    new Promise((resolve, reject) => {
+      setTimeout(() => {
+        // This should be handled gracefully
+        reject('lamine yamal');
+
+        // but this will be uncaught!
+        // I don't think there's anything we can do about this tbh
+        //throw 'lamine yamal';
+      }, 2);
+    });
+
+  const c = (e: any) => {
+    t.is(e, 'lamine yamal');
+  };
+
+  const fn = defer(op, undefined, c);
+
+  await fn(1);
+});
+
+// TODO what about the injected code?
+
+// Maybe thjere are a couple of tests:
+// - injects defer function
+// - doesn't inject defer function if it doesn't need to
+// And we just do a really basic AST check
+// Or maybe even a regex checj
+
+// Then we do a bunch of tests on the export array
+// We just codeify that
+
+// Let's assume that exports has already run
+test('transform', (t) => {
+  const source = `export default [fn(x).then(s => s)];`;
+  const result = `export default [defer(fn(x), s => s)];`;
+
+  const ast = parse(source);
+
+  const transformed = transform(ast, [promises], {}) as n.Program;
+
+  // assertDeferDeclaration(transformed)
+
+  // TODO: extract the export array, then print it
+  // Could I exclude the export array from the whole test?
+
+  const { code } = print(transformed);
+
+  t.is(code, result);
+});

--- a/packages/compiler/test/transforms/promises.test.ts
+++ b/packages/compiler/test/transforms/promises.test.ts
@@ -121,7 +121,7 @@ test('defer: returns a value', async (t) => {
 test('defer: invoke the complete callback and pass state', async (t) => {
   const op = (s) => ++s;
 
-  const fn = defer(op, (s) => (s *= 2));
+  const fn = defer(op, (p) => p.then((s) => (s *= 2)));
 
   const result = await fn(2);
 

--- a/packages/compiler/test/transforms/promises.test.ts
+++ b/packages/compiler/test/transforms/promises.test.ts
@@ -239,4 +239,22 @@ test('transform: fn().catch()', (t) => {
   t.is(transformedExport, result);
 });
 
+test.only('transform: fn(get().then())', (t) => {
+  const source = `fn(get(x).then(s => s));`;
+  const result = `fn(defer(get(x), s => s));`;
+
+  const ast = parse(source);
+
+  const transformed = transform(ast, [promises]) as n.Program;
+
+  assertDeferDeclaration(transformed);
+
+  const { code } = print(transformed);
+
+  t.log(code);
+
+  const { code: transformedExport } = print(transformed.program.body.at(-1));
+  t.is(transformedExport, result);
+});
+
 // TODO test stuff like nested functions

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,18 @@
 # engine-multi
 
+## 1.2.0
+
+### Minor Changes
+
+- Allow operations to behave like promises (ie, support fn().then())
+
+### Patch Changes
+
+- Updated dependencies [40fd45b]
+- Updated dependencies [40fd45b]
+  - @openfn/compiler@0.2.0
+  - @openfn/runtime@1.4.1
+
 ## 1.1.13
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.1.13",
+  "version": "1.2.0",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openfn/lightning-mock
 
+## 2.0.14
+
+### Patch Changes
+
+- Updated dependencies [40fd45b]
+- Updated dependencies
+  - @openfn/runtime@1.4.1
+  - @openfn/engine-multi@1.2.0
+
 ## 2.0.13
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/runtime
 
+## 1.4.1
+
+### Patch Changes
+
+- 40fd45b: Allow the linker to directly import some whitelisted packages
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Job processing runtime.",
   "type": "module",
   "exports": {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -10,3 +10,5 @@ export * from './events';
 export * from './errors';
 
 export * from './modules/repo';
+
+export * from './runtime-helpers';

--- a/packages/runtime/src/runtime-helpers.ts
+++ b/packages/runtime/src/runtime-helpers.ts
@@ -1,0 +1,27 @@
+/**
+ * Helper functions designed to be used in job code
+ */
+
+import { State } from '@openfn/lexicon';
+
+// Defer will take an operation with a promise chain
+// and break it up into a deferred function call which
+// ensures the operation is a promise
+// eg, fn().then(s => s)
+
+// TODO move unit tests in here
+export function defer(
+  fn: (s: State) => State,
+  complete = (p: Promise<any>) => p,
+  error = (e: any): void => {
+    throw e;
+  }
+) {
+  return (state: State) => {
+    try {
+      return complete(Promise.resolve(fn(state)).catch(error));
+    } catch (e) {
+      return error(e);
+    }
+  };
+}

--- a/packages/runtime/src/runtime-helpers.ts
+++ b/packages/runtime/src/runtime-helpers.ts
@@ -13,15 +13,15 @@ import { State } from '@openfn/lexicon';
 export function defer(
   fn: (s: State) => State,
   complete = (p: Promise<any>) => p,
-  error = (e: any): void => {
+  error = (e: any, _state: State): void => {
     throw e;
   }
 ) {
   return (state: State) => {
     try {
-      return complete(Promise.resolve(fn(state)).catch(error));
+      return complete(Promise.resolve(fn(state)).catch((e) => error(e, state)));
     } catch (e) {
-      return error(e);
+      return error(e, state);
     }
   };
 }

--- a/packages/runtime/src/runtime-helpers.ts
+++ b/packages/runtime/src/runtime-helpers.ts
@@ -9,7 +9,6 @@ import { State } from '@openfn/lexicon';
 // ensures the operation is a promise
 // eg, fn().then(s => s)
 
-// TODO move unit tests in here
 export function defer(
   fn: (s: State) => State,
   complete = (p: Promise<any>) => p,

--- a/packages/runtime/test/runtime-helpers.test.ts
+++ b/packages/runtime/test/runtime-helpers.test.ts
@@ -63,8 +63,9 @@ test('defer: catch an error', async (t) => {
     throw 'lamine yamal';
   };
 
-  const c = (_e: any) => {
-    t.pass('caught the error');
+  const c = (e: any, s: any) => {
+    t.truthy(e);
+    t.truthy(s);
   };
 
   const fn = defer(op, undefined, c);
@@ -85,8 +86,9 @@ test('defer: catch an async error', async (t) => {
       }, 2);
     });
 
-  const c = (e: any) => {
+  const c = (e: any, s: any) => {
     t.is(e, 'lamine yamal');
+    t.truthy(s);
   };
 
   const fn = defer(op, undefined, c);

--- a/packages/runtime/test/runtime-helpers.test.ts
+++ b/packages/runtime/test/runtime-helpers.test.ts
@@ -1,0 +1,95 @@
+import test from 'ava';
+import { defer } from '../src/runtime-helpers';
+
+test('defer does not execute immediately', (t) => {
+  let x = 0;
+
+  const op = () => x++;
+
+  defer(op);
+
+  t.is(x, 0);
+});
+
+test('defer: function executes when called', async (t) => {
+  let x = 0;
+
+  const op = () => x++;
+
+  const fn = defer(op);
+
+  await fn({});
+
+  t.is(x, 1);
+});
+
+test('defer: function executes an async function when called', async (t) => {
+  const op = () =>
+    new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(22);
+      }, 2);
+    });
+
+  const fn = defer(op);
+
+  const result = await fn({});
+
+  t.is(result, 22);
+});
+
+test('defer: returns a value', async (t) => {
+  const op = (s) => s * s;
+
+  const fn = defer(op);
+
+  const result = await fn(5);
+
+  t.is(result, 25);
+});
+
+test('defer: invoke the complete callback and pass state', async (t) => {
+  const op = (s) => ++s;
+
+  const fn = defer(op, (p) => p.then((s) => (s *= 2)));
+
+  const result = await fn(2);
+
+  t.is(result, 6);
+});
+
+test('defer: catch an error', async (t) => {
+  const op = () => {
+    throw 'lamine yamal';
+  };
+
+  const c = (_e: any) => {
+    t.pass('caught the error');
+  };
+
+  const fn = defer(op, undefined, c);
+
+  await fn(1);
+});
+
+test('defer: catch an async error', async (t) => {
+  const op = () =>
+    new Promise((_resolve, reject) => {
+      setTimeout(() => {
+        // This should be handled gracefully
+        reject('lamine yamal');
+
+        // but this will be uncaught!
+        // I don't think there's anything we can do about this tbh
+        //throw 'lamine yamal';
+      }, 2);
+    });
+
+  const c = (e: any) => {
+    t.is(e, 'lamine yamal');
+  };
+
+  const fn = defer(op, undefined, c);
+
+  await fn(1);
+});

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,18 @@
 # ws-worker
 
+## 1.4.0
+
+### Minor Changes
+
+- Allow operations to behave like promises (ie, support fn().then())
+
+### Patch Changes
+
+- Updated dependencies [40fd45b]
+- Updated dependencies
+  - @openfn/runtime@1.4.1
+  - @openfn/engine-multi@1.2.0
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@openfn/language-common':
         specifier: 1.7.7
         version: 1.7.7
+      '@openfn/language-http':
+        specifier: 6.4.0
+        version: 6.4.0
       '@openfn/runtime':
         specifier: workspace:^
         version: link:../../packages/runtime
@@ -1400,6 +1403,11 @@ packages:
       heap: 0.2.7
     dev: false
 
+  /@fastify/busboy@2.1.1:
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+    dev: false
+
   /@inquirer/checkbox@1.3.5:
     resolution: {integrity: sha512-ZznkPU+8XgNICKkqaoYENa0vTw9jeToEHYyG5gUKpGmY+4PqPTsvLpSisOt9sukLkYzPRkpSCHREgJLqbCG3Fw==}
     engines: {node: '>=14.18.0'}
@@ -1656,6 +1664,22 @@ packages:
       semver: 7.5.4
     dev: true
 
+  /@openfn/language-common@1.15.0:
+    resolution: {integrity: sha512-aBWCvnJc0MCRjF6wUHicU5nkM3wWxrJV7K81j0FB7hQqerFSTk/ceq8/a98bi2Tcd9CV8WBTPF1AfROMcpNSEg==}
+    dependencies:
+      ajv: 8.17.1
+      axios: 1.1.3
+      csv-parse: 5.5.6
+      csvtojson: 2.0.10
+      date-fns: 2.30.0
+      http-status-codes: 2.3.0
+      jsonpath-plus: 4.0.0
+      lodash: 4.17.21
+      undici: 5.28.4
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@openfn/language-common@1.7.5:
     resolution: {integrity: sha512-QivV3v5Oq5fb4QMopzyqUUh+UGHaFXBdsGr6RCmu6bFnGXdJdcQ7GpGpW5hKNq29CkmE23L/qAna1OLr4rP/0w==}
     dependencies:
@@ -1681,6 +1705,16 @@ packages:
   /@openfn/language-common@2.0.0-rc3:
     resolution: {integrity: sha512-7kwhBnCd1idyTB3MD9dXmUqROAhoaUIkz2AGDKuv9vn/cbZh7egEv9/PzKkRcDJYFV9qyyS+cVT3Xbgsg2ii5g==}
     bundledDependencies: []
+
+  /@openfn/language-http@6.4.0:
+    resolution: {integrity: sha512-dZwbBV47UrmUlDo5Z9F5XMQq0i8XEHNo0xbgUcCeq7EaJrYn4E2EzK4q2DLzSZb+14K/PWOeUHATL/LCHx+w6g==}
+    dependencies:
+      '@openfn/language-common': 1.15.0
+      cheerio: 1.0.0-rc.12
+      cheerio-tableparser: 1.0.1
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2132,6 +2166,15 @@ packages:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
+  /ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.1
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+    dev: false
+
   /ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -2519,8 +2562,16 @@ packages:
       readable-stream: 4.2.0
     dev: true
 
+  /bluebird@3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+    dev: false
+
   /blueimp-md5@2.19.0:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
+
+  /boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: false
 
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -2738,6 +2789,34 @@ packages:
 
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  /cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.1.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+    dev: false
+
+  /cheerio-tableparser@1.0.1:
+    resolution: {integrity: sha512-SCSWdMoFvIue0jdFZqRNPXDCZ67vuirJEG3pfh3AAU2hwxe/qh1EQUkUNPWlZhd6DMjRlTfcpcPWbaowjwRnNQ==}
+    dev: false
+
+  /cheerio@1.0.0-rc.12:
+    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
+    engines: {node: '>= 6'}
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      htmlparser2: 8.0.2
+      parse5: 7.1.2
+      parse5-htmlparser2-tree-adapter: 7.0.0
+    dev: false
 
   /chokidar@2.1.8:
     resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
@@ -3035,6 +3114,21 @@ packages:
       which: 2.0.2
     dev: true
 
+  /css-select@5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      nth-check: 2.1.1
+    dev: false
+
+  /css-what@6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
+    dev: false
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -3053,6 +3147,10 @@ packages:
     resolution: {integrity: sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==}
     dev: true
 
+  /csv-parse@5.5.6:
+    resolution: {integrity: sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A==}
+    dev: false
+
   /csv-stringify@5.6.5:
     resolution: {integrity: sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==}
     dev: true
@@ -3066,6 +3164,16 @@ packages:
       csv-stringify: 5.6.5
       stream-transform: 2.1.3
     dev: true
+
+  /csvtojson@2.0.10:
+    resolution: {integrity: sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+    dependencies:
+      bluebird: 3.7.2
+      lodash: 4.17.21
+      strip-bom: 2.0.0
+    dev: false
 
   /currently-unhandled@0.4.1:
     resolution: {integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==}
@@ -3257,6 +3365,33 @@ packages:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
     dev: true
 
+  /dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+    dev: false
+
+  /domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
+
+  /domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
+  /domutils@3.1.0:
+    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+    dev: false
+
   /dreamopt@0.8.0:
     resolution: {integrity: sha512-vyJTp8+mC+G+5dfgsY+r3ckxlz+QMX40VjPQsZc5gxVAxLmi64TBoVkP54A/pRAXMXsbu2GMMBrZPxNv23waMg==}
     engines: {node: '>=0.4.0'}
@@ -3317,6 +3452,11 @@ packages:
     dependencies:
       ansi-colors: 4.1.3
     dev: true
+
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+    dev: false
 
   /err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -4032,6 +4172,10 @@ packages:
       - supports-color
     dev: true
 
+  /fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: false
+
   /fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
@@ -4070,6 +4214,10 @@ packages:
 
   /fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+    dev: false
+
+  /fast-uri@3.0.1:
+    resolution: {integrity: sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==}
     dev: false
 
   /fastq@1.13.0:
@@ -4515,6 +4663,15 @@ packages:
       lru-cache: 7.18.3
     dev: true
 
+  /htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
+    dev: false
+
   /http-assert@1.5.0:
     resolution: {integrity: sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==}
     engines: {node: '>= 0.8'}
@@ -4582,6 +4739,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /http-status-codes@2.3.0:
+    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
+    dev: false
 
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -4983,6 +5144,10 @@ packages:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
     engines: {node: '>=12'}
 
+  /is-utf8@0.2.1:
+    resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
+    dev: false
+
   /is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
@@ -5075,6 +5240,10 @@ packages:
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: true
+
+  /json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    dev: false
 
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -5821,6 +5990,12 @@ packages:
       path-key: 3.1.1
     dev: true
 
+  /nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+    dependencies:
+      boolbase: 1.0.0
+    dev: false
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -6089,6 +6264,19 @@ packages:
   /parse-ms@3.0.0:
     resolution: {integrity: sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==}
     engines: {node: '>=12'}
+
+  /parse5-htmlparser2-tree-adapter@7.0.0:
+    resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.1.2
+    dev: false
+
+  /parse5@7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+    dependencies:
+      entities: 4.5.0
+    dev: false
 
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -6655,6 +6843,11 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  /require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
     dev: true
@@ -7177,6 +7370,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
+
+  /strip-bom@2.0.0:
+    resolution: {integrity: sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-utf8: 0.2.1
+    dev: false
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -7797,6 +7997,13 @@ packages:
   /underscore@1.12.1:
     resolution: {integrity: sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==}
     dev: true
+
+  /undici@5.28.4:
+    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
+    engines: {node: '>=14.0'}
+    dependencies:
+      '@fastify/busboy': 2.1.1
+    dev: false
 
   /union-value@1.0.1:
     resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,43 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
 
+  integration-tests/execute:
+    dependencies:
+      '@openfn/compiler':
+        specifier: workspace:^
+        version: link:../../packages/compiler
+      '@openfn/language-common':
+        specifier: 1.7.7
+        version: 1.7.7
+      '@openfn/runtime':
+        specifier: workspace:^
+        version: link:../../packages/runtime
+      '@types/node':
+        specifier: ^18.15.13
+        version: 18.15.13
+      ava:
+        specifier: 5.3.1
+        version: 5.3.1
+      date-fns:
+        specifier: ^2.30.0
+        version: 2.30.0
+      rimraf:
+        specifier: ^3.0.2
+        version: 3.0.2
+      ts-node:
+        specifier: 10.8.1
+        version: 10.8.1(@types/node@18.15.13)(typescript@5.1.6)
+      tslib:
+        specifier: ^2.4.0
+        version: 2.4.0
+      typescript:
+        specifier: ^5.1.6
+        version: 5.1.6
+    devDependencies:
+      '@types/rimraf':
+        specifier: ^3.0.2
+        version: 3.0.2
+
   integration-tests/worker:
     dependencies:
       '@openfn/engine-multi':
@@ -1630,6 +1667,17 @@ packages:
       - debug
     dev: true
 
+  /@openfn/language-common@1.7.7:
+    resolution: {integrity: sha512-GSoAbo6oL0b8jHufhLKvIzHJ271aE2AKv/ibeuiWU3CqN1gRmaHArlA/omlCs/rsfcieSp2VWAvWeGuFY8buZw==}
+    dependencies:
+      axios: 1.1.3
+      date-fns: 2.30.0
+      jsonpath-plus: 4.0.0
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@openfn/language-common@2.0.0-rc3:
     resolution: {integrity: sha512-7kwhBnCd1idyTB3MD9dXmUqROAhoaUIkz2AGDKuv9vn/cbZh7egEv9/PzKkRcDJYFV9qyyS+cVT3Xbgsg2ii5g==}
     bundledDependencies: []
@@ -1660,7 +1708,7 @@ packages:
       '@slack/logger': 3.0.0
       '@slack/types': 2.8.0
       '@types/is-stream': 1.1.0
-      '@types/node': 18.15.3
+      '@types/node': 18.15.13
       axios: 0.27.2
       eventemitter3: 3.1.2
       form-data: 2.5.1
@@ -1753,7 +1801,7 @@ packages:
   /@types/gunzip-maybe@1.4.0:
     resolution: {integrity: sha512-dFP9GrYAR9KhsjTkWJ8q8Gsfql75YIKcg9DuQOj/IrlPzR7W+1zX+cclw1McV82UXAQ+Lpufvgk3e9bC8+HzgA==}
     dependencies:
-      '@types/node': 18.15.3
+      '@types/node': 18.15.13
     dev: true
 
   /@types/http-assert@1.5.3:
@@ -1880,10 +1928,6 @@ packages:
   /@types/node@18.15.13:
     resolution: {integrity: sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==}
 
-  /@types/node@18.15.3:
-    resolution: {integrity: sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==}
-    dev: true
-
   /@types/node@20.4.5:
     resolution: {integrity: sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==}
 
@@ -1960,7 +2004,7 @@ packages:
   /@types/tar-stream@2.2.2:
     resolution: {integrity: sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==}
     dependencies:
-      '@types/node': 18.15.3
+      '@types/node': 18.15.13
     dev: true
 
   /@types/treeify@1.0.0:
@@ -2248,7 +2292,6 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
 
   /atob@2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
@@ -2396,7 +2439,6 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
-    dev: true
 
   /b4a@1.6.1:
     resolution: {integrity: sha512-AsKjNhz72yxteo/0EtQEiwkMUgk/tGmycXlbG4g3Ard2/ULtNLUykGOkeK0egmN27h0xMAhb76jYccW+XTBExA==}
@@ -2869,7 +2911,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -3166,7 +3207,6 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -4138,7 +4178,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: true
 
   /for-in@1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
@@ -4169,7 +4208,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: true
 
   /fragment-cache@0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
@@ -5052,7 +5090,6 @@ packages:
   /jsonpath-plus@4.0.0:
     resolution: {integrity: sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==}
     engines: {node: '>=10.0'}
-    dev: true
 
   /jsonpath@1.1.1:
     resolution: {integrity: sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==}
@@ -6380,7 +6417,6 @@ packages:
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: true
 
   /proxy-middleware@0.15.0:
     resolution: {integrity: sha512-EGCG8SeoIRVMhsqHQUdDigB2i7qU7fCsWASwn54+nPutYO8n4q6EiwMzyfWlC+dzRFExP+kvcnDFdBDHoZBU7Q==}


### PR DESCRIPTION
This PR enables all operations in job code to be treated like promises. 

This confers the following benefits:

* `fn.catch()` is a really useful thing to be able to do
* We can drop most callbacks from adaptor APIs

Closes #721 

Documentation in #https://github.com/OpenFn/docs/pull/518 (this docs PR should be a great non-technical explanation of what this PR actually does)

## Motivations and examples

It occurred to me a little while ago that adaptor API design would be way cleaner if we didn't need a callback option as the last argument. It gets very hard to manage optional arguments AND an optional callback.

I also think that the callback function is semantically a little difficult. Why is is there? In most cases, you can rewrite `get(www, {}, callback)` as `get(www, {}); callback()`. It's exactly the same thing.

About the only time you need the callback is if you're nested inside an each (or maybe some other operation): `each($.data, post('/upsert', $.data, (s) => s))`. The final callback here needs to be invoked for each item in the array - an `fn()` block won't do it.

But if you could treat each operation as a promise, make it thenable and catchable, you wouldn't need the callback.

You can do stuff like this:

```
each($.data, post('/upsert', (state) => state.data).then((s) => s))
```

You can also use a catch on any operation now, if for any reason you want to do your own error handling (#496):
```
get('www').catch(e => { ... })
```

## Compiler magic

It turns out that making operations into promises isn't easy.

I don't want to re-write every adaptor to return a promise. Even if I did, that wouldn't work with the runtime (which expects to execute an array of functions, not an array of promises). Plus the promise would execute immediately, whereas we want to defer execution until later.

I also don't want magic in the runtime to handle this. I think it's important that compiled code can be executed in a simple node.js app without our runtime. That keeps code portable. If the runtime is doing  magic to promisify all operations, then the expression isn't very portable.

So the solution goes in the compiler. We have to transform the users's code into something portable.

The tl;dr is, we take  a promise `fn().then(x)` and compile it into tthis:

```
_defer(fn(), p => p.then(x))`
```
Where defer is a function imported from the runtime itself, so really the compiled code is like
```
import { defer as _defer } from '@openfn/runtime';
export default [_defer(fn(), p => p.then(x))]
```

It's kinda hard to explain, I struggle with the language and this reflects in the implementation. But I'll have a go.

Some important things to understand here:
- fn() returns a function (maybe an async one) but not a promise
- The `fn()` is compiled into an array of functions, which will be passed to the runtime
- The runtime expects an array of functions to execute, not an array of promises
- Even if I wanted to change every adaptor to return a promise, that wouldn't really work with the runtime
- It is critical that the operation created by `fn()` is not executed immediately. This is the whole thing. Each operation must create a function to be executed later.
- And obviously when you do promise.then(), the promise will execute right away

My solution is to break up the chain into two parts
1) The original operation `fn()`, untouched.
2) The promise bit, `then(whatever)`. Which might actually be a chain of promises.

I do this by creating a function called `defer(operation, thenFn, catchFn)`
- `defer` is just am operation really. It returns a function that takes state and returns state.
- When `defer` is invoked, it'll call the operation `fn()` and pass the result into `Promise.resolve`
- This gives us a Promise that takes and returns state
- Then we have to trigger the promise bit

The compiler code to break up the promise into a defer function is a little gnarly. I've tested it as well as I can.

Catch also complicates things.

We compile `catch()` and `then()` a bit differently. The catch is designed to trap any exception thrown by the operation - even though the operation may not be a promise. So the defer function needs to handle this right.

If for some reason the user does `fn().catch().then()`, then we have to handle the catch function AND invoke the promise with state.

## New Integration Tests

I've added a new suite of integration tests specifically for job writing.

These just compile and run against an adaptor - no CLI or Worker in the way. So it should be a nice clean environment to write, test, debug and experiment with pure job code.

## TODO

At the time of writing I've still got a couple of things to look at:

* [x] catch needs to pass state to the callback
* [x] The defer function is actually quite long (it pretty prints at like 12 lines) and it distracts quite heavily from the job code. I don't want to minify the function because I want compiled code to be readable. So either I need a prettier/simpler function, or we need to import the defer function from a library (I don't think it's totally unreasonable to import from @openfn/runtime in job code)
* [x] Compiler stuff is scary and I want to test this so damn hard
* [x] Docs 