### PR TITLE
describe-package: include common functions

### DIFF
--- a/.changeset/empty-balloons-beam.md
+++ b/.changeset/empty-balloons-beam.md
@@ -1,5 +1,0 @@
----
-'@openfn/describe-package': minor
----
-
-Include common functions in the exported definitions

--- a/.changeset/empty-balloons-beam.md
+++ b/.changeset/empty-balloons-beam.md
@@ -1,0 +1,5 @@
+---
+'@openfn/describe-package': minor
+---
+
+Include common functions in the exported definitions

--- a/examples/dts-inspector/CHANGELOG.md
+++ b/examples/dts-inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # dts-inspector
 
+## 1.0.18
+
+### Patch Changes
+
+- Updated dependencies [6d01592]
+  - @openfn/describe-package@0.1.0
+
 ## 1.0.17
 
 ### Patch Changes

--- a/examples/dts-inspector/package.json
+++ b/examples/dts-inspector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dts-inspector",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/integration-tests-worker
 
+## 1.0.49
+
+### Patch Changes
+
+- @openfn/engine-multi@1.1.12
+- @openfn/lightning-mock@2.0.12
+- @openfn/ws-worker@1.2.2
+
 ## 1.0.48
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.48",
+  "version": "1.0.49",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 1.4.2
+
+### Patch Changes
+
+- Updated dependencies [6d01592]
+  - @openfn/describe-package@0.1.0
+  - @openfn/compiler@0.1.4
+
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/compiler
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies [6d01592]
+  - @openfn/describe-package@0.1.0
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/compiler",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Compiler and language tooling for openfn jobs.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/describe-package/CHANGELOG.md
+++ b/packages/describe-package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/describe-package
 
+## 0.1.0
+
+### Minor Changes
+
+- 6d01592: Include common functions in the exported definitions
+
 ## 0.0.20
 
 ### Patch Changes

--- a/packages/describe-package/package.json
+++ b/packages/describe-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/describe-package",
-  "version": "0.0.20",
+  "version": "0.1.0",
   "description": "Utilities to inspect an npm package.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/describe-package/src/describe-project.ts
+++ b/packages/describe-package/src/describe-project.ts
@@ -41,13 +41,6 @@ const describeFunction = (
   symbol: WrappedSymbol,
   moduleName?: string
 ): FunctionDescription => {
-  let parent = undefined;
-  // If this is an export alias (exported from another package) say where it came from
-  if (symbol.isExportAlias) {
-    // @ts-ignore symbol.parent
-    [parent] = symbol.symbol.parent.escapedName.match(/(language-\w+)/);
-  }
-
   return {
     type: 'function',
     name: moduleName ? `${moduleName}.${symbol.name}` : symbol.name,
@@ -64,7 +57,6 @@ const describeFunction = (
       }
       return { code: eg.trim() };
     }),
-    parent,
   };
 };
 

--- a/packages/describe-package/test/describe-project.test.ts
+++ b/packages/describe-package/test/describe-project.test.ts
@@ -57,7 +57,6 @@ test('Load an example with caption', async (t) => {
 test('Load common fn', async (t) => {
   const fn = get('fn');
   t.truthy(fn);
-  t.is(fn.parent, 'language-common');
 });
 
 test('Recognise a magic function', async (t) => {

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # engine-multi
 
+## 1.1.12
+
+### Patch Changes
+
+- @openfn/compiler@0.1.4
+
 ## 1.1.11
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/lightning-mock
 
+## 2.0.12
+
+### Patch Changes
+
+- @openfn/engine-multi@1.1.12
+
 ## 2.0.11
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ws-worker
 
+## 1.2.2
+
+### Patch Changes
+
+- @openfn/engine-multi@1.1.12
+
 ## 1.2.1
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
`describe-package` will read in the d.ts of  a package and give a nicely formatted JSON description.

But it doesn't do a good job of common functions. They're reported as "namespaces" with no actual content. I've always blamed this on the Typescript compiler and I think I still do.

Anyway, I didn't really expect to fix this, but I was taking a look and I reaslised - although TS doesn't give us those definitions out of the box, we've actually already loaded them in. So it's not much work to cross-reference them.

So now it works! If you ask for the functions of http, it'll now include the defs for common. Hurrah!