### PR TITLE
Add snapshots option to cli pull command

### DIFF
--- a/.changeset/long-clocks-draw.md
+++ b/.changeset/long-clocks-draw.md
@@ -1,0 +1,6 @@
+---
+'@openfn/cli': minor
+'@openfn/deploy': minor
+---
+
+Add snapshots option to cli pull command

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -46,6 +46,7 @@ export type Opts = {
   repoDir?: string;
   sanitize: 'none' | 'remove' | 'summarize' | 'obfuscate';
   skipAdaptorValidation?: boolean;
+  snapshots?: string[];
   specifier?: string; // docgen
   start?: string; // workflow start step
   statePath?: string;
@@ -399,6 +400,14 @@ export const skipAdaptorValidation: CLIOption = {
     boolean: true,
     description: "Suppress warning message for jobs which don't use an adaptor",
     default: false,
+  },
+};
+
+export const snapshots: CLIOption = {
+  name: 'snapshots',
+  yargs: {
+    description: 'List os snapshot ids to pull',
+    array: true,
   },
 };
 

--- a/packages/cli/src/pull/command.ts
+++ b/packages/cli/src/pull/command.ts
@@ -14,10 +14,18 @@ export type PullOptions = Required<
     | 'configPath'
     | 'projectId'
     | 'confirm'
+    | 'snapshots'
   >
 >;
 
-const options = [o.statePath, o.projectPath, o.configPath, o.log, o.logJson];
+const options = [
+  o.statePath,
+  o.projectPath,
+  o.configPath,
+  o.log,
+  o.logJson,
+  o.snapshots,
+];
 
 const pullCommand: yargs.CommandModule<PullOptions> = {
   command: 'pull [projectId]',

--- a/packages/cli/src/pull/handler.ts
+++ b/packages/cli/src/pull/handler.ts
@@ -29,7 +29,11 @@ async function pullHandler(options: PullOptions, logger: Logger) {
     );
 
     // Get the project.json from Lightning
-    const { data: project } = await getProject(config, options.projectId);
+    const { data: project } = await getProject(
+      config,
+      options.projectId,
+      options.snapshots
+    );
 
     if (!project) {
       logger.error('ERROR: Project not found.');

--- a/packages/deploy/src/client.ts
+++ b/packages/deploy/src/client.ts
@@ -1,14 +1,25 @@
 import { DeployConfig, ProjectPayload } from './types';
 import { DeployError } from './deployError';
 
-const getLightningUrl = (config: DeployConfig, path: string = '') =>
-  new URL(`/api/provision/${path}`, config.endpoint);
+const getLightningUrl = (
+  config: DeployConfig,
+  path: string = '',
+  snapshots?: string[]
+) => {
+  const params = new URLSearchParams();
+  snapshots?.forEach((snapshot) => params.append('snapshots[]', snapshot));
+  return new URL(
+    `/api/provision/${path}?${params.toString()}`,
+    config.endpoint
+  );
+};
 
 export async function getProject(
   config: DeployConfig,
-  projectId: string
+  projectId: string,
+  snapshots?: string[]
 ): Promise<{ data: ProjectPayload | null }> {
-  const url = getLightningUrl(config, projectId);
+  const url = getLightningUrl(config, projectId, snapshots);
   console.log(`Checking ${url} for existing project.`);
 
   try {


### PR DESCRIPTION
## Short Description

Adds `--snapshots` option to cli pull command

## Related issue

Fixes #729 

## QA Notes

- `openfnx pull {projectId}` should work as it was before
- adding `--snapshots` option appends the snapshots to the query params. i.e `?snapshots[]=1&snapshots[]=2`


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added unit tests
- [x] Changesets have been added (if there are production code changes)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
