### PR TITLE
Add snapshots to the url for fetching project spec

### DIFF
--- a/.changeset/four-wolves-tease.md
+++ b/.changeset/four-wolves-tease.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': minor
+---
+
+Add snapshot ids to the url for fetching project spec

--- a/.changeset/four-wolves-tease.md
+++ b/.changeset/four-wolves-tease.md
@@ -1,5 +1,0 @@
----
-'@openfn/cli': minor
----
-
-Add snapshot ids to the url for fetching project spec

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/cli
 
+## 1.6.1
+
+### Patch Changes
+
+- 505d60b: Add snapshot ids to the url for fetching project spec
+
 ## 1.6.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/cli/src/pull/handler.ts
+++ b/packages/cli/src/pull/handler.ts
@@ -55,8 +55,13 @@ async function pullHandler(options: PullOptions, logger: Logger) {
 
     logger.always('Downloading the project spec (as YAML) from the server.');
     // Get the project.yaml from Lightning
+    const queryParams = new URLSearchParams();
+    queryParams.append('id', options.projectId);
+    options.snapshots?.forEach((snapshot) =>
+      queryParams.append('snapshots[]', snapshot)
+    );
     const url = new URL(
-      `api/provision/yaml?id=${options.projectId}`,
+      `api/provision/yaml?${queryParams.toString()}`,
       config.endpoint
     );
     logger.debug('Fetching project spec from', url);


### PR DESCRIPTION
## Short Description

This is a follow up to https://github.com/OpenFn/kit/pull/732
The cli makes 2 API requests when you run `openfn pull {projectID}` . 

This PR adds the provided snapshot ids to the URL for fetching the `project` spec

## Related issue

Fixes #729 

## Implementation Details
- I'm a little worried that the logic for building the query params has been duplicated. At the same time, I think it's okay to duplicate it because they are 2 different endpoints and they "could" require different logic.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added unit tests
- [x] Changesets have been added (if there are production code changes)


