### PR TITLE
compiler: support method operations

### DIFF
--- a/.changeset/wise-deers-speak.md
+++ b/.changeset/wise-deers-speak.md
@@ -1,0 +1,5 @@
+---
+'@openfn/compiler': minor
+---
+
+Treat method calls like http.get like operations

--- a/packages/compiler/src/transforms/top-level-operations.ts
+++ b/packages/compiler/src/transforms/top-level-operations.ts
@@ -21,8 +21,9 @@ function visitor(path: NodePath<namedTypes.CallExpression>) {
     // ie, the parent must be an ExpressionStatement, and the statement's parent must be a Program
     n.Program.check(root) &&
     n.Statement.check(path.parent.node) &&
-    // If it's an Operation call (ie, fn(() => {})), the callee will be an IdentifierExpression
-    n.Identifier.check(path.node.callee)
+    // An Operation could be an Identifier (fn()) or Member Expression (http.get())
+    (n.Identifier.check(path.node.callee) ||
+      n.MemberExpression.check(path.node.callee))
   ) {
     // Now Find the top level exports array
     const target = root.body.at(-1);

--- a/packages/compiler/test/compile.test.ts
+++ b/packages/compiler/test/compile.test.ts
@@ -24,6 +24,13 @@ test('compile a single operation', (t) => {
   t.is(result, expected);
 });
 
+test('compile a single namespaced operation', (t) => {
+  const source = 'http.get();';
+  const expected = 'export default [http.get()];';
+  const result = compile(source);
+  t.is(result, expected);
+});
+
 test('compile a single operation without being fussy about semicolons', (t) => {
   const source = 'fn()';
   const expected = 'export default [fn()];';


### PR DESCRIPTION
A small fix in the compiler to recognise `http.get()` as an operation, like `get()`

This is needed to support the new http namespace in `common`

## Discussion

Is this reasonable? Is this going to break everything?

It's fine.

To date, we have assumed that any top level function call, eg, `fn()`, is an operation call. And as a result it gets relocated into the exports array.
```
export default [fn()]`
```

Up to today, any method calls will be left alone. Which may or may not work depending on what you're trying to do. 
```
http.get(www)
```
Where `get` is the old non-operation common.http.get.

That probably won't work though, because the get wil be issued before the runtime calls the operation pipeline. It'll all be out of order.

Now, because I'm recognising method calls as operations, I'll do this:
```
export default [http.get(www)]
```

If http.get is an operation, this will work. If it's not, well, it shouldn't be at the top of your code, should it? It shoudl be in an fn block. We do say that top level statements should be Operations (it's true, see the last line of the [Job Writing Guide](https://docs.openfn.org/documentation/jobs/job-writing-guide#operations-and-state) )