### PR TITLE
Worker: limit payload size

### DIFF
--- a/.changeset/sweet-bats-know.md
+++ b/.changeset/sweet-bats-know.md
@@ -2,4 +2,4 @@
 '@openfn/ws-worker': minor
 ---
 
-Allow a payload limit to be set for large dataclips"
+Allow a payload limit to be set for large dataclips and logs

--- a/.changeset/sweet-bats-know.md
+++ b/.changeset/sweet-bats-know.md
@@ -1,5 +1,0 @@
----
-'@openfn/ws-worker': minor
----
-
-Allow a payload limit to be set for large dataclips and logs

--- a/.changeset/sweet-bats-know.md
+++ b/.changeset/sweet-bats-know.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': minor
+---
+
+Allow a payload limit to be set for large dataclips"

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/integration-tests-worker
 
+## 1.0.53
+
+### Patch Changes
+
+- Updated dependencies [f363254]
+  - @openfn/ws-worker@1.5.0
+
 ## 1.0.52
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.52",
+  "version": "1.0.53",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -853,7 +853,7 @@ test.serial('override the worker payload through run options', (t) => {
         },
       ],
       options: {
-        payload_memory_limit_mb: 100,
+        payload_limit_mb: 100,
       },
     };
 
@@ -891,7 +891,7 @@ test.serial('Redact logs which exceed the payload limit', (t) => {
         },
       ],
       options: {
-        payload_memory_limit_mb: 0,
+        payload_limit_mb: 0,
       },
     };
 

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -787,5 +787,88 @@ test.serial('set a timeout on a run', (t) => {
   });
 });
 
+test.serial('set a default payload limit on the worker', (t) => {
+  return new Promise(async (done) => {
+    if (!worker.destroyed) {
+      await worker.destroy();
+    }
+
+    ({ worker } = await initWorker(
+      lightningPort,
+      {
+        maxWorkers: 1,
+        // use the dummy repo to remove autoinstall
+        repoDir: path.resolve('./dummy-repo'),
+      },
+      {
+        payloadLimitMb: 0,
+      }
+    ));
+
+    const run = {
+      id: crypto.randomUUID(),
+      jobs: [
+        {
+          adaptor: '@openfn/test-adaptor@1.0.0',
+          body: `fn((s) => ({ data: 'aaaa' }))`,
+        },
+      ],
+    };
+
+    lightning.once('step:complete', (evt) => {
+      const { reason, output_dataclip_id, output_dataclip } = evt.payload;
+      t.is(reason, 'success');
+      t.falsy(output_dataclip_id);
+      t.falsy(output_dataclip);
+
+      done();
+    });
+
+    lightning.enqueueRun(run);
+  });
+});
+
+test.serial('override the worker payload through run options', (t) => {
+  return new Promise(async (done) => {
+    if (!worker.destroyed) {
+      await worker.destroy();
+    }
+
+    ({ worker } = await initWorker(
+      lightningPort,
+      {
+        maxWorkers: 1,
+        // use the dummy repo to remove autoinstall
+        repoDir: path.resolve('./dummy-repo'),
+      },
+      { payloadLimitMb: 0 }
+    ));
+
+    const run = {
+      id: crypto.randomUUID(),
+      jobs: [
+        {
+          adaptor: '@openfn/test-adaptor@1.0.0',
+          body: `fn((s) => ({ data: 'aaaa' }))`,
+        },
+      ],
+      options: {
+        payload_memory_limit_mb: 100,
+      },
+    };
+
+    lightning.once('step:complete', (evt) => {
+      const { reason, output_dataclip_id, output_dataclip } = evt.payload;
+      t.is(reason, 'success');
+      t.truthy(output_dataclip_id);
+      t.deepEqual(output_dataclip, JSON.stringify({ data: 'aaaa' }));
+
+      done();
+    });
+
+    lightning.enqueueRun(run);
+  });
+});
+
 // REMEMBER the default worker was destroyed at this point!
 // If you want to use a worker, you'll have to create your own

--- a/packages/lexicon/lightning.d.ts
+++ b/packages/lexicon/lightning.d.ts
@@ -46,8 +46,8 @@ export type LightningPlanOptions = {
   start?: StepId;
   output_dataclips?: boolean;
 
-  // future options
-  run_memory_limit?: number
+  run_memory_limit_mb?: number;
+  payload_memory_limit_mb?: number;
 };
 
 /**

--- a/packages/lexicon/lightning.d.ts
+++ b/packages/lexicon/lightning.d.ts
@@ -47,7 +47,7 @@ export type LightningPlanOptions = {
   output_dataclips?: boolean;
 
   run_memory_limit_mb?: number;
-  payload_memory_limit_mb?: number;
+  payload_limit_mb?: number;
 };
 
 /**

--- a/packages/lexicon/lightning.d.ts
+++ b/packages/lexicon/lightning.d.ts
@@ -178,6 +178,7 @@ export type StepCompletePayload = ExitReason & {
   step_id: string;
   output_dataclip?: string;
   output_dataclip_id?: string;
+  output_dataclip_error?: 'DATACLIP_TOO_LARGE';
   thread_id?: string;
   mem: {
     job: number;

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ws-worker
 
+## 1.5.0
+
+### Minor Changes
+
+- f363254: Allow a payload limit to be set for large dataclips and logs (payload_limit_mb)
+
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/ws-worker/src/events/run-start.ts
+++ b/packages/ws-worker/src/events/run-start.ts
@@ -12,7 +12,7 @@ export default async function onRunStart(
   context: Context,
   event: WorkflowStartPayload
 ) {
-  const { channel, state, options } = context;
+  const { channel, state, options = {} } = context;
   // Cheat on the timestamp time to make sure this is the first thing in the log
   const time = (timestamp() - BigInt(10e6)).toString();
 

--- a/packages/ws-worker/src/events/run-start.ts
+++ b/packages/ws-worker/src/events/run-start.ts
@@ -12,7 +12,7 @@ export default async function onRunStart(
   context: Context,
   event: WorkflowStartPayload
 ) {
-  const { channel, state } = context;
+  const { channel, state, options } = context;
   // Cheat on the timestamp time to make sure this is the first thing in the log
   const time = (timestamp() - BigInt(10e6)).toString();
 
@@ -35,6 +35,15 @@ export default async function onRunStart(
   };
 
   await sendEvent<RunStartPayload>(channel, RUN_START, { versions });
+
+  if ('payloadLimitMb' in options) {
+    await onJobLog(versionLogContext, {
+      time,
+      message: [`Payload limit: ${options.payloadLimitMb}mb`],
+      level: 'info',
+      name: 'RTE',
+    });
+  }
 
   const versionMessage = calculateVersionString(versions);
 

--- a/packages/ws-worker/src/events/step-complete.ts
+++ b/packages/ws-worker/src/events/step-complete.ts
@@ -60,9 +60,11 @@ export default async function onStepComplete(
 
       // Write the dataclip if it's not too big
       evt.output_dataclip = payload;
-      evt.output_dataclip_id = dataclipId;
     }
+    evt.output_dataclip_id = dataclipId;
   } catch (e) {
+    evt.output_dataclip_error = 'DATACLIP_TOO_LARGE';
+
     const time = (timestamp() - BigInt(10e6)).toString();
     // If the dataclip is too big, return the step without it
     // (the workflow will carry on internally)

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -33,6 +33,8 @@ export type ServerOptions = {
     min?: number;
     max?: number;
   };
+
+  payloadLimitMb?: number; // max memory limit for socket payload (ie, step:complete, log)
 };
 
 // this is the server/koa API
@@ -164,7 +166,7 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
 
   router.get('/', healthcheck);
 
-  app.options = options || {};
+  app.options = options;
 
   // TODO this probably needs to move into ./api/ somewhere
   app.execute = async ({ id, token }: ClaimRun) => {

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -176,7 +176,7 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
       const {
         channel: runChannel,
         plan,
-        options,
+        options = {},
         input,
       } = await joinRunChannel(app.socket, token, id, logger);
 

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -180,6 +180,11 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
         input,
       } = await joinRunChannel(app.socket, token, id, logger);
 
+      // Default the payload limit if it's not otherwise set on the run options
+      if (!('payloadLimitMb' in options)) {
+        options.payloadLimitMb = app.options.payloadLimitMb;
+      }
+
       // Callback to be triggered when the work is done (including errors)
       const onFinish = () => {
         logger.debug(`workflow ${id} complete: releasing worker`);

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -39,6 +39,7 @@ function engineReady(engine: any) {
       max: maxBackoff,
     },
     maxWorkflows: args.capacity,
+    payloadLimitMb: args.payloadMemory,
   };
 
   if (args.lightningPublicKey) {

--- a/packages/ws-worker/src/util/cli.ts
+++ b/packages/ws-worker/src/util/cli.ts
@@ -15,6 +15,7 @@ type Args = {
   backoff: string;
   capacity?: number;
   runMemory?: number;
+  payloadMemory?: number;
   statePropsToRemove?: string[];
   maxRunDurationSeconds: number;
 };
@@ -48,6 +49,7 @@ export default function parseArgs(argv: string[]): Args {
     WORKER_LIGHTNING_PUBLIC_KEY,
     WORKER_LIGHTNING_SERVICE_URL,
     WORKER_LOG_LEVEL,
+    WORKER_MAX_PAYLOAD_MEMORY_MB,
     WORKER_MAX_RUN_DURATION_SECONDS,
     WORKER_MAX_RUN_MEMORY_MB,
     WORKER_PORT,
@@ -114,6 +116,11 @@ export default function parseArgs(argv: string[]): Args {
         'Maximum memory allocated to a single run, in mb. Env: WORKER_MAX_RUN_MEMORY_MB',
       type: 'number',
     })
+    .option('payload-memory', {
+      description:
+        'Maximum memory allocated to a single run, in mb. Env: WORKER_MAX_PAYLOAD_MEMORY_MB',
+      type: 'number',
+    })
     .option('max-run-duration-seconds', {
       alias: 't',
       description:
@@ -146,6 +153,7 @@ export default function parseArgs(argv: string[]): Args {
       ['configuration', 'response']
     ),
     runMemory: setArg(args.runMemory, WORKER_MAX_RUN_MEMORY_MB, 500),
+    payloadMemory: setArg(args.payloadMemory, WORKER_MAX_PAYLOAD_MEMORY_MB, 10),
     maxRunDurationSeconds: setArg(
       args.maxRunDurationSeconds,
       WORKER_MAX_RUN_DURATION_SECONDS,

--- a/packages/ws-worker/src/util/cli.ts
+++ b/packages/ws-worker/src/util/cli.ts
@@ -49,7 +49,7 @@ export default function parseArgs(argv: string[]): Args {
     WORKER_LIGHTNING_PUBLIC_KEY,
     WORKER_LIGHTNING_SERVICE_URL,
     WORKER_LOG_LEVEL,
-    WORKER_MAX_PAYLOAD_MEMORY_MB,
+    WORKER_MAX_PAYLOAD_MB,
     WORKER_MAX_RUN_DURATION_SECONDS,
     WORKER_MAX_RUN_MEMORY_MB,
     WORKER_PORT,
@@ -118,7 +118,7 @@ export default function parseArgs(argv: string[]): Args {
     })
     .option('payload-memory', {
       description:
-        'Maximum memory allocated to a single run, in mb. Env: WORKER_MAX_PAYLOAD_MEMORY_MB',
+        'Maximum memory allocated to a single run, in mb. Env: WORKER_MAX_PAYLOAD_MB',
       type: 'number',
     })
     .option('max-run-duration-seconds', {
@@ -153,7 +153,7 @@ export default function parseArgs(argv: string[]): Args {
       ['configuration', 'response']
     ),
     runMemory: setArg(args.runMemory, WORKER_MAX_RUN_MEMORY_MB, 500),
-    payloadMemory: setArg(args.payloadMemory, WORKER_MAX_PAYLOAD_MEMORY_MB, 10),
+    payloadMemory: setArg(args.payloadMemory, WORKER_MAX_PAYLOAD_MB, 10),
     maxRunDurationSeconds: setArg(
       args.maxRunDurationSeconds,
       WORKER_MAX_RUN_DURATION_SECONDS,

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -43,6 +43,7 @@ const mapTriggerEdgeCondition = (edge: Edge) => {
 export type WorkerRunOptions = ExecuteOptions & {
   // Defaults to true - must be explicity false to stop dataclips being sent
   outputDataclips?: boolean;
+  payloadLimitMb?: number;
 };
 
 export default (
@@ -57,6 +58,12 @@ export default (
   if (run.options) {
     if (run.options.run_timeout_ms) {
       engineOpts.runTimeoutMs = run.options.run_timeout_ms;
+    }
+    if (run.options.payload_memory_limit_mb) {
+      engineOpts.payloadLimitMb = run.options.payload_memory_limit_mb;
+    }
+    if (run.options.run_memory_limit_mb) {
+      engineOpts.memoryLimitMb = run.options.run_memory_limit_mb;
     }
     if (run.options.sanitize) {
       engineOpts.sanitize = run.options.sanitize;

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -54,21 +54,20 @@ export default (
 
   // But some need to get passed down into the engine's options
   const engineOpts: WorkerRunOptions = {};
-
   if (run.options) {
-    if (run.options.run_timeout_ms) {
+    if ('run_timeout_ms' in run.options) {
       engineOpts.runTimeoutMs = run.options.run_timeout_ms;
     }
-    if (run.options.payload_memory_limit_mb) {
+    if ('payload_memory_limit_mb' in run.options) {
       engineOpts.payloadLimitMb = run.options.payload_memory_limit_mb;
     }
-    if (run.options.run_memory_limit_mb) {
+    if ('run_memory_limit_mb' in run.options) {
       engineOpts.memoryLimitMb = run.options.run_memory_limit_mb;
     }
-    if (run.options.sanitize) {
+    if ('sanitize' in run.options) {
       engineOpts.sanitize = run.options.sanitize;
     }
-    if (run.options.hasOwnProperty('output_dataclips')) {
+    if ('output_dataclips' in run.options) {
       engineOpts.outputDataclips = run.options.output_dataclips;
     }
   }

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -58,8 +58,8 @@ export default (
     if ('run_timeout_ms' in run.options) {
       engineOpts.runTimeoutMs = run.options.run_timeout_ms;
     }
-    if ('payload_memory_limit_mb' in run.options) {
-      engineOpts.payloadLimitMb = run.options.payload_memory_limit_mb;
+    if ('payload_limit_mb' in run.options) {
+      engineOpts.payloadLimitMb = run.options.payload_limit_mb;
     }
     if ('run_memory_limit_mb' in run.options) {
       engineOpts.memoryLimitMb = run.options.run_memory_limit_mb;

--- a/packages/ws-worker/src/util/ensure-payload-size.ts
+++ b/packages/ws-worker/src/util/ensure-payload-size.ts
@@ -1,0 +1,16 @@
+export default (payload: string, limit_mb?: number) => {
+  // @ts-ignore
+  if (!isNaN(limit_mb)) {
+    const limit = limit_mb as number;
+    const size_bytes = Buffer.byteLength(payload, 'utf8');
+    const size_mb = size_bytes / 1024 / 1024;
+    if (size_mb > limit) {
+      const e = new Error();
+      // @ts-ignore
+      e.severity = 'kill';
+      e.name = 'PAYLOAD_TOO_LARGE';
+      e.message = `The payload exceeded the size limit of ${limit}mb`;
+      throw e;
+    }
+  }
+};

--- a/packages/ws-worker/test/events/step-complete.test.ts
+++ b/packages/ws-worker/test/events/step-complete.test.ts
@@ -205,6 +205,7 @@ test('do not include dataclips in step:complete if output_dataclip is too big', 
     [STEP_COMPLETE]: (evt: StepCompletePayload) => {
       t.falsy(evt.output_dataclip_id);
       t.falsy(evt.output_dataclip);
+      t.is(evt.output_dataclip_error, 'DATACLIP_TOO_LARGE');
     },
   });
 

--- a/packages/ws-worker/test/events/step-complete.test.ts
+++ b/packages/ws-worker/test/events/step-complete.test.ts
@@ -4,7 +4,7 @@ import type { StepCompletePayload } from '@openfn/lexicon/lightning';
 import handleStepComplete from '../../src/events/step-complete';
 import { mockChannel } from '../../src/mock/sockets';
 import { createRunState } from '../../src/util';
-import { STEP_COMPLETE } from '../../src/events';
+import { RUN_LOG, STEP_COMPLETE } from '../../src/events';
 import { createPlan } from '../util';
 import { JobCompletePayload } from '@openfn/engine-multi';
 
@@ -184,5 +184,72 @@ test('do not include dataclips in step:complete if output_dataclip is false', as
     duration: 61,
     thread_id: 'abc',
   } as JobCompletePayload;
+  await handleStepComplete({ channel, state, options } as any, event);
+});
+
+test('do not include dataclips in step:complete if output_dataclip is too big', async (t) => {
+  const plan = createPlan();
+  const jobId = 'job-1';
+  const result = { data: new Array(1024 * 1024 + 1).fill('z').join('') };
+
+  const state = createRunState(plan);
+  state.activeJob = jobId;
+  state.activeStep = 'b';
+
+  const options = {
+    payloadLimitMb: 1,
+  };
+
+  const channel = mockChannel({
+    [RUN_LOG]: () => true,
+    [STEP_COMPLETE]: (evt: StepCompletePayload) => {
+      t.falsy(evt.output_dataclip_id);
+      t.falsy(evt.output_dataclip);
+    },
+  });
+
+  const event = {
+    jobId,
+    workflowId: plan.id,
+    state: result,
+    next: ['a'],
+    mem: { job: 1, system: 10 },
+    duration: 61,
+    thread_id: 'abc',
+  } as JobCompletePayload;
+
+  await handleStepComplete({ channel, state, options } as any, event);
+});
+
+test('log when the output_dataclip is too big', async (t) => {
+  const plan = createPlan();
+  const jobId = 'job-1';
+  const result = { data: new Array(1024 * 1024 + 1).fill('z').join('') };
+
+  const state = createRunState(plan);
+  state.activeJob = jobId;
+  state.activeStep = 'b';
+
+  const options = {
+    payloadLimitMb: 1,
+  };
+
+  const channel = mockChannel({
+    [RUN_LOG]: (e) => {
+      t.regex(e.message[0], /dataclip too large/i);
+    },
+    [STEP_COMPLETE]: () => true,
+  });
+
+  const event = {
+    jobId,
+    workflowId: plan.id,
+    state: result,
+    next: ['a'],
+    mem: { job: 1, system: 10 },
+    duration: 61,
+    thread_id: 'abc',
+  } as JobCompletePayload;
+
   await handleStepComplete({ channel, state, options } as any, event);
 });

--- a/packages/ws-worker/test/util/convert-lightning-plan.test.ts
+++ b/packages/ws-worker/test/util/convert-lightning-plan.test.ts
@@ -90,7 +90,7 @@ test('convert a single job with options', (t) => {
       sanitize: 'obfuscate',
       run_timeout_ms: 10,
       run_memory_limit_mb: 500,
-      payload_memory_limit_mb: 20,
+      payload_limit_mb: 20,
     },
   };
   const { plan, options } = convertPlan(run as LightningPlan);

--- a/packages/ws-worker/test/util/convert-lightning-plan.test.ts
+++ b/packages/ws-worker/test/util/convert-lightning-plan.test.ts
@@ -89,6 +89,8 @@ test('convert a single job with options', (t) => {
     options: {
       sanitize: 'obfuscate',
       run_timeout_ms: 10,
+      run_memory_limit_mb: 500,
+      payload_memory_limit_mb: 20,
     },
   };
   const { plan, options } = convertPlan(run as LightningPlan);
@@ -102,6 +104,8 @@ test('convert a single job with options', (t) => {
   });
   t.deepEqual(options, {
     runTimeoutMs: 10,
+    memoryLimitMb: 500,
+    payloadLimitMb: 20,
     sanitize: 'obfuscate',
   });
 });

--- a/packages/ws-worker/test/util/ensure-payload-size.test.ts
+++ b/packages/ws-worker/test/util/ensure-payload-size.test.ts
@@ -1,0 +1,52 @@
+import test from 'ava';
+import ensurePayloadSize from '../../src/util/ensure-payload-size';
+
+const mb = (bytes: number) => bytes / 1024 / 1024;
+
+test('throw limit 0, payload 1 byte', (t) => {
+  t.throws(() => ensurePayloadSize('x', 0), {
+    name: 'PAYLOAD_TOO_LARGE',
+  });
+});
+
+test('ok for limit 1byte, payload 1 byte', (t) => {
+  t.notThrows(() => ensurePayloadSize('x', mb(1)));
+});
+
+test('throw for limit 1byte, payload 2 bytes', (t) => {
+  t.throws(() => ensurePayloadSize('xy', mb(1)), {
+    name: 'PAYLOAD_TOO_LARGE',
+  });
+});
+
+test('ok for short string, limit 1mb', (t) => {
+  t.notThrows(() => ensurePayloadSize('hello world', 1));
+});
+
+test('ok for 1mb string, limit 1mb', (t) => {
+  const str = new Array(1024 * 1024).fill('z').join('');
+  t.notThrows(() => ensurePayloadSize(str, 1));
+});
+
+test('throw for 1mb string + 1 byte, limit 1mb', (t) => {
+  const str = new Array(1024 * 1024 + 1).fill('z').join('');
+  t.throws(() => ensurePayloadSize(str, 1), {
+    name: 'PAYLOAD_TOO_LARGE',
+  });
+});
+
+test('ok if no limit', (t) => {
+  const str = new Array(1024 * 1024 + 1).fill('z').join('');
+  t.notThrows(() => ensurePayloadSize(str));
+});
+
+test('error shape', (t) => {
+  try {
+    const str = new Array(1024 * 1024 + 1).fill('z').join('');
+    ensurePayloadSize(str, 1);
+  } catch (e: any) {
+    t.is(e.severity, 'kill');
+    t.is(e.name, 'PAYLOAD_TOO_LARGE');
+    t.is(e.message, 'The payload exceeded the size limit of 1mb');
+  }
+});


### PR DESCRIPTION
* [x] Don't send a dataclip on step:complete if the payload  is too big
* [x] Don't send a log message if the payload is too big
* [x] Send `output_dataclip_id` to lightning  if the dataclip is removed

Closes #739 #571

Log output with limit printed, log redacted and dataclip not sent:
```
RTE Memory limit: 500mb
RTE Timeout: 300s
RTE Payload limit: 10mb
VER Versions:
    ▸ node.js                    18.12.1
    ▸ worker                     1.4.1
    ▸ @openfn/language-common    1.15.1
R/T Executing 4b9cf63e-82c0-46c3-beca-ad84d8d2daab
R/T Starting step New job
R/T [linker] loading module @openfn/language-common
R/T [linker] Loading module @openfn/language-common from /tmp/openfn/worker/repo/node_modules/@openfn/language-common_1.15.1/dist/index.cjs
R/T Resolved adaptor @openfn/language-common to version 1.15.1
R/T Executing expression (1 operations)
R/T Starting operation 1
JOB (Log message redacted: exceeds 10mb memory limit)
R/T Operation 1 complete in 59ms
R/T Expression complete!
R/T Completed step New job in 346ms
R/T Final memory usage: [step 81mb] [system 234mb]
R/T Dataclip too large. This dataclip will not be sent back to lighting.
R/T Run complete with status: success
```
