### PR TITLE
Support file path in job body

### DIFF
--- a/.changeset/swift-dingos-know.md
+++ b/.changeset/swift-dingos-know.md
@@ -3,4 +3,4 @@
 '@openfn/deploy': minor
 ---
 
-Support file paths for job body
+Deploy: allow job body to be loaded from a file path in workflow.yaml

--- a/.changeset/swift-dingos-know.md
+++ b/.changeset/swift-dingos-know.md
@@ -1,0 +1,6 @@
+---
+'@openfn/cli': minor
+'@openfn/deploy': minor
+---
+
+Support file paths for job body

--- a/packages/cli/src/pull/handler.ts
+++ b/packages/cli/src/pull/handler.ts
@@ -6,7 +6,7 @@ import {
   getProject,
   getSpec,
   getStateFromProjectPayload,
-  updatePulledSpecJobBodyPath,
+  syncRemoteSpec,
 } from '@openfn/deploy';
 import type { Logger } from '../util/logger';
 import { PullOptions } from '../pull/command';
@@ -48,8 +48,6 @@ async function pullHandler(options: PullOptions, logger: Logger) {
     // Build the state.json
     const state = getStateFromProjectPayload(project!);
 
-    // defer writing to disk until we have the spec
-
     logger.always('Downloading the project spec (as YAML) from the server.');
     // Get the project.yaml from Lightning
     const queryParams = new URLSearchParams();
@@ -82,8 +80,7 @@ async function pullHandler(options: PullOptions, logger: Logger) {
     const resolvedPath = path.resolve(config.specPath);
     logger.debug('reading spec from', resolvedPath);
 
-    // @ts-ignore
-    const updatedSpec = await updatePulledSpecJobBodyPath(
+    const updatedSpec = await syncRemoteSpec(
       await res.text(),
       state,
       config,

--- a/packages/deploy/src/index.ts
+++ b/packages/deploy/src/index.ts
@@ -1,8 +1,8 @@
 import { confirm } from '@inquirer/prompts';
 import { inspect } from 'node:util';
-import { DeployConfig, ProjectState, SpecJob } from './types';
+import { DeployConfig, ProjectState } from './types';
 import { readFile, writeFile } from 'fs/promises';
-import { parseAndValidate, addSpecJobBodyPath } from './validator';
+import { parseAndValidate } from './validator';
 import jsondiff from 'json-diff';
 import {
   mergeProjectPayloadIntoState,
@@ -10,6 +10,7 @@ import {
   toProjectPayload,
   getStateFromProjectPayload,
 } from './stateTransform';
+import { syncRemoteSpec } from './pull';
 import { deployProject, getProject } from './client';
 import { DeployError } from './deployError';
 import { Logger } from '@openfn/logger';
@@ -33,6 +34,7 @@ export {
   mergeSpecIntoState,
   mergeProjectPayloadIntoState,
   getStateFromProjectPayload,
+  syncRemoteSpec,
 };
 
 export async function getConfig(path?: string): Promise<DeployConfig> {
@@ -91,7 +93,7 @@ function writeState(config: DeployConfig, nextState: {}): Promise<void> {
 export async function getSpec(path: string) {
   try {
     const body = await readFile(path, 'utf8');
-    return await parseAndValidate(body, path);
+    return parseAndValidate(body, path);
   } catch (error: any) {
     if (error.code === 'ENOENT') {
       throw new DeployError(`File not found: ${path}`, 'SPEC_ERROR');
@@ -102,55 +104,6 @@ export async function getSpec(path: string) {
 }
 
 // =============================================
-
-async function getAllSpecJobs(
-  config: DeployConfig,
-  logger: Logger
-): Promise<SpecJob[]> {
-  const jobs: SpecJob[] = [];
-
-  try {
-    const [state, spec] = await Promise.all([
-      getState(config.statePath),
-      getSpec(config.specPath),
-    ]);
-
-    for (const [workflowKey, workflow] of Object.entries(spec.doc.workflows)) {
-      if (workflow.jobs) {
-        for (const [jobKey, specJob] of Object.entries(workflow.jobs)) {
-          const stateJob = state.workflows[workflowKey]?.jobs[jobKey];
-          stateJob &&
-            jobs.push({
-              id: stateJob.id,
-              name: specJob.name,
-              adaptor: specJob.adaptor,
-              body: specJob.body,
-            });
-        }
-      }
-    }
-  } catch (error: any) {
-    logger.debug(`Could not read the spec and state: ${error.message}`);
-  }
-
-  return jobs;
-}
-
-export async function updatePulledSpecJobBodyPath(
-  newSpecBody: string,
-  newState: ProjectState,
-  config: DeployConfig,
-  logger: Logger
-): Promise<string> {
-  try {
-    const oldSpecJobs = await getAllSpecJobs(config, logger);
-
-    return await addSpecJobBodyPath(newSpecBody, newState, oldSpecJobs, config);
-  } catch (error: any) {
-    logger.warn(`Could not update spec job body paths: ${error.message}`);
-    return newSpecBody;
-  }
-}
 
 export async function deploy(config: DeployConfig, logger: Logger) {
   const [state, spec] = await Promise.all([

--- a/packages/deploy/src/pull.ts
+++ b/packages/deploy/src/pull.ts
@@ -1,0 +1,122 @@
+import YAML, { Pair, Scalar, isPair, isScalar } from 'yaml';
+import { DeployConfig, ProjectState, SpecJob } from './types';
+import { Logger } from '@openfn/logger';
+import { writeFile } from 'fs/promises';
+import path from 'path';
+import { getState, getSpec } from './index';
+
+async function getAllSpecJobs(
+  config: DeployConfig,
+  logger: Logger
+): Promise<SpecJob[]> {
+  const jobs: SpecJob[] = [];
+
+  try {
+    const state = await getState(config.statePath);
+    const spec = await getSpec(config.specPath);
+
+    for (const [workflowKey, workflow] of Object.entries(spec.doc.workflows)) {
+      if (workflow.jobs) {
+        for (const [jobKey, specJob] of Object.entries(workflow.jobs)) {
+          const stateJob = state.workflows[workflowKey]?.jobs[jobKey];
+          stateJob &&
+            jobs.push({
+              id: stateJob.id,
+              name: specJob.name,
+              adaptor: specJob.adaptor,
+              body: specJob.body,
+            });
+        }
+      }
+    }
+  } catch (error: any) {
+    logger.debug(`Could not read the spec and state: ${error.message}`);
+  }
+
+  return jobs;
+}
+
+async function extractJobsToDisk(
+  specBody: string,
+  state: ProjectState,
+  oldJobs: SpecJob[],
+  config: DeployConfig
+): Promise<string> {
+  function isPairWithScalarKey(
+    node: any
+  ): node is Pair & { key: Scalar & { value: string } } {
+    return (
+      isPair(node) && isScalar(node.key) && typeof node.key.value === 'string'
+    );
+  }
+
+  const doc = YAML.parseDocument(specBody);
+
+  await YAML.visitAsync(doc, {
+    async Pair(_, pair: any, pairPath) {
+      if (
+        !pair.key ||
+        pair.key.value !== 'body' ||
+        !isScalar(pair.value) ||
+        pairPath.length <= 6
+      ) {
+        return;
+      }
+
+      const jobPair = pairPath[pairPath.length - 2];
+      const workflowPair = pairPath[pairPath.length - 6];
+
+      if (!isPairWithScalarKey(jobPair) || !isPairWithScalarKey(workflowPair)) {
+        return;
+      }
+
+      const jobKey = jobPair.key.value;
+      const workflowKey = workflowPair.key.value;
+
+      // find the job in the state
+      const stateJob = state.workflows[workflowKey]?.jobs[jobKey];
+
+      if (!stateJob) {
+        return;
+      }
+
+      // check if the state job is in the old spec jobs
+      const oldSpecJob = oldJobs.find((job) => job.id === stateJob.id);
+
+      if (!oldSpecJob || typeof oldSpecJob?.body !== 'object') {
+        return;
+      }
+
+      const oldSpecJobPath = oldSpecJob.body.path;
+
+      if (oldSpecJobPath) {
+        const basePath = path.dirname(config.specPath);
+        const resolvedPath = path.resolve(basePath, oldSpecJobPath);
+        await writeFile(resolvedPath, pair.value.value);
+
+        // set the body path in the spec
+        const map = doc.createNode({ path: oldSpecJobPath });
+
+        pair.value = map;
+      }
+    },
+  });
+
+  return doc.toString();
+}
+
+export async function syncRemoteSpec(
+  remoteSpecBody: string,
+  newState: ProjectState,
+  config: DeployConfig,
+  logger: Logger
+): Promise<string> {
+  try {
+    const oldSpecJobs = await getAllSpecJobs(config, logger);
+
+    return extractJobsToDisk(remoteSpecBody, newState, oldSpecJobs, config);
+  } catch (error: any) {
+    logger.warn(`Could not update spec job body paths: ${error.message}`);
+    return remoteSpecBody;
+  }
+}

--- a/packages/deploy/src/stateTransform.ts
+++ b/packages/deploy/src/stateTransform.ts
@@ -5,6 +5,7 @@ import {
   ProjectSpec,
   ProjectState,
   SpecEdge,
+  SpecJobBody,
   StateEdge,
   WorkflowSpec,
   WorkflowState,
@@ -20,6 +21,14 @@ import {
 import { DeployError } from './deployError';
 import { Logger } from '@openfn/logger/dist';
 
+function stringifyJobBody(body: SpecJobBody): string {
+  if (typeof body === 'object') {
+    return body.content;
+  } else {
+    return body;
+  }
+}
+
 function mergeJobs(
   stateJobs: WorkflowState['jobs'],
   specJobs: WorkflowSpec['jobs']
@@ -33,7 +42,7 @@ function mergeJobs(
             id: crypto.randomUUID(),
             name: specJob.name,
             adaptor: specJob.adaptor,
-            body: specJob.body,
+            body: stringifyJobBody(specJob.body),
           },
         ];
       }
@@ -49,7 +58,7 @@ function mergeJobs(
             id: stateJob.id,
             name: specJob.name,
             adaptor: specJob.adaptor,
-            body: specJob.body,
+            body: stringifyJobBody(specJob.body),
           },
         ];
       }

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -1,9 +1,23 @@
-export type Job = {
+export type StateJob = {
   id?: string;
   name: string;
   adaptor: string;
   body: string;
   delete?: boolean;
+};
+
+export type SpecJobBody =
+  | string
+  | {
+      path?: string;
+      content: string;
+    };
+
+export type SpecJob = {
+  id?: string;
+  name: string;
+  adaptor: string;
+  body: SpecJobBody;
 };
 
 export type Trigger = {
@@ -38,7 +52,7 @@ export type SpecEdge = {
 export type WorkflowSpec = {
   id?: string;
   name: string;
-  jobs?: Record<string | symbol, Job>;
+  jobs?: Record<string | symbol, SpecJob>;
   triggers?: Record<string | symbol, Trigger>;
   edges?: Record<string | symbol, SpecEdge>;
 };
@@ -52,7 +66,7 @@ export interface ProjectSpec {
 export interface WorkflowState {
   id: string;
   name: string;
-  jobs: Record<string | symbol, Concrete<Job>>;
+  jobs: Record<string | symbol, Concrete<StateJob>>;
   triggers: Record<string | symbol, Concrete<Trigger>>;
   edges: Record<string | symbol, Concrete<StateEdge>>;
   delete?: boolean;
@@ -78,7 +92,7 @@ export interface ProjectPayload {
     id: string;
     name: string;
     project_id?: string;
-    jobs: Concrete<Job>[];
+    jobs: Concrete<StateJob>[];
     triggers: Concrete<Trigger>[];
     edges: Concrete<StateEdge>[];
   }[];

--- a/packages/deploy/test/fixtures.ts
+++ b/packages/deploy/test/fixtures.ts
@@ -11,7 +11,10 @@ export function fullExampleSpec() {
           'job-a': {
             name: 'job a',
             adaptor: '@openfn/language-common@latest',
-            body: '',
+            body: {
+              path: 'somefile.js',
+              content: '',
+            },
           },
           'job-b': {
             name: 'job b',

--- a/packages/deploy/test/util.ts
+++ b/packages/deploy/test/util.ts
@@ -1,0 +1,14 @@
+import mock from 'mock-fs';
+import path from 'node:path';
+
+export const mockFs = (files: Record<string, string>) => {
+  const pnpm = path.resolve('../../node_modules/.pnpm');
+  mock({
+    [pnpm]: mock.load(pnpm, {}),
+    ...files,
+  });
+};
+
+export const resetMockFs = () => {
+  mock.restore();
+};

--- a/packages/deploy/test/validator.test.ts
+++ b/packages/deploy/test/validator.test.ts
@@ -1,11 +1,23 @@
 import test from 'ava';
 import { parseAndValidate } from '../src/validator';
+import fs from 'fs/promises';
+import path from 'path';
+
+// Helper to create and clean up temporary test files
+const createTempFile = async (t, content: string, ext = 'txt') => {
+  const fileName = `${t.title.replace(/\s+/g, '_')}-${Math.floor(
+    Math.random() * 20
+  )}.${ext}`;
+  const filePath = path.resolve(fileName);
+  await fs.writeFile(filePath, content);
+  return filePath;
+};
 
 function findError(errors: any[], message: string) {
   return errors.find((e) => e.message === message);
 }
 
-test('Workflows must be a map', (t) => {
+test('Workflows must be a map', async (t) => {
   const doc = `
     name: project-name
     workflows:
@@ -13,7 +25,7 @@ test('Workflows must be a map', (t) => {
       - name: workflow-two
     `;
 
-  const results = parseAndValidate(doc);
+  const results = await parseAndValidate(doc, 'spec.yaml');
 
   const err = findError(results.errors, 'must be a map');
 
@@ -21,7 +33,7 @@ test('Workflows must be a map', (t) => {
   t.is(err.path, 'workflows');
 });
 
-test('Workflows must have unique ids', (t) => {
+test('Workflows must have unique ids', async (t) => {
   const doc = `
     name: project-name
     workflows:
@@ -33,14 +45,14 @@ test('Workflows must have unique ids', (t) => {
         name: workflow three
   `;
 
-  const results = parseAndValidate(doc);
+  const results = await parseAndValidate(doc, 'spec.yaml');
 
   const err = findError(results.errors, 'duplicate id: workflow-one');
   t.truthy(err);
   t.is(err.path, 'workflow-one');
 });
 
-test('Jobs must have unique ids within a workflow', (t) => {
+test('Jobs must have unique ids within a workflow', async (t) => {
   const doc = `
     name: project-name
     workflows:
@@ -52,14 +64,14 @@ test('Jobs must have unique ids within a workflow', (t) => {
           bar:
     `;
 
-  const results = parseAndValidate(doc);
+  const results = await parseAndValidate(doc, 'spec.yaml');
 
   const err = findError(results.errors, 'duplicate id: foo');
   t.is(err.path, 'workflow-two/foo');
   t.truthy(err);
 });
 
-test('Job ids can duplicate across workflows', (t) => {
+test('Job ids can duplicate across workflows', async (t) => {
   const doc = `
     name: project-name
     workflows:
@@ -73,12 +85,12 @@ test('Job ids can duplicate across workflows', (t) => {
           foo:
     `;
 
-  const results = parseAndValidate(doc);
+  const results = await parseAndValidate(doc, 'spec.yaml');
 
   t.is(results.errors.length, 0);
 });
 
-test('Workflow edges are parsed correctly', (t) => {
+test('Workflow edges are parsed correctly', async (t) => {
   const doc = `
     name: project-name
     workflows:
@@ -101,7 +113,7 @@ test('Workflow edges are parsed correctly', (t) => {
             condition_expression: true
   `;
 
-  const results = parseAndValidate(doc);
+  const results = await parseAndValidate(doc, 'spec.yaml');
 
   t.assert(
     results.doc.workflows['workflow-one'].edges![
@@ -110,12 +122,12 @@ test('Workflow edges are parsed correctly', (t) => {
   );
 });
 
-test('allow empty workflows', (t) => {
+test('allow empty workflows', async (t) => {
   let doc = `
     name: project-name
   `;
 
-  const result = parseAndValidate(doc);
+  const result = await parseAndValidate(doc, 'spec.yaml');
 
   t.is(result.errors.length, 0);
 
@@ -123,4 +135,35 @@ test('allow empty workflows', (t) => {
     name: 'project-name',
     workflows: {},
   });
+});
+
+test('adds the file content into the job body from the specified path', async (t) => {
+  // Step 1: Create a temporary file that the YAML will reference
+  const fileContent = 'fn(state => state.data);';
+  const filePath = await createTempFile(t, fileContent);
+
+  // Step 2: YAML document that references the file
+  const doc = `
+    name: project-name
+    workflows:
+      workflow-one:
+        name: workflow one
+        jobs:
+          job-one:
+            name: job one
+            adaptor: '@openfn/language-http@latest'
+            body:
+              path: ${path.basename(filePath)}
+  `;
+
+  // Step 3: Run the parseAndValidate function
+  const results = await parseAndValidate(doc, 'spec.yaml');
+
+  // Step 4: Assert that the content from the file was merged into the spec
+  const jobBody = results.doc.workflows['workflow-one'].jobs!['job-one'].body;
+
+  t.is(jobBody.content, fileContent);
+
+  // Cleanup
+  await fs.rm(filePath);
 });


### PR DESCRIPTION
## Short Description

Support file paths in job body

## Related issue

Fixes #285 

## Implementation Details
When the `path` is present in the body, we load the file's content into another key `content`. So essentially, it becomes:
`{ path: './bodyPath.js', content: 'content fron bodyPath.js' }`

The `YAML.vistor` function does all the magic here. 
While traversing the nodes, we check if the current node is the `job body`. We know that it's the job body by moving up the `path tree` until we find a node with the key `jobs`. Here's how the path tree looks like:
```bash
[
  Document {
    ....
    contents: YAMLMap { items: [Array], range: [Array] },
    range: [ 0, 972, 972 ]
  },
  YAMLMap { items: [ [Pair], [Pair] ], range: [ 0, 972, 972 ] },
  Pair {
    key: Scalar {
      value: 'workflows',
      ...
    },
    value: YAMLMap { items: [Array], range: [Array] }
  },
  YAMLMap { items: [ [Pair] ], range: [ 74, 972, 972 ] },
  Pair {
    key: Scalar {
      value: 'DHIS2-to-Sheets',
      ...
    },
    value: YAMLMap { items: [Array], range: [Array] }
  },
  YAMLMap {
    items: [ [Pair], [Pair], [Pair], [Pair] ],
    range: [ 95, 972, 972 ]
  },
  Pair {
    key: Scalar {
      value: 'jobs',
      ...
    },
    value: YAMLMap { items: [Array], range: [Array] }
  },
  YAMLMap { items: [ [Pair], [Pair] ], range: [ 133, 526, 526 ] },
  Pair {
    key: Scalar {
      value: 'Upload-to-Google-Sheet',
      ...
    },
    value: YAMLMap { items: [Array], range: [Array] }
  },
  YAMLMap {
    items: [ [Pair], [Pair], [Pair] ],
    range: [ 363, 526, 526 ]
  }
]
```

When you `pull`, we merge the `StateJob.id` into the `SpecJob.id` of the current state and spec in place. We then keep track of all the jobs in a single place. The `id` here is guaranteed to be unique.
These "old spec jobs" are what we use to match the "new spec job". 


## QA Notes

List any considerations/cases/advice for testing/QA here.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added unit tests
- [x] Changesets have been added (if there are production code changes)


