### PR TITLE
Use language-common that does not depend on axios

### DIFF
--- a/.changeset/late-eels-relax.md
+++ b/.changeset/late-eels-relax.md
@@ -1,6 +1,0 @@
----
-'@openfn/integration-tests-execute': patch
-'@openfn/describe-package': patch
----
-
-Update language-common to a version that does not have a dependency on axios.

--- a/.changeset/late-eels-relax.md
+++ b/.changeset/late-eels-relax.md
@@ -1,0 +1,6 @@
+---
+'@openfn/integration-tests-execute': patch
+'@openfn/describe-package': patch
+---
+
+Update language-common to a version that does not have a dependency on axios.

--- a/examples/dts-inspector/CHANGELOG.md
+++ b/examples/dts-inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # dts-inspector
 
+## 1.0.20
+
+### Patch Changes
+
+- Updated dependencies [423a927]
+  - @openfn/describe-package@0.1.2
+
 ## 1.0.19
 
 ### Patch Changes

--- a/examples/dts-inspector/package.json
+++ b/examples/dts-inspector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dts-inspector",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/integration-tests/execute/CHANGELOG.md
+++ b/integration-tests/execute/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/integration-tests-execute
 
+## 1.0.4
+
+### Patch Changes
+
+- 423a927: Update language-common to a version that does not have a dependency on axios.
+  - @openfn/compiler@0.3.2
+
 ## 1.0.3
 
 ### Patch Changes

--- a/integration-tests/execute/package.json
+++ b/integration-tests/execute/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@openfn/compiler": "workspace:^",
-    "@openfn/language-common": "1.7.7",
-    "@openfn/language-http": "6.4.0",
+    "@openfn/language-common": "2.0.1",
+    "@openfn/language-http": "6.4.3",
     "@openfn/runtime": "workspace:^",
     "@types/node": "^18.15.13",
     "ava": "5.3.1",

--- a/integration-tests/execute/package.json
+++ b/integration-tests/execute/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-execute",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Job execution tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/integration-tests-worker
 
+## 1.0.58
+
+### Patch Changes
+
+- @openfn/engine-multi@1.2.4
+- @openfn/lightning-mock@2.0.18
+- @openfn/ws-worker@1.6.3
+
 ## 1.0.57
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @openfn/cli
 
+## 1.8.3
+
+### Patch Changes
+
+Security update.
+
+- Updated dependencies [423a927]
+  - @openfn/describe-package@0.1.2
+  - @openfn/compiler@0.3.2
+
 ## 1.8.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/compiler
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies [423a927]
+  - @openfn/describe-package@0.1.2
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/compiler",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Compiler and language tooling for openfn jobs.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/describe-package/CHANGELOG.md
+++ b/packages/describe-package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/describe-package
 
+## 0.1.2
+
+### Patch Changes
+
+- 423a927: Update language-common to a version that does not have a dependency on axios.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/describe-package/package.json
+++ b/packages/describe-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/describe-package",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Utilities to inspect an npm package.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/describe-package/package.json
+++ b/packages/describe-package/package.json
@@ -37,7 +37,7 @@
   },
   "keywords": [],
   "devDependencies": {
-    "@openfn/language-common": "1.7.5",
+    "@openfn/language-common": "2.0.1",
     "@types/node": "^18.15.13",
     "@types/node-localstorage": "^1.3.0",
     "@types/rimraf": "^3.0.2",

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # engine-multi
 
+## 1.2.4
+
+### Patch Changes
+
+- @openfn/compiler@0.3.2
+
 ## 1.2.3
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/lightning-mock
 
+## 2.0.18
+
+### Patch Changes
+
+- @openfn/engine-multi@1.2.4
+
 ## 2.0.17
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ws-worker
 
+## 1.6.3
+
+### Patch Changes
+
+Security update
+
+- @openfn/engine-multi@1.2.4
+
 ## 1.6.2
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,11 +107,11 @@ importers:
         specifier: workspace:^
         version: link:../../packages/compiler
       '@openfn/language-common':
-        specifier: 1.7.7
-        version: 1.7.7
+        specifier: 2.0.1
+        version: 2.0.1
       '@openfn/language-http':
-        specifier: 6.4.0
-        version: 6.4.0
+        specifier: 6.4.3
+        version: 6.4.3
       '@openfn/runtime':
         specifier: workspace:^
         version: link:../../packages/runtime
@@ -383,8 +383,8 @@ importers:
         version: 5.0.0
     devDependencies:
       '@openfn/language-common':
-        specifier: 1.7.5
-        version: 1.7.5
+        specifier: 2.0.1
+        version: 2.0.1
       '@types/node':
         specifier: ^18.15.13
         version: 18.15.13
@@ -1398,7 +1398,6 @@ packages:
   /@fastify/busboy@2.1.1:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
-    dev: false
 
   /@inquirer/checkbox@1.3.5:
     resolution: {integrity: sha512-ZznkPU+8XgNICKkqaoYENa0vTw9jeToEHYyG5gUKpGmY+4PqPTsvLpSisOt9sukLkYzPRkpSCHREgJLqbCG3Fw==}
@@ -1674,11 +1673,14 @@ packages:
     engines: {node: ^16.14.0 || >=18.0.0}
     dev: true
 
-  /@openfn/language-common@1.15.0:
-    resolution: {integrity: sha512-aBWCvnJc0MCRjF6wUHicU5nkM3wWxrJV7K81j0FB7hQqerFSTk/ceq8/a98bi2Tcd9CV8WBTPF1AfROMcpNSEg==}
+  /@openfn/language-common@2.0.0-rc3:
+    resolution: {integrity: sha512-7kwhBnCd1idyTB3MD9dXmUqROAhoaUIkz2AGDKuv9vn/cbZh7egEv9/PzKkRcDJYFV9qyyS+cVT3Xbgsg2ii5g==}
+    bundledDependencies: []
+
+  /@openfn/language-common@2.0.1:
+    resolution: {integrity: sha512-eiBcgjEzRrZL/sr/ULK/GUQSzktvThbAoorWDM3nXHq22d4OAJkePfFPY4mb7xveCKDNBADTWY39j7CgPiI9Jw==}
     dependencies:
       ajv: 8.17.1
-      axios: 1.1.3
       csv-parse: 5.5.6
       csvtojson: 2.0.10
       date-fns: 2.30.0
@@ -1686,44 +1688,13 @@ packages:
       jsonpath-plus: 4.0.0
       lodash: 4.17.21
       undici: 5.28.4
-    transitivePeerDependencies:
-      - debug
-    dev: false
 
-  /@openfn/language-common@1.7.5:
-    resolution: {integrity: sha512-QivV3v5Oq5fb4QMopzyqUUh+UGHaFXBdsGr6RCmu6bFnGXdJdcQ7GpGpW5hKNq29CkmE23L/qAna1OLr4rP/0w==}
+  /@openfn/language-http@6.4.3:
+    resolution: {integrity: sha512-8ihgIYId+ewMuNU9hbe5JWEWvaJInDrIEiy4EyO7tbzu5t/f1kO18JIzQWm6r7dcHiMfcG2QaXe6O3br1xOrDA==}
     dependencies:
-      axios: 1.1.3
-      date-fns: 2.30.0
-      jsonpath-plus: 4.0.0
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - debug
-    dev: true
-
-  /@openfn/language-common@1.7.7:
-    resolution: {integrity: sha512-GSoAbo6oL0b8jHufhLKvIzHJ271aE2AKv/ibeuiWU3CqN1gRmaHArlA/omlCs/rsfcieSp2VWAvWeGuFY8buZw==}
-    dependencies:
-      axios: 1.1.3
-      date-fns: 2.30.0
-      jsonpath-plus: 4.0.0
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /@openfn/language-common@2.0.0-rc3:
-    resolution: {integrity: sha512-7kwhBnCd1idyTB3MD9dXmUqROAhoaUIkz2AGDKuv9vn/cbZh7egEv9/PzKkRcDJYFV9qyyS+cVT3Xbgsg2ii5g==}
-    bundledDependencies: []
-
-  /@openfn/language-http@6.4.0:
-    resolution: {integrity: sha512-dZwbBV47UrmUlDo5Z9F5XMQq0i8XEHNo0xbgUcCeq7EaJrYn4E2EzK4q2DLzSZb+14K/PWOeUHATL/LCHx+w6g==}
-    dependencies:
-      '@openfn/language-common': 1.15.0
+      '@openfn/language-common': 2.0.1
       cheerio: 1.0.0-rc.12
       cheerio-tableparser: 1.0.1
-    transitivePeerDependencies:
-      - debug
     dev: false
 
   /@pkgjs/parseargs@0.11.0:
@@ -2164,7 +2135,6 @@ packages:
       fast-uri: 3.0.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-    dev: false
 
   /ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -2276,6 +2246,7 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: true
 
   /ava@5.1.0:
     resolution: {integrity: sha512-e5VFrSQ0WBPyZJWRXVrO7RFOizFeNM0t2PORwrPvWtApgkORI6cvGnY3GX1G+lzpd0HjqNx5Jus22AhxVnUMNA==}
@@ -2400,15 +2371,6 @@ packages:
       fast-glob: 3.3.2
     dev: true
 
-  /axios@1.1.3:
-    resolution: {integrity: sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==}
-    dependencies:
-      follow-redirects: 1.15.3
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   /axios@1.7.7:
     resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
     dependencies:
@@ -2459,7 +2421,6 @@ packages:
 
   /bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
-    dev: false
 
   /blueimp-md5@2.19.0:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
@@ -2814,6 +2775,7 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
+    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -2949,7 +2911,6 @@ packages:
 
   /csv-parse@5.5.6:
     resolution: {integrity: sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A==}
-    dev: false
 
   /csv-stringify@5.6.5:
     resolution: {integrity: sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==}
@@ -2973,7 +2934,6 @@ packages:
       bluebird: 3.7.2
       lodash: 4.17.21
       strip-bom: 2.0.0
-    dev: false
 
   /currently-unhandled@0.4.1:
     resolution: {integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==}
@@ -3089,6 +3049,7 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+    dev: true
 
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -3892,7 +3853,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: false
 
   /fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
@@ -3947,7 +3907,6 @@ packages:
 
   /fast-uri@3.0.1:
     resolution: {integrity: sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==}
-    dev: false
 
   /fastq@1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
@@ -4009,15 +3968,6 @@ packages:
       pkg-dir: 4.2.0
     dev: true
 
-  /follow-redirects@1.15.3:
-    resolution: {integrity: sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   /follow-redirects@1.15.8:
     resolution: {integrity: sha512-xgrmBhBToVKay1q2Tao5LI26B83UhrB/vM1avwVSDzt8rx3rO6AizBAaF46EgksTVr+rFTQaqZZ9MVBfUe4nig==}
     engines: {node: '>=4.0'}
@@ -4052,6 +4002,7 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+    dev: true
 
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -4338,7 +4289,6 @@ packages:
 
   /http-status-codes@2.3.0:
     resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
-    dev: false
 
   /https-proxy-agent@7.0.5:
     resolution: {integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==}
@@ -4646,7 +4596,6 @@ packages:
 
   /is-utf8@0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
-    dev: false
 
   /is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
@@ -4729,7 +4678,6 @@ packages:
 
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-    dev: false
 
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -5880,6 +5828,7 @@ packages:
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: true
 
   /pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
@@ -6078,7 +6027,6 @@ packages:
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
@@ -6486,7 +6434,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-utf8: 0.2.1
-    dev: false
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -7091,7 +7038,6 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.1.1
-    dev: false
 
   /unique-filename@3.0.0:
     resolution: {integrity: sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==}


### PR DESCRIPTION
## Short Description

Update dev dependencies to use a version to `@openfn/language-common` that does not depend on a vulnerable version of axios.

## Related issue

Fixes #768 

## Implementation Details

A more detailed breakdown of the changes, including motivations (if not provided in the issue).

## QA Notes

List any considerations/cases/advice for testing/QA here.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added unit tests
- [ ] If this is a change to the Worker, does the API_VERSION need bumping?
- [x] Changesets have been added (if there are production code changes)


