### PR TITLE
engine: Include timestamp on `JOB_ERROR`

### DIFF
--- a/.changeset/healthy-kangaroos-cross.md
+++ b/.changeset/healthy-kangaroos-cross.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': minor
+---
+
+Include timestamp on JOB_ERROR payload

--- a/.changeset/healthy-kangaroos-cross.md
+++ b/.changeset/healthy-kangaroos-cross.md
@@ -1,5 +1,0 @@
----
-'@openfn/engine-multi': minor
----
-
-Include timestamp on JOB_ERROR payload

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openfn/integration-tests-worker
 
+## 1.0.62
+
+### Patch Changes
+
+- Updated dependencies [ae55a6a]
+  - @openfn/engine-multi@1.3.0
+  - @openfn/ws-worker@1.7.0
+  - @openfn/lightning-mock@2.0.20
+
 ## 1.0.61
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.61",
+  "version": "1.0.62",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # engine-multi
 
+## 1.3.0
+
+### Minor Changes
+
+- ae55a6a: Include timestamp on JOB_ERROR payload
+
 ## 1.2.5
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/engine-multi/src/api/lifecycle.ts
+++ b/packages/engine-multi/src/api/lifecycle.ts
@@ -120,6 +120,7 @@ export const jobError = (
     duration,
     jobId,
     next,
+    time: timestamp(),
   });
 };
 

--- a/packages/engine-multi/src/events.ts
+++ b/packages/engine-multi/src/events.ts
@@ -86,6 +86,7 @@ export interface JobCompletePayload extends ExternalEvent {
 export interface JobErrorPayload extends ExternalEvent {
   jobId: string;
   duration: number;
+  time: bigint;
   state: any; // the result state
   error: any;
   next: string[]; // downstream jobs

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/lightning-mock
 
+## 2.0.20
+
+### Patch Changes
+
+- Updated dependencies [ae55a6a]
+  - @openfn/engine-multi@1.3.0
+
 ## 2.0.19
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,16 @@
 # ws-worker
 
+## 1.7.0
+
+### Minor Changes
+
+- ae55a6a: Include timestamp on step complete even if the step failed
+
+### Patch Changes
+
+- Updated dependencies [ae55a6a]
+  - @openfn/engine-multi@1.3.0
+
 ## 1.6.7
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.6.7",
+  "version": "1.7.0",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Short Description

Includes timestamp on `JOB_ERROR` event payload

Fixes #794 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)


