### PR TITLE
CLI: Support kafka trigger type

### DIFF
--- a/.changeset/shiny-fans-tickle.md
+++ b/.changeset/shiny-fans-tickle.md
@@ -1,5 +1,0 @@
----
-'@openfn/deploy': minor
----
-
-Support Kafka trigger type in CLI

--- a/.changeset/shiny-fans-tickle.md
+++ b/.changeset/shiny-fans-tickle.md
@@ -1,0 +1,5 @@
+---
+'@openfn/deploy': minor
+---
+
+Support Kafka trigger type in CLI

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openfn/cli
 
+## 1.8.5
+
+### Patch Changes
+
+Support Kafka trigger type in CLI
+
+- Updated dependencies [7c96d79]
+  - @openfn/deploy@0.8.0
+
 ## 1.8.4
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/deploy/CHANGELOG.md
+++ b/packages/deploy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/deploy
 
+## 0.8.0
+
+### Minor Changes
+
+- 7c96d79: Support Kafka trigger type in CLI
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/deploy",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Deploy projects to Lightning instances",
   "type": "module",
   "exports": {

--- a/packages/deploy/src/stateTransform.ts
+++ b/packages/deploy/src/stateTransform.ts
@@ -168,6 +168,7 @@ function mergeTriggers(
 
         // prefer spec, but use state if spec is missing, or default
         const trigger = {
+          id: stateTrigger!.id,
           type: pickValue(specTrigger!, stateTrigger!, 'type', 'webhook'),
           enabled: pickValue(specTrigger!, stateTrigger!, 'enabled', true),
         };

--- a/packages/deploy/src/stateTransform.ts
+++ b/packages/deploy/src/stateTransform.ts
@@ -141,7 +141,7 @@ function mergeTriggers(
     splitZip(stateTriggers, specTriggers!).map(
       ([triggerKey, stateTrigger, specTrigger]) => {
         if (specTrigger && !stateTrigger) {
-          const trigger = {
+          const trigger: any = {
             id: crypto.randomUUID(),
             ...pickKeys(specTrigger, ['type', 'enabled']),
           };
@@ -154,7 +154,7 @@ function mergeTriggers(
             trigger.kafka_configuration = {
               ...specTrigger.kafka_configuration,
               hosts: transformSpecKafkaHost(
-                specTrigger.kafka_configuration?.hosts ?? []
+                specTrigger.kafka_configuration?.hosts
               ),
             };
           }
@@ -167,7 +167,7 @@ function mergeTriggers(
         }
 
         // prefer spec, but use state if spec is missing, or default
-        const trigger = {
+        const trigger: any = {
           id: stateTrigger!.id,
           type: pickValue(specTrigger!, stateTrigger!, 'type', 'webhook'),
           enabled: pickValue(specTrigger!, stateTrigger!, 'enabled', true),

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -22,16 +22,36 @@ export type SpecJob = {
   credential: string | null;
 };
 
-export type Trigger = {
-  id?: string;
-  type?: string;
+export type StateKafkaHost = [string, string];
+
+export type StateKafkaConfiguration = {
+  hosts: StateKafkaHost[];
+  topics: string[];
+  initial_offset_reset_policy: string;
+  connect_timeout: number;
+};
+
+export type SpecKafkaConfiguration = {
+  hosts: string[];
+  topics: string[];
+  initial_offset_reset_policy: string;
+  connect_timeout: number;
+};
+
+export type SpecTrigger = {
+  type: string;
+  cron_expression?: string;
+  enabled?: boolean;
+  kafka_configuration?: SpecKafkaConfiguration;
+};
+
+export type StateTrigger = {
+  id: string;
+  type: string;
   cron_expression?: string;
   delete?: boolean;
-  hosts?: string[];
-  topics?: string[];
-  initial_offset_reset_policy?: string;
-  connect_timeout?: number;
   enabled?: boolean;
+  kafka_configuration?: StateKafkaConfiguration;
 };
 
 export type StateEdge = {
@@ -59,7 +79,7 @@ export type WorkflowSpec = {
   id?: string;
   name: string;
   jobs?: Record<string | symbol, SpecJob>;
-  triggers?: Record<string | symbol, Trigger>;
+  triggers?: Record<string | symbol, SpecTrigger>;
   edges?: Record<string | symbol, SpecEdge>;
 };
 
@@ -85,7 +105,7 @@ export interface WorkflowState {
   id: string;
   name: string;
   jobs: Record<string | symbol, Concrete<StateJob>>;
-  triggers: Record<string | symbol, Concrete<Trigger>>;
+  triggers: Record<string | symbol, Concrete<StateTrigger>>;
   edges: Record<string | symbol, Concrete<StateEdge>>;
   delete?: boolean;
   project_id?: string;
@@ -113,7 +133,7 @@ export interface ProjectPayload {
     name: string;
     project_id?: string;
     jobs: Concrete<StateJob>[];
-    triggers: Concrete<Trigger>[];
+    triggers: Concrete<StateTrigger>[];
     edges: Concrete<StateEdge>[];
   }[];
 }

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -27,6 +27,10 @@ export type Trigger = {
   type?: string;
   cron_expression?: string;
   delete?: boolean;
+  hosts?: string[];
+  topics?: string[];
+  initial_offset_reset_policy?: string;
+  connect_timeout?: number;
   enabled?: boolean;
 };
 


### PR DESCRIPTION
## Short Description

This pull request adds `kafka` trigger type. 

Fixes #796 

## Implementation Details

- The structure maintains the structure as it is in lightning
- There is a validation that uses regex to ensure that the host is in the form `hostname:number`

## QA Notes

List any considerations/cases/advice for testing/QA here.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)


