### PR TITLE
Support multiple adaptors in the compiler

### DIFF
--- a/.changeset/neat-lies-begin.md
+++ b/.changeset/neat-lies-begin.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': minor
+---
+
+Support multiple adaptors in job structures

--- a/.changeset/sharp-needles-peel.md
+++ b/.changeset/sharp-needles-peel.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Update worker to use adaptors as an array on xplans. Internal only change.

--- a/.changeset/sharp-tips-pretend.md
+++ b/.changeset/sharp-tips-pretend.md
@@ -1,0 +1,5 @@
+---
+'@openfn/compiler': minor
+---
+
+support multiple adaptors when adding imports

--- a/.changeset/wild-donuts-check.md
+++ b/.changeset/wild-donuts-check.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Support multiple adaptors

--- a/integration-tests/execute/src/execute.ts
+++ b/integration-tests/execute/src/execute.ts
@@ -6,10 +6,12 @@ const execute = async (job: string, state: any, adaptor = 'common') => {
   // compile with common and dumb imports
   const options = {
     'add-imports': {
-      adaptor: {
-        name: `@openfn/language-${adaptor}`,
-        exportAll: true,
-      },
+      adaptors: [
+        {
+          name: `@openfn/language-${adaptor}`,
+          exportAll: true,
+        },
+      ],
     },
   };
   const compiled = compiler(job, options);

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -56,10 +56,8 @@ const compileWorkflow = async (
     const job = step as Job;
     const jobOpts = {
       ...opts,
+      adaptors: job.adaptors ?? opts.adaptors,
     };
-    if (job.adaptor) {
-      jobOpts.adaptors = [job.adaptor];
-    }
     if (job.expression) {
       job.expression = await compileJob(
         job.expression as string,

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -115,37 +115,41 @@ export const loadTransformOptions = async (
   // If an adaptor is passed in, we need to look up its declared exports
   // and pass them along to the compiler
   if (opts.adaptors?.length && opts.ignoreImports != true) {
-    let exports;
-    const [pattern] = opts.adaptors;
-    const [specifier] = pattern.split('=');
+    const adaptorsConfig = [];
+    for (const adaptorInput of opts.adaptors) {
+      let exports;
+      const [specifier] = adaptorInput.split('=');
 
-    // Preload exports from a path, optionally logging errors in case of a failure
-    log.debug(`Trying to preload types for ${specifier}`);
-    const path = await resolveSpecifierPath(pattern, opts.repoDir, log);
-    if (path) {
-      try {
-        exports = await preloadAdaptorExports(
-          path,
-          opts.useAdaptorsMonorepo,
-          log
-        );
-      } catch (e) {
-        log.error(`Failed to load adaptor typedefs from path ${path}`);
-        log.error(e);
+      // Preload exports from a path, optionally logging errors in case of a failure
+      log.debug(`Trying to preload types for ${specifier}`);
+      const path = await resolveSpecifierPath(adaptorInput, opts.repoDir, log);
+      if (path) {
+        try {
+          exports = await preloadAdaptorExports(
+            path,
+            opts.useAdaptorsMonorepo,
+            log
+          );
+        } catch (e) {
+          log.error(`Failed to load adaptor typedefs from path ${path}`);
+          log.error(e);
+        }
       }
-    }
 
-    if (!exports || exports.length === 0) {
-      log.debug(`No module exports found for ${pattern}`);
+      if (!exports || exports.length === 0) {
+        log.debug(`No module exports found for ${adaptorInput}`);
+      }
+
+      adaptorsConfig.push({
+        name: stripVersionSpecifier(specifier),
+        exports,
+        exportAll: true,
+      });
     }
 
     options['add-imports'] = {
       ignore: opts.ignoreImports as string[],
-      adaptor: {
-        name: stripVersionSpecifier(specifier),
-        exports,
-        exportAll: true,
-      },
+      adaptors: adaptorsConfig,
     };
   }
 

--- a/packages/cli/src/execute/execute.ts
+++ b/packages/cli/src/execute/execute.ts
@@ -67,14 +67,12 @@ export function parseAdaptors(plan: ExecutionPlan) {
 
   const adaptors: ModuleInfoMap = {};
 
-  // TODO what if there are different versions of the same adaptor?
-  // This structure can't handle it - we'd need to build it for every job
   Object.values(plan.workflow.steps).forEach((step) => {
     const job = step as Job;
-    if (job.adaptor) {
-      const { name, ...maybeVersionAndPath } = extractInfo(job.adaptor);
+    job.adaptors.forEach((adaptor) => {
+      const { name, ...maybeVersionAndPath } = extractInfo(adaptor);
       adaptors[name] = maybeVersionAndPath;
-    }
+    });
   });
 
   return adaptors;

--- a/packages/cli/src/execute/execute.ts
+++ b/packages/cli/src/execute/execute.ts
@@ -69,7 +69,11 @@ export function parseAdaptors(plan: ExecutionPlan) {
 
   Object.values(plan.workflow.steps).forEach((step) => {
     const job = step as Job;
-    job.adaptors.forEach((adaptor) => {
+    // Usually every job should have an adaptors array
+    // But there are a couple of cases mostly in test, when validation is skipped,
+    // when the array may not be set
+    // It's mostly redundant nbut harmless to optionally chain here
+    job.adaptors?.forEach((adaptor) => {
       const { name, ...maybeVersionAndPath } = extractInfo(adaptor);
       adaptors[name] = maybeVersionAndPath;
     });

--- a/packages/cli/src/execute/get-autoinstall-targets.ts
+++ b/packages/cli/src/execute/get-autoinstall-targets.ts
@@ -5,9 +5,11 @@ const getAutoinstallTargets = (plan: ExecutionPlan) => {
   Object.values(plan.workflow.steps).forEach((step) => {
     const job = step as Job;
     // Do not autoinstall adaptors with a path
-    if (job.adaptor && !/=/.test(job.adaptor)) {
-      adaptors[job.adaptor] = true;
-    }
+    job.adaptors
+      ?.filter((adaptor) => !/=/.test(adaptor))
+      .forEach((adaptor) => {
+        adaptors[adaptor] = true;
+      });
   });
   return Object.keys(adaptors);
 };

--- a/packages/cli/src/execute/handler.ts
+++ b/packages/cli/src/execute/handler.ts
@@ -85,7 +85,7 @@ const executeHandler = async (options: ExecuteOptions, logger: Logger) => {
     if (options.start) {
       customStart = matchStep(
         plan,
-        options.start ?? plan.options.start,
+        options.start ?? plan.options!.start,
         'start',
         logger
       );
@@ -95,7 +95,7 @@ const executeHandler = async (options: ExecuteOptions, logger: Logger) => {
     if (options.end) {
       customEnd = matchStep(
         plan,
-        options.end ?? plan.options.end,
+        options.end ?? plan.options!.end,
         'end',
         logger
       );
@@ -113,8 +113,8 @@ const executeHandler = async (options: ExecuteOptions, logger: Logger) => {
   const finalPlan = {
     ...plan,
     options: {
-      ...plan.options,
-      start: customStart || plan.options.start,
+      ...plan.options!,
+      start: customStart || plan.options!.start,
       end: customEnd,
     },
     workflow: plan.workflow,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,4 +1,7 @@
 // the executionPLan for the CLI is a bit differnt to the runtime's perspective
+
+import { Trigger, UUID, WorkflowOptions } from '@openfn/lexicon';
+
 // Ie config can be a string
 export type JobNodeID = string;
 
@@ -9,19 +12,26 @@ export type OldCLIWorkflow = {
 };
 
 export type CLIExecutionPlan = {
-  id?: string; // UUID for this plan
-  start?: JobNodeID;
-  jobs: CLIJobNode[];
+  id?: string;
+  options: WorkflowOptions;
+  workflow: {
+    id?: UUID;
+    name?: string;
+    steps: Array<CLIJobNode | Trigger>;
+  };
 };
 
 export type CLIJobNode = {
   id?: string;
-  adaptor?: string;
   expression?: string; // path or expression
   configuration?: string | object; // path or credential object
   data?: any;
-
   next?: string | Record<JobNodeID, true | CLIJobEdge>;
+
+  // We can accept a single adaptor or multiple
+  // The CLI will convert it to adaptors as an array
+  adaptor?: string;
+  adaptors?: string[];
 };
 
 export type CLIJobEdge = {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -13,7 +13,7 @@ export type OldCLIWorkflow = {
 
 export type CLIExecutionPlan = {
   id?: string;
-  options: WorkflowOptions;
+  options?: WorkflowOptions;
   workflow: {
     id?: UUID;
     name?: string;

--- a/packages/cli/src/util/expand-adaptors.ts
+++ b/packages/cli/src/util/expand-adaptors.ts
@@ -14,8 +14,6 @@ const expand = (name: string) => {
 
 type ArrayOrPlan<T> = T extends string[] ? string[] : ExecutionPlan;
 
-// TODO typings here aren't good,I can't get this to work!
-// At least this looks nice externally
 export default <T extends Array<string> | ExecutionPlan>(
   input: T
 ): ArrayOrPlan<T> => {
@@ -26,7 +24,9 @@ export default <T extends Array<string> | ExecutionPlan>(
   const plan = input as ExecutionPlan;
   Object.values(plan.workflow.steps).forEach((step) => {
     const job = step as Job;
-    job.adaptors = job.adaptors.map(expand);
+    if (job.adaptors) {
+      job.adaptors = job.adaptors.map(expand);
+    }
   });
 
   return plan as any;

--- a/packages/cli/src/util/expand-adaptors.ts
+++ b/packages/cli/src/util/expand-adaptors.ts
@@ -26,9 +26,7 @@ export default <T extends Array<string> | ExecutionPlan>(
   const plan = input as ExecutionPlan;
   Object.values(plan.workflow.steps).forEach((step) => {
     const job = step as Job;
-    if (job.adaptor) {
-      job.adaptor = expand(job.adaptor);
-    }
+    job.adaptors = job.adaptors.map(expand);
   });
 
   return plan as any;

--- a/packages/cli/src/util/load-plan.ts
+++ b/packages/cli/src/util/load-plan.ts
@@ -5,15 +5,10 @@ import { isPath } from '@openfn/compiler';
 import abort from './abort';
 import expandAdaptors from './expand-adaptors';
 import mapAdaptorsToMonorepo from './map-adaptors-to-monorepo';
-import type {
-  ExecutionPlan,
-  Job,
-  LegacyJob,
-  WorkflowOptions,
-} from '@openfn/lexicon';
+import type { ExecutionPlan, Job, WorkflowOptions } from '@openfn/lexicon';
 import type { Opts } from '../options';
 import type { Logger } from './logger';
-import type { OldCLIWorkflow } from '../types';
+import type { CLIExecutionPlan, CLIJobNode, OldCLIWorkflow } from '../types';
 
 const loadPlan = async (
   options: Pick<
@@ -110,7 +105,7 @@ const loadExpression = async (
     // TODO support state props to remove?
     maybeAssign(options, wfOptions, ['timeout']);
 
-    const plan: ExecutionPlan = {
+    const plan: CLIExecutionPlan = {
       workflow: {
         name,
         steps: [step],
@@ -128,7 +123,7 @@ const loadExpression = async (
     );
 
     // This will never execute
-    return {} as ExecutionPlan;
+    return {} as CLIExecutionPlan;
   }
 };
 
@@ -190,7 +185,7 @@ const fetchFile = async (
 // TODO this is currently untested in load-plan
 // (but covered a bit in execute tests)
 const importExpressions = async (
-  plan: ExecutionPlan,
+  plan: CLIExecutionPlan,
   rootDir: string,
   log: Logger
 ) => {
@@ -238,9 +233,9 @@ const importExpressions = async (
 
 // Allow users to specify a single adaptor on a job,
 // but convert the internal representation into an array
-const ensureAdaptors = (plan: ExecutionPlan) => {
+const ensureAdaptors = (plan: CLIExecutionPlan) => {
   Object.values(plan.workflow.steps).forEach((step) => {
-    const job = step as LegacyJob;
+    const job = step as CLIJobNode;
     if (job.adaptor) {
       job.adaptors = [job.adaptor];
       delete job.adaptor;
@@ -251,7 +246,7 @@ const ensureAdaptors = (plan: ExecutionPlan) => {
 };
 
 const loadXPlan = async (
-  plan: ExecutionPlan,
+  plan: CLIExecutionPlan,
   options: Pick<Opts, 'monorepoPath' | 'baseDir' | 'expandAdaptors'>,
   logger: Logger,
   defaultName: string = ''
@@ -279,5 +274,5 @@ const loadXPlan = async (
 
   logger.info(`Loaded workflow ${plan.workflow.name ?? ''}`);
 
-  return plan;
+  return plan as ExecutionPlan;
 };

--- a/packages/cli/src/util/map-adaptors-to-monorepo.ts
+++ b/packages/cli/src/util/map-adaptors-to-monorepo.ts
@@ -58,9 +58,7 @@ const mapAdaptorsToMonorepo = (
     const plan = input as ExecutionPlan;
     Object.values(plan.workflow.steps).forEach((step) => {
       const job = step as Job;
-      if (job.adaptor) {
-        job.adaptor = updatePath(job.adaptor, monorepoPath, log);
-      }
+      job.adaptors = job.adaptors.map((a) => updatePath(a, monorepoPath, log));
     });
 
     return plan;

--- a/packages/cli/src/util/map-adaptors-to-monorepo.ts
+++ b/packages/cli/src/util/map-adaptors-to-monorepo.ts
@@ -58,7 +58,11 @@ const mapAdaptorsToMonorepo = (
     const plan = input as ExecutionPlan;
     Object.values(plan.workflow.steps).forEach((step) => {
       const job = step as Job;
-      job.adaptors = job.adaptors.map((a) => updatePath(a, monorepoPath, log));
+      if (job.adaptors) {
+        job.adaptors = job.adaptors.map((a) =>
+          updatePath(a, monorepoPath, log)
+        );
+      }
     });
 
     return plan;

--- a/packages/cli/src/util/print-versions.ts
+++ b/packages/cli/src/util/print-versions.ts
@@ -30,14 +30,13 @@ const printVersions = async (
   includeComponents = false
 ) => {
   const { adaptors, logJson } = options;
-  let adaptor = '';
-  if (adaptors && adaptors.length) {
-    adaptor = adaptors[0];
-  }
 
-  let adaptorVersion;
-  let adaptorName = '';
-  if (adaptor) {
+  let longestAdaptorName = '';
+  const adaptorList: Array<string>[] = [];
+
+  adaptors?.forEach((adaptor) => {
+    let adaptorVersion;
+    let adaptorName = '';
     if (adaptor.match('=')) {
       const [namePart, pathPart] = adaptor.split('=');
       adaptorVersion = loadVersionFromPath(pathPart);
@@ -50,11 +49,15 @@ const printVersions = async (
       adaptorName = name;
       adaptorVersion = version || 'latest';
     }
-  }
+    adaptorList.push([adaptorName, adaptorVersion]);
+    if (adaptorName.length > longestAdaptorName.length) {
+      longestAdaptorName = adaptorName;
+    }
+  });
 
   // Work out the longest label
   const longest = Math.max(
-    ...[NODE, CLI, RUNTIME, COMPILER, adaptorName].map((s) => s.length)
+    ...[NODE, CLI, RUNTIME, COMPILER, longestAdaptorName].map((s) => s.length)
   );
 
   // Prefix and pad version numbers
@@ -83,8 +86,10 @@ const printVersions = async (
       output.versions.runtime = runtimeVersion;
       output.versions.compiler = compilerVersion;
     }
-    if (adaptorName) {
-      output.versions[adaptorName] = adaptorVersion;
+    if (adaptorList.length) {
+      for (const [name, version] of adaptorList) {
+        output.versions[name] = version;
+      }
     }
   } else {
     output = `Versions:
@@ -96,8 +101,10 @@ ${prefix(CLI)}${version}`;
 ${prefix(COMPILER)}${compilerVersion}`;
     }
 
-    if (adaptorName) {
-      output += `\n${prefix(adaptorName)}${adaptorVersion}`;
+    if (adaptorList.length) {
+      for (const [name, version] of adaptorList) {
+        output += `\n${prefix(name)}${version}`;
+      }
     }
   }
   logger.always(output);

--- a/packages/cli/src/util/validate-plan.ts
+++ b/packages/cli/src/util/validate-plan.ts
@@ -1,4 +1,10 @@
-import { ExecutionPlan, Step, WorkflowOptions } from '@openfn/lexicon';
+import {
+  ExecutionPlan,
+  Job,
+  Step,
+  Trigger,
+  WorkflowOptions,
+} from '@openfn/lexicon';
 import { Logger } from '@openfn/logger';
 
 const assertWorkflowStructure = (plan: ExecutionPlan, logger: Logger) => {
@@ -23,13 +29,13 @@ const assertWorkflowStructure = (plan: ExecutionPlan, logger: Logger) => {
   assertOptionsStructure(options, logger);
 };
 
-const assertStepStructure = (step: Step, index: number) => {
+const assertStepStructure = (step: Job | Trigger, index: number) => {
   const allowedKeys = [
     'id',
     'name',
     'next',
     'previous',
-    'adaptor',
+    'adaptors',
     'expression',
     'state',
     'configuration',
@@ -42,7 +48,7 @@ const assertStepStructure = (step: Step, index: number) => {
     }
   }
 
-  if ('adaptor' in step && !('expression' in step)) {
+  if ((step as Job).adaptors.length && !('expression' in step)) {
     throw new Error(
       `Step ${step.id ?? index} with an adaptor must also have an expression`
     );

--- a/packages/cli/src/util/validate-plan.ts
+++ b/packages/cli/src/util/validate-plan.ts
@@ -42,7 +42,7 @@ const assertStepStructure = (step: Job | Trigger, index: number) => {
     }
   }
 
-  if ((step as Job).adaptors.length && !('expression' in step)) {
+  if ((step as Job).adaptors?.length && !('expression' in step)) {
     throw new Error(
       `Step ${step.id ?? index} with an adaptor must also have an expression`
     );

--- a/packages/cli/src/util/validate-plan.ts
+++ b/packages/cli/src/util/validate-plan.ts
@@ -1,10 +1,4 @@
-import {
-  ExecutionPlan,
-  Job,
-  Step,
-  Trigger,
-  WorkflowOptions,
-} from '@openfn/lexicon';
+import { ExecutionPlan, Job, Trigger, WorkflowOptions } from '@openfn/lexicon';
 import { Logger } from '@openfn/logger';
 
 const assertWorkflowStructure = (plan: ExecutionPlan, logger: Logger) => {

--- a/packages/cli/test/__repo__/node_modules/@openfn/language-postgres_0.0.1/index.js
+++ b/packages/cli/test/__repo__/node_modules/@openfn/language-postgres_0.0.1/index.js
@@ -1,3 +1,4 @@
 export const execute = () => () => 'execute called!';
 
-export const fn = (f) => (state) => f(state);
+// don't use the same functions as common
+export const alterState = (f) => (state) => f(state);

--- a/packages/cli/test/__repo__/node_modules/@openfn/language-postgres_0.0.1/types.d.ts
+++ b/packages/cli/test/__repo__/node_modules/@openfn/language-postgres_0.0.1/types.d.ts
@@ -1,3 +1,3 @@
 export declare function execute(f: Array<(state: any) => any>): number;
 
-export declare function fn(f: (state: any) => any): any;
+export declare function alterState(f: (state: any) => any): any;

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -169,7 +169,7 @@ test.serial('run test job with default state', async (t) => {
   t.assert(message === 'Result: 42');
 });
 
-test.serial('run test job with custom state', async (t) => {
+test.serial.only('run test job with custom state', async (t) => {
   const state = JSON.stringify({ data: { answer: 1 } });
 
   await run(`test -S ${state}`, '');
@@ -511,7 +511,7 @@ test.serial(
   'use execute from language-postgres: openfn job.js -a @openfn/language-postgres',
   async (t) => {
     const job =
-      'fn((state) => { /* function isn\t actually called by the mock adaptor */ throw new Error("fake adaptor") });';
+      'alterState((state) => { /* function isn\t actually called by the mock adaptor */ throw new Error("fake adaptor") });';
     const result = await run(
       'openfn -a @openfn/language-postgres --no-autoinstall',
       job,

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -169,7 +169,7 @@ test.serial('run test job with default state', async (t) => {
   t.assert(message === 'Result: 42');
 });
 
-test.serial.only('run test job with custom state', async (t) => {
+test.serial('run test job with custom state', async (t) => {
   const state = JSON.stringify({ data: { answer: 1 } });
 
   await run(`test -S ${state}`, '');

--- a/packages/cli/test/compile/compile.test.ts
+++ b/packages/cli/test/compile/compile.test.ts
@@ -20,10 +20,10 @@ const expressionPath = '/job.js';
 type TransformOptionsWithImports = {
   ['add-imports']: {
     ignore: true | string[];
-    adaptor: {
+    adaptors: Array<{
       name: string;
       exports: string[];
-    };
+    }>;
   };
 };
 
@@ -234,7 +234,7 @@ test.serial(
     t.truthy(result['add-imports']);
 
     // Should describe the exports of the times-two module
-    const { name, exports } = result['add-imports'].adaptor;
+    const [{ name, exports }] = result['add-imports'].adaptors;
     t.assert(name === 'times-two');
     t.assert(exports.includes('byTwo'));
   }
@@ -257,7 +257,7 @@ test.serial(
     t.truthy(result['add-imports']);
 
     // Should describe the exports of the times-two module
-    const { name, exports } = result['add-imports'].adaptor;
+    const [{ name, exports }] = result['add-imports'].adaptors;
     t.assert(name === 'times-two');
     t.assert(exports.includes('byTwo'));
   }
@@ -282,7 +282,7 @@ test.serial(
     t.truthy(result['add-imports']);
 
     // Should describe the exports of the times-two module
-    const { name, exports } = result['add-imports'].adaptor;
+    const [{ name, exports }] = result['add-imports'].adaptors;
     t.assert(name === 'times-two');
     t.assert(exports.includes('byTwo'));
   }

--- a/packages/cli/test/execute/get-autoinstall-targets.test.ts
+++ b/packages/cli/test/execute/get-autoinstall-targets.test.ts
@@ -29,14 +29,14 @@ test('plan with zero adaptors', (t) => {
   t.is(result.length, 0);
 });
 
-test('plan with multiple adaptors', (t) => {
+test('plan with multiple adaptors in multiple steps', (t) => {
   const plan = getPlan([
     {
-      adaptor: '@openfn/language-common',
+      adaptors: ['@openfn/language-common'],
       expression: 'fn()',
     },
     {
-      adaptor: '@openfn/language-http',
+      adaptors: ['@openfn/language-http'],
       expression: 'fn()',
     },
   ]);
@@ -48,11 +48,11 @@ test('plan with multiple adaptors', (t) => {
 test('plan with duplicate adaptors', (t) => {
   const plan = getPlan([
     {
-      adaptor: '@openfn/language-common',
+      adaptors: ['@openfn/language-common'],
       expression: 'fn()',
     },
     {
-      adaptor: '@openfn/language-common',
+      adaptors: ['@openfn/language-common'],
       expression: 'fn()',
     },
   ]);
@@ -61,18 +61,34 @@ test('plan with duplicate adaptors', (t) => {
   t.deepEqual(result, ['@openfn/language-common']);
 });
 
+test('plan with multiple adaptors in one step with duplicates', (t) => {
+  const plan = getPlan([
+    {
+      adaptors: [
+        '@openfn/language-common',
+        '@openfn/language-http',
+        '@openfn/language-http',
+      ],
+      expression: 'fn()',
+    },
+  ]);
+  const result = getAutoinstallTargets(plan);
+  t.is(result.length, 2);
+  t.deepEqual(result, ['@openfn/language-common', '@openfn/language-http']);
+});
+
 test('plan with one adaptor but different versions', (t) => {
   const plan = getPlan([
     {
-      adaptor: '@openfn/language-common@1.0.0',
+      adaptors: ['@openfn/language-common@1.0.0'],
       expression: 'fn()',
     },
     {
-      adaptor: '@openfn/language-common@2.0.0',
+      adaptors: ['@openfn/language-common@2.0.0'],
       expression: 'fn()',
     },
     {
-      adaptor: '@openfn/language-common@3.0.0',
+      adaptors: ['@openfn/language-common@3.0.0'],
       expression: 'fn()',
     },
   ]);
@@ -89,7 +105,7 @@ test('do not return adaptors with a path', (t) => {
   const plan = getPlan([
     {
       expression: 'fn()',
-      adaptor: 'common=a/b/c',
+      adaptors: ['common=a/b/c'],
     },
   ]);
   const result = getAutoinstallTargets(plan);

--- a/packages/cli/test/execute/parse-adaptors.test.ts
+++ b/packages/cli/test/execute/parse-adaptors.test.ts
@@ -68,22 +68,22 @@ test('parse plan with several steps', (t) => {
     workflow: {
       steps: [
         {
-          adaptor: '@openfn/language-common',
+          adaptors: ['@openfn/language-common'],
           expression: 'fn()',
         },
         {
-          adaptor: '@openfn/language-http@1.0.0',
+          adaptors: ['@openfn/language-http@1.0.0'],
           expression: 'fn()',
         },
         {
-          adaptor: '@openfn/language-salesforce=a/b/c',
+          adaptors: ['@openfn/language-salesforce=a/b/c'],
           expression: 'fn()',
         },
       ],
     },
   };
   const result = parseAdaptors(plan);
-  t.assert(Object.keys(result).length === 3);
+  t.is(Object.keys(result).length, 3);
   t.deepEqual(result, {
     '@openfn/language-common': {},
     '@openfn/language-http': {
@@ -93,23 +93,4 @@ test('parse plan with several steps', (t) => {
       path: 'a/b/c',
     },
   });
-});
-
-// TODO we can't do this right now
-// We'd have to send different maps to different jobs
-// Which we can support but maybe I'm gonna push that out of scope
-test.skip('parse workflow with multiple versions of the same adaptor', (t) => {
-  const workflow = {
-    start: 'a',
-    jobs: {
-      a: {
-        adaptor: '@openfn/language-common@1.0.0',
-        expression: 'fn()',
-      },
-      b: {
-        adaptor: '@openfn/language-common@2.0.0',
-        expression: 'fn()',
-      },
-    },
-  };
 });

--- a/packages/cli/test/execute/parse-adaptors.test.ts
+++ b/packages/cli/test/execute/parse-adaptors.test.ts
@@ -7,7 +7,7 @@ const createPlan = (adaptor: string): ExecutionPlan => ({
   workflow: {
     steps: [
       {
-        adaptor,
+        adaptors: [adaptor],
         expression: '.',
       },
     ],

--- a/packages/cli/test/util/expand-adaptors.test.ts
+++ b/packages/cli/test/util/expand-adaptors.test.ts
@@ -61,22 +61,22 @@ test('expands adaptors in an execution plan', (t) => {
       steps: [
         {
           id: 'a',
-          adaptor: 'common',
+          adaptors: ['common'],
           expression: 'fn()',
         },
         {
           id: 'b',
-          adaptor: 'http@1.0.0',
+          adaptors: ['http@1.0.0'],
           expression: 'fn()',
         },
         {
           id: 'c',
-          adaptor: 'salesforce=a/b/c',
+          adaptors: ['salesforce=a/b/c'],
           expression: 'fn()',
         },
         {
           id: 'd',
-          adaptor: 'a/b/c/my-adaptor.js',
+          adaptors: ['a/b/c/my-adaptor.js'],
           expression: 'fn()',
         },
       ],
@@ -85,8 +85,8 @@ test('expands adaptors in an execution plan', (t) => {
   };
   expandAdaptors(plan);
   const [a, b, c, d] = plan.workflow.steps;
-  t.is(a.adaptor, '@openfn/language-common');
-  t.is(b.adaptor, '@openfn/language-http@1.0.0');
-  t.is(c.adaptor, '@openfn/language-salesforce=a/b/c');
-  t.is(d.adaptor, 'a/b/c/my-adaptor.js');
+  t.is(a.adaptors[0], '@openfn/language-common');
+  t.is(b.adaptors[0], '@openfn/language-http@1.0.0');
+  t.is(c.adaptors[0], '@openfn/language-salesforce=a/b/c');
+  t.is(d.adaptors[0], 'a/b/c/my-adaptor.js');
 });

--- a/packages/cli/test/util/map-adaptors-to-monorepo.test.ts
+++ b/packages/cli/test/util/map-adaptors-to-monorepo.test.ts
@@ -87,7 +87,7 @@ test.serial('mapAdaptorsToMonorepo: map workflow', async (t) => {
       steps: [
         {
           expression: '.',
-          adaptor: 'common',
+          adaptors: ['common'],
         },
       ],
     },
@@ -99,7 +99,7 @@ test.serial('mapAdaptorsToMonorepo: map workflow', async (t) => {
     steps: [
       {
         expression: '.',
-        adaptor: `common=${ABS_REPO_PATH}/packages/common`,
+        adaptors: [`common=${ABS_REPO_PATH}/packages/common`],
       },
     ],
   });

--- a/packages/cli/test/util/validate-plan.test.ts
+++ b/packages/cli/test/util/validate-plan.test.ts
@@ -6,108 +6,110 @@ import validate from '../../src/util/validate-plan';
 const logger = createMockLogger('', { level: 'debug' });
 
 test.afterEach(() => {
-    logger._reset();
-})
+  logger._reset();
+});
 
 test('throws for missing workflow', (t) => {
-    const plan = {
-        options: {
-            start: 'a',
-        }
-    } as ExecutionPlan;
+  const plan = {
+    options: {
+      start: 'a',
+    },
+  } as ExecutionPlan;
 
-    t.throws(() => validate(plan, logger), {
-        message: `Missing or invalid "workflow" key in execution plan`,
-    });
+  t.throws(() => validate(plan, logger), {
+    message: `Missing or invalid "workflow" key in execution plan`,
+  });
 });
 
 test('throws for steps not an array', (t) => {
+  const plan = {
+    options: {
+      start: 'a',
+    },
+    workflow: {
+      steps: {
+        id: 'a',
+      },
+    },
+  } as unknown as ExecutionPlan;
 
-    const plan = {
-        options: {
-            start: 'a',
-        },
-        workflow: {
-            steps: {
-                id: 'a'
-            }
-        },
-    } as unknown as ExecutionPlan;
-
-    t.throws(() => validate(plan, logger), {
-        message: 'The workflow.steps key must be an array',
-    });
+  t.throws(() => validate(plan, logger), {
+    message: 'The workflow.steps key must be an array',
+  });
 });
 
 test('throws for a step with an adaptor but no expression', (t) => {
-    const plan = {
-        options: {
-            start: 'a',
+  const plan = {
+    options: {
+      start: 'a',
+    },
+    workflow: {
+      steps: [
+        {
+          id: 'a',
+          adaptors: ['z'],
         },
-        workflow: {
-            steps: [
-                {
-                    id: 'a',
-                    adaptor: 'z'
-                }
-            ],
-        },
-    } as unknown as ExecutionPlan;
+      ],
+    },
+  } as unknown as ExecutionPlan;
 
-    t.throws(() => validate(plan, logger), {
-        message: 'Step a with an adaptor must also have an expression',
-    });
+  t.throws(() => validate(plan, logger), {
+    message: 'Step a with an adaptor must also have an expression',
+  });
 });
 
 test('throws for unknown key in a step', (t) => {
-    const plan = {
-        options: {
-            start: 'a',
+  const plan = {
+    options: {
+      start: 'a',
+    },
+    workflow: {
+      steps: [
+        {
+          id: 'a',
+          key: 'z',
         },
-        workflow: {
-            steps: [
-                {
-                    id: 'a',
-                    key: 'z'
-                }
-            ],
-        },
-    }as unknown as ExecutionPlan;
+      ],
+    },
+  } as unknown as ExecutionPlan;
 
-    t.throws(() => validate(plan, logger), {
-        message: 'Invalid key "key" in step a',
-    });
+  t.throws(() => validate(plan, logger), {
+    message: 'Invalid key "key" in step a',
+  });
 });
 
 test.serial('should warn if no steps are defined', (t) => {
-    const plan: ExecutionPlan = {
-        options: {
-            start: 'a',
-        },
-        workflow: {
-            steps: [],
-        },
-    };
-    validate(plan, logger);
-    const { message, level } = logger._parse(logger._history[0]);
-    t.is(level, 'warn');
-    t.regex(message as string, /The workflow.steps array is empty/);
-})
+  const plan: ExecutionPlan = {
+    options: {
+      start: 'a',
+    },
+    workflow: {
+      steps: [],
+    },
+  };
+  validate(plan, logger);
+  const { message, level } = logger._parse(logger._history[0]);
+  t.is(level, 'warn');
+  t.regex(message as string, /The workflow.steps array is empty/);
+});
 
 test.serial('should warn if unknown key is passed in options', (t) => {
-    const plan = {
-        options: {
-            start: 'a',
-            key: 'z',
+  const plan = {
+    options: {
+      start: 'a',
+      key: 'z',
+    },
+    workflow: {
+      steps: [
+        {
+          id: 'a',
+          adaptors: [],
         },
-        workflow: {
-            steps: [{
-                id: 'a',
-            }],
-        },
-    } as unknown as ExecutionPlan;
-    validate(plan, logger);
-    const { message, level } = logger._parse(logger._history[0]);
-    t.is(level, 'warn');
-    t.regex(message as string, /Unrecognized option "key" in options object/);
-})
+      ],
+    },
+  } as unknown as ExecutionPlan;
+  validate(plan, logger);
+  const { message, level } = logger._parse(logger._history[0]);
+  t.is(level, 'warn');
+  t.regex(message as string, /Unrecognized option "key" in options object/);
+});

--- a/packages/compiler/test/compile.test.ts
+++ b/packages/compiler/test/compile.test.ts
@@ -56,10 +56,12 @@ test('compile multiple operations', (t) => {
 test('add imports', (t) => {
   const options = {
     'add-imports': {
-      adaptor: {
-        name: '@openfn/language-common',
-        exports: ['fn'],
-      },
+      adaptors: [
+        {
+          name: '@openfn/language-common',
+          exports: ['fn'],
+        },
+      ],
     },
   };
   const source = 'fn();';
@@ -71,10 +73,12 @@ test('add imports', (t) => {
 test('do not add imports', (t) => {
   const options = {
     'add-imports': {
-      adaptor: {
-        name: '@openfn/language-common',
-        exports: ['fn'],
-      },
+      adaptors: [
+        {
+          name: '@openfn/language-common',
+          exports: ['fn'],
+        },
+      ],
     },
   };
   // This example already has the correct imports declared, so add-imports should do nothing
@@ -87,9 +91,11 @@ test('do not add imports', (t) => {
 test('dumbly add imports', (t) => {
   const options = {
     'add-imports': {
-      adaptor: {
-        name: '@openfn/language-common',
-      },
+      adaptors: [
+        {
+          name: '@openfn/language-common',
+        },
+      ],
     },
   };
   // This example already has the correct imports declared, so add-imports should do nothing
@@ -102,11 +108,13 @@ test('dumbly add imports', (t) => {
 test('add imports with export all', (t) => {
   const options = {
     'add-imports': {
-      adaptor: {
-        name: '@openfn/language-common',
-        exports: ['fn'],
-        exportAll: true,
-      },
+      adaptors: [
+        {
+          name: '@openfn/language-common',
+          exports: ['fn'],
+          exportAll: true,
+        },
+      ],
     },
   };
   const source = 'fn();';
@@ -154,10 +162,12 @@ test('compile a lazy state ($) expression', (t) => {
 test('compile a lazy state ($) expression with dumb imports', (t) => {
   const options = {
     'add-imports': {
-      adaptor: {
-        name: '@openfn/language-common',
-        exportAll: true,
-      },
+      adaptors: [
+        {
+          name: '@openfn/language-common',
+          exportAll: true,
+        },
+      ],
     },
   };
   const source = 'get($.data.endpoint);';

--- a/packages/compiler/test/transforms/add-imports.test.ts
+++ b/packages/compiler/test/transforms/add-imports.test.ts
@@ -234,10 +234,12 @@ test('add imports for a test module', async (t) => {
 
   const options = {
     'add-imports': {
-      adaptor: {
-        name: 'test-adaptor',
-        exports: exports,
-      },
+      adaptors: [
+        {
+          name: 'test-adaptor',
+          exports: exports,
+        },
+      ],
     },
   };
   const transformed = transform(ast, [addImports], options) as n.Program;
@@ -260,10 +262,12 @@ test('only add used imports for a test module', async (t) => {
 
   const options = {
     'add-imports': {
-      adaptor: {
-        name: 'test-adaptor',
-        exports: exports,
-      },
+      adaptors: [
+        {
+          name: 'test-adaptor',
+          exports: exports,
+        },
+      ],
     },
   };
   const transformed = transform(ast, [addImports], options) as n.Program;
@@ -285,15 +289,58 @@ test("don't add imports if nothing is used", async (t) => {
 
   const options = {
     'add-imports': {
-      adaptor: {
-        name: 'test-adaptor',
-        exports: exports,
-      },
+      adaptors: [
+        {
+          name: 'test-adaptor',
+          exports: exports,
+        },
+      ],
     },
   };
   const transformed = transform(ast, [addImports], options) as n.Program;
 
   t.assert(transformed.body.length === 0);
+});
+
+test('add imports for multiple adaptors', async (t) => {
+  const ast = b.program([
+    b.expressionStatement(b.identifier('x')),
+    b.expressionStatement(b.identifier('y')),
+  ]);
+
+  const options = {
+    'add-imports': {
+      adaptors: [
+        {
+          name: 'adaptor-a',
+          exports: ['x'],
+        },
+        {
+          name: 'adaptor-b',
+          exports: ['y'],
+        },
+      ],
+    },
+  };
+  const transformed = transform(ast, [addImports], options) as n.Program;
+
+  // Note that the first is y, and the second is x
+  const [first, second] = transformed.body as [
+    n.ImportDeclaration,
+    n.ImportDeclaration
+  ];
+  t.assert(n.ImportDeclaration.check(first));
+  const imports_1 = first.specifiers as n.ImportSpecifier[];
+  t.assert(imports_1.length === 1);
+  t.assert(imports_1.find((i) => i.imported.name === 'y'));
+  t.is(first.source.value, 'adaptor-b');
+
+  t.assert(n.ImportDeclaration.check(second));
+  const imports_2 = (second as n.ImportDeclaration)
+    .specifiers as n.ImportSpecifier[];
+  t.assert(imports_2.length === 1);
+  t.assert(imports_2.find((i) => i.imported.name === 'x'));
+  t.is(second.source.value, 'adaptor-a');
 });
 
 test("don't import if a variable is declared with the same name", async (t) => {
@@ -307,10 +354,12 @@ test("don't import if a variable is declared with the same name", async (t) => {
 
   const options = {
     'add-imports': {
-      adaptor: {
-        name: 'test-adaptor',
-        exports: exports,
-      },
+      adaptors: [
+        {
+          name: 'test-adaptor',
+          exports: exports,
+        },
+      ],
     },
   };
   const transformed = transform(ast, [addImports], options) as n.Program;
@@ -325,10 +374,12 @@ test('dumbly add imports for an adaptor with empty exports', (t) => {
 
   const options = {
     'add-imports': {
-      adaptor: {
-        name: 'test-adaptor',
-        exports: [],
-      },
+      adaptors: [
+        {
+          name: 'test-adaptor',
+          exports: [],
+        },
+      ],
     },
   };
   const transformed = transform(ast, [addImports], options) as n.Program;
@@ -350,9 +401,11 @@ test('dumbly add imports for an adaptor with unknown exports', (t) => {
 
   const options = {
     'add-imports': {
-      adaptor: {
-        name: 'test-adaptor',
-      },
+      adaptors: [
+        {
+          name: 'test-adaptor',
+        },
+      ],
     },
   };
   const transformed = transform(ast, [addImports], options) as n.Program;
@@ -405,10 +458,12 @@ test("don't auto add imports for node globals", (t) => {
 
   const options = {
     'add-imports': {
-      adaptor: {
-        name: 'test-adaptor',
-        exports: [],
-      },
+      adaptors: [
+        {
+          name: 'test-adaptor',
+          exports: [],
+        },
+      ],
     },
   };
   const transformed = transform(ast, [addImports], options) as n.Program;
@@ -430,10 +485,12 @@ test("Don't add imports for ignored identifiers", async (t) => {
   const options = {
     'add-imports': {
       ignore: ['x'],
-      adaptor: {
-        name: 'test-adaptor',
-        exports: [],
-      },
+      adaptors: [
+        {
+          name: 'test-adaptor',
+          exports: [],
+        },
+      ],
     },
   };
 
@@ -460,10 +517,12 @@ test("Don't add imports from import specifiers", async (t) => {
 
   const options = {
     'add-imports': {
-      adaptor: {
-        name: 'test-adaptor',
-        exports: [],
-      },
+      adaptors: [
+        {
+          name: 'test-adaptor',
+          exports: [],
+        },
+      ],
     },
   };
 
@@ -480,10 +539,12 @@ test('export everything from an adaptor', (t) => {
 
   const options = {
     'add-imports': {
-      adaptor: {
-        name: 'test-adaptor',
-        exportAll: true,
-      },
+      adaptors: [
+        {
+          name: 'test-adaptor',
+          exportAll: true,
+        },
+      ],
     },
   };
   const transformed = transform(ast, [addImports], options) as n.Program;

--- a/packages/engine-multi/src/api/compile.ts
+++ b/packages/engine-multi/src/api/compile.ts
@@ -22,7 +22,7 @@ export default async (context: ExecutionContext) => {
             job.expression as string,
             logger,
             repoDir,
-            job.adaptor // TODO need to expand this. Or do I?
+            job.adaptors
           );
         } catch (e) {
           throw new CompileError(e, job.id!);
@@ -47,22 +47,30 @@ const compileJob = async (
   job: string,
   logger: Logger,
   repoDir?: string,
-  adaptor?: string
+  adaptors?: string[]
 ) => {
   const compilerOptions: Options = {
     logger,
   };
 
-  if (adaptor && repoDir) {
-    // TODO I probably dont want to log this stuff
-    const pathToAdaptor = await getModulePath(adaptor, repoDir, logger);
-    const exports = await preloadAdaptorExports(pathToAdaptor!, false, logger);
-    compilerOptions['add-imports'] = {
-      adaptor: {
+  if (adaptors && repoDir) {
+    const adaptorConfig = [];
+    for (const adaptor of adaptors) {
+      // TODO I probably don't want to log this stuff
+      const pathToAdaptor = await getModulePath(adaptor, repoDir, logger);
+      const exports = await preloadAdaptorExports(
+        pathToAdaptor!,
+        false,
+        logger
+      );
+      adaptorConfig.push({
         name: stripVersionSpecifier(adaptor),
         exports,
         exportAll: true,
-      },
+      });
+    }
+    compilerOptions['add-imports'] = {
+      adaptors: adaptorConfig,
     };
   }
   return compile(job, compilerOptions);

--- a/packages/engine-multi/src/test/util.ts
+++ b/packages/engine-multi/src/test/util.ts
@@ -7,7 +7,7 @@ export const createPlan = (job = {}) =>
       steps: [
         {
           id: 'j1',
-          adaptor: 'common', // not used
+          adaptors: ['common'], // not used
           configuration: {}, // not used
           expression: '(s) => ({ data: { answer: s.data?.input || 42 } })',
 

--- a/packages/engine-multi/test/api/autoinstall.test.ts
+++ b/packages/engine-multi/test/api/autoinstall.test.ts
@@ -48,7 +48,7 @@ const createContext = (
       plan: {
         workflow: {
           steps: jobs || [
-            { adaptor: '@openfn/language-common@1.0.0', expression: '.' },
+            { adaptors: ['@openfn/language-common@1.0.0'], expression: '.' },
           ],
         },
         options: {},
@@ -126,15 +126,15 @@ test('identifyAdaptors: pick out adaptors and remove duplicates', (t) => {
     workflow: {
       steps: [
         {
-          adaptor: 'common@1.0.0',
+          adaptors: ['common@1.0.0'],
           expression: '.',
         },
         {
-          adaptor: 'common@1.0.0',
+          adaptors: ['common@1.0.0'],
           expression: '.',
         },
         {
-          adaptor: 'common@1.0.1',
+          adaptors: ['common@1.0.1'],
           expression: '.',
         },
       ],
@@ -150,7 +150,7 @@ test('identifyAdaptors: pick out adaptors and remove duplicates', (t) => {
 test.serial('autoinstall: handle @latest', async (t) => {
   const jobs = [
     {
-      adaptor: 'x@latest',
+      adaptors: ['x@latest'],
     },
   ];
 
@@ -169,7 +169,7 @@ test.serial('autoinstall: handle @latest', async (t) => {
 test.serial('autoinstall: handle @next', async (t) => {
   const jobs = [
     {
-      adaptor: 'x@next',
+      adaptors: ['x@next'],
     },
   ];
 
@@ -269,9 +269,15 @@ test.serial('autoinstall: install in sequence', async (t) => {
     handleIsInstalled: false,
   } as any;
 
-  const c1 = createContext(options, [{ adaptor: '@openfn/language-common@1' }]);
-  const c2 = createContext(options, [{ adaptor: '@openfn/language-common@2' }]);
-  const c3 = createContext(options, [{ adaptor: '@openfn/language-common@3' }]);
+  const c1 = createContext(options, [
+    { adaptors: ['@openfn/language-common@1'] },
+  ]);
+  const c2 = createContext(options, [
+    { adaptors: ['@openfn/language-common@2'] },
+  ]);
+  const c3 = createContext(options, [
+    { adaptors: ['@openfn/language-common@3'] },
+  ]);
 
   autoinstall(c1);
   await wait(1);
@@ -300,10 +306,10 @@ test('autoinstall: handle two seperate, non-overlapping installs', async (t) => 
   };
 
   const c1 = createContext(options, [
-    { adaptor: '@openfn/language-dhis2@1.0.0' },
+    { adaptors: ['@openfn/language-dhis2@1.0.0'] },
   ]);
   const c2 = createContext(options, [
-    { adaptor: '@openfn/language-http@1.0.0' },
+    { adaptors: ['@openfn/language-http@1.0.0'] },
   ]);
 
   const p1 = await autoinstall(c1);
@@ -336,7 +342,7 @@ test.serial(
 
     const job = [
       {
-        adaptor: 'lodash@1.0.0',
+        adaptors: ['lodash@1.0.0'],
       },
     ];
 
@@ -357,10 +363,10 @@ test.serial(
 test.serial('autoinstall: return a map to modules', async (t) => {
   const jobs = [
     {
-      adaptor: '@openfn/language-common@1.0.0',
+      adaptors: ['@openfn/language-common@1.0.0'],
     },
     {
-      adaptor: '@openfn/language-http@1.0.0',
+      adaptors: ['@openfn/language-http@1.0.0'],
     },
   ];
 
@@ -388,13 +394,16 @@ test.serial('autoinstall: return a map to modules', async (t) => {
 test.serial('autoinstall: write linker options back to the plan', async (t) => {
   const jobs = [
     {
-      adaptor: '@openfn/language-common@1.0.0',
+      adaptors: ['@openfn/language-common@1.0.0'],
     },
     {
-      adaptor: '@openfn/language-common@2.0.0',
+      adaptors: [
+        '@openfn/language-common@2.0.0',
+        '@openfn/language-collections@1.0.0',
+      ],
     },
     {
-      adaptor: '@openfn/language-http@1.0.0',
+      adaptors: ['@openfn/language-http@1.0.0'],
     },
   ];
 
@@ -419,6 +428,10 @@ test.serial('autoinstall: write linker options back to the plan', async (t) => {
       path: 'tmp/repo/node_modules/@openfn/language-common_2.0.0',
       version: '2.0.0',
     },
+    '@openfn/language-collections': {
+      path: 'tmp/repo/node_modules/@openfn/language-collections_1.0.0',
+      version: '1.0.0',
+    },
   });
   t.deepEqual(c.linker, {
     '@openfn/language-http': {
@@ -433,11 +446,11 @@ test.serial('autoinstall: support custom whitelist', async (t) => {
   const jobs = [
     {
       // will be ignored
-      adaptor: 'x@1.0.0',
+      adaptors: ['x@1.0.0'],
     },
     {
       // will be installed
-      adaptor: 'y@1.0.0',
+      adaptors: ['y@1.0.0'],
     },
   ];
 
@@ -462,7 +475,7 @@ test.serial('autoinstall: emit an event on completion', async (t) => {
   let event: any;
   const jobs = [
     {
-      adaptor: '@openfn/language-common@1.0.0',
+      adaptors: ['@openfn/language-common@1.0.0'],
       version: '1.0.0',
     },
   ];

--- a/packages/engine-multi/test/engine.test.ts
+++ b/packages/engine-multi/test/engine.test.ts
@@ -28,6 +28,7 @@ const createPlan = (expression: string = '.', id = 'a') => ({
     steps: [
       {
         expression,
+        adaptors: [],
       },
     ],
   },

--- a/packages/engine-multi/test/errors.test.ts
+++ b/packages/engine-multi/test/errors.test.ts
@@ -207,14 +207,14 @@ test.serial('after uncaught exception, free up the pool', (t) => {
   });
 });
 
-test.serial('emit a crash error on process.exit()', (t) => {
+test.serial.only('emit a crash error on process.exit()', (t) => {
   return new Promise((done) => {
     const plan = {
       id: 'z',
       workflow: {
         steps: [
           {
-            adaptor: '@openfn/helper@1.0.0',
+            adaptors: ['@openfn/helper@1.0.0'],
             expression: 'export default [exit()]',
           },
         ],

--- a/packages/engine-multi/test/integration.test.ts
+++ b/packages/engine-multi/test/integration.test.ts
@@ -214,7 +214,7 @@ test.serial('trigger workflow-log for adaptor logs', (t) => {
         // This will trigger console.log from inside the adaptor
         // rather than from job code directly
         expression: "log('hola')",
-        adaptor: '@openfn/helper@1.0.0',
+        adaptors: ['@openfn/helper@1.0.0'],
       },
     ]);
 

--- a/packages/lexicon/core.d.ts
+++ b/packages/lexicon/core.d.ts
@@ -27,7 +27,7 @@ export type Workflow = {
  * This is some openfn expression plus metadata (adaptor, credentials)
  */
 export interface Job extends Step {
-  adaptors?: string[];
+  adaptors: string[];
   expression: Expression;
   configuration?: object | string;
   state?: Omit<State, 'configuration'> | string;
@@ -42,6 +42,16 @@ export interface Job extends Step {
       version?: string;
     }
   >;
+}
+
+/**
+ * Defines an older style job from when we only supported a single adaptor
+ * And mostly we still do, so we want to support the simple adaptor property
+ * rather than just adaptors
+ * Internally, this will be mapped
+ */
+export interface LegacyJob extends Job {
+  adaptor?: string;
 }
 
 /**

--- a/packages/lexicon/core.d.ts
+++ b/packages/lexicon/core.d.ts
@@ -27,7 +27,7 @@ export type Workflow = {
  * This is some openfn expression plus metadata (adaptor, credentials)
  */
 export interface Job extends Step {
-  adaptor?: string;
+  adaptors?: string[];
   expression: Expression;
   configuration?: object | string;
   state?: Omit<State, 'configuration'> | string;

--- a/packages/lexicon/core.d.ts
+++ b/packages/lexicon/core.d.ts
@@ -3,11 +3,14 @@ import { SanitizePolicies } from '@openfn/logger';
 /**
  * An execution plan is a portable definition of a Work Order,
  * or, a unit of work to execute
+ * This definition represents the external format - the shape of
+ * the plan pre-compilation before it's passed into the runtime manager
+ * (ie, the CLI or Worker)
  */
 export type ExecutionPlan = {
   id?: UUID; // this would be the run (nee attempt) id
   workflow: Workflow;
-  options: WorkflowOptions;
+  options?: WorkflowOptions;
 };
 
 /**
@@ -27,14 +30,14 @@ export type Workflow = {
  * This is some openfn expression plus metadata (adaptor, credentials)
  */
 export interface Job extends Step {
-  adaptors: string[];
+  adaptors?: string[];
   expression: Expression;
   configuration?: object | string;
   state?: Omit<State, 'configuration'> | string;
 
   // Internal use only
-  // Allow module paths and versions to be overriden in the linker
-  // Maps to runtime.ModuleInfoMapo
+  // Allow module paths and versions to be overridden in the linker
+  // Maps to runtime.ModuleInfoMap
   linker?: Record<
     string,
     {
@@ -42,16 +45,6 @@ export interface Job extends Step {
       version?: string;
     }
   >;
-}
-
-/**
- * Defines an older style job from when we only supported a single adaptor
- * And mostly we still do, so we want to support the simple adaptor property
- * rather than just adaptors
- * Internally, this will be mapped
- */
-export interface LegacyJob extends Job {
-  adaptor?: string;
 }
 
 /**

--- a/packages/lexicon/lightning.d.ts
+++ b/packages/lexicon/lightning.d.ts
@@ -1,5 +1,5 @@
 import type { SanitizePolicies } from '@openfn/logger';
-import { State } from './core';
+import { LegacyJob, State } from './core';
 
 export const API_VERSION: number;
 
@@ -29,9 +29,9 @@ export type LightningPlan = {
   dataclip_id: string;
   starting_node_id: string;
 
-  triggers: Node[];
-  jobs: Node[];
-  edges: Edge[];
+  triggers: LightningTrigger[];
+  jobs: LightningJob[];
+  edges: LightningEdge[];
 
   options?: LightningPlanOptions;
 };
@@ -59,16 +59,23 @@ export type LightningPlanOptions = {
  * Sticking with the Node/Edge semantics to help distinguish the
  * Lightning and runtime typings
  */
-export type Node = {
+export interface LightningNode {
   id: string;
   name?: string;
   body?: string;
   adaptor?: string;
   credential?: any;
   credential_id?: string;
-  type?: 'webhook' | 'cron'; // trigger only
   state?: State;
-};
+}
+
+export interface LightningTrigger extends LightningNode {
+  type: 'webhook' | 'cron';
+}
+
+export interface LightningJob extends LightningNode {
+  adaptor: string;
+}
 
 /**
  * This is a Path (or link) between two Jobs in a Plan.
@@ -76,7 +83,7 @@ export type Node = {
  * Sticking with the Node/Edge semantics to help distinguish the
  * Lightning and runtime typings
  */
-export interface Edge {
+export interface LightningEdge {
   id: string;
   source_job_id?: string;
   source_trigger_id?: string;

--- a/packages/lightning-mock/test/server.test.ts
+++ b/packages/lightning-mock/test/server.test.ts
@@ -36,6 +36,7 @@ test.serial('should setup an run at /POST /run', async (t) => {
           user: 'john',
           password: 'rambo',
         },
+        adaptor: 'abc',
       },
     ],
     edges: [],

--- a/packages/runtime/src/execute/compile-plan.ts
+++ b/packages/runtime/src/execute/compile-plan.ts
@@ -131,10 +131,13 @@ export default (plan: ExecutionPlan) => {
 
     if (job.linker) {
       newStep.linker = job.linker;
-    } else if (job.adaptor) {
+    } else if (job.adaptors) {
       const job = step as Job;
-      const { name, version } = getNameAndVersion(job.adaptor!);
-      newStep.linker = { [name]: { version: version! } };
+      newStep.linker ??= {};
+      for (const adaptor of job.adaptors!) {
+        const { name, version } = getNameAndVersion(adaptor);
+        newStep.linker[name] = { version: version! };
+      }
     }
 
     if (step.next) {

--- a/packages/runtime/src/util/validate-plan.ts
+++ b/packages/runtime/src/util/validate-plan.ts
@@ -70,10 +70,12 @@ export const buildModel = ({ workflow }: ExecutionPlan) => {
 };
 
 const assertStart = (plan: ExecutionPlan) => {
-  const { start } = plan.options;
-  if (typeof start === 'string') {
-    if (!plan.workflow.steps.find(({ id }) => id === start)) {
-      throw new ValidationError(`Could not find start job: ${start}`);
+  if (plan.options) {
+    const { start } = plan.options;
+    if (typeof start === 'string') {
+      if (!plan.workflow.steps.find(({ id }) => id === start)) {
+        throw new ValidationError(`Could not find start job: ${start}`);
+      }
     }
   }
 };

--- a/packages/runtime/test/execute/compile-plan.test.ts
+++ b/packages/runtime/test/execute/compile-plan.test.ts
@@ -208,12 +208,12 @@ test('should write adaptor versions', (t) => {
         {
           id: 'x',
           expression: '.',
-          adaptor: 'x@1.0',
+          adaptors: ['x@1.0'],
         },
         {
           id: 'y',
           expression: '.',
-          adaptor: 'y@1.0',
+          adaptors: ['y@1.0'],
         },
       ],
     },

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -777,21 +777,21 @@ test('run a workflow using the repo using a specific version', async (t) => {
 });
 
 test('run a workflow using the repo with multiple versions of the same adaptor', async (t) => {
-  const plan = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {
           id: 'a',
           expression: `import result from 'ultimate-answer';
           export default [(s) => { s.data.a = result; return s;}];`,
-          adaptor: 'ultimate-answer@1.0.0',
+          adaptors: ['ultimate-answer@1.0.0'],
           next: { b: true },
         },
         {
           id: 'b',
           expression: `import result from 'ultimate-answer';
           export default [(s) => { s.data.b = result; return s;}];`,
-          adaptor: 'ultimate-answer@2.0.0',
+          adaptors: ['ultimate-answer@2.0.0'],
         },
       ],
     },

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -10,7 +10,7 @@ import type {
   WorkflowOptions,
   Lazy,
 } from '@openfn/lexicon';
-import { LightningPlan, Edge } from '@openfn/lexicon/lightning';
+import { LightningPlan, LightningEdge } from '@openfn/lexicon/lightning';
 import { ExecuteOptions } from '@openfn/engine-multi';
 
 export const conditions: Record<string, (upstreamId: string) => string | null> =
@@ -22,7 +22,7 @@ export const conditions: Record<string, (upstreamId: string) => string | null> =
     always: (_upstreamId: string) => null,
   };
 
-const mapEdgeCondition = (edge: Edge) => {
+const mapEdgeCondition = (edge: LightningEdge) => {
   const { condition } = edge;
   if (condition && condition in conditions) {
     const upstream = (edge.source_job_id || edge.source_trigger_id) as string;
@@ -31,7 +31,7 @@ const mapEdgeCondition = (edge: Edge) => {
   return condition;
 };
 
-const mapTriggerEdgeCondition = (edge: Edge) => {
+const mapTriggerEdgeCondition = (edge: LightningEdge) => {
   const { condition } = edge;
   // This handles cron triggers with undefined conditions and the 'always' string.
   if (condition === undefined || condition === 'always') return true;
@@ -88,7 +88,7 @@ export default (
 
   const nodes: Record<StepId, Step> = {};
 
-  const edges: Edge[] = run.edges ?? [];
+  const edges: LightningEdge[] = run.edges ?? [];
 
   // We don't really care about triggers, it's mostly just a empty node
   if (run.triggers?.length) {
@@ -125,7 +125,7 @@ export default (
         id,
         configuration: step.credential || step.credential_id,
         expression: step.body!,
-        adaptor: step.adaptor,
+        adaptors: step.adaptor ? [step.adaptor] : [],
       };
 
       if (step.name) {

--- a/packages/ws-worker/src/util/create-run-state.ts
+++ b/packages/ws-worker/src/util/create-run-state.ts
@@ -22,8 +22,8 @@ export default (plan: ExecutionPlan, input?: Lazy<State>): RunState => {
     // find the first job
     const jobs = plan.workflow.steps as Job[];
     let startNode = jobs[0];
-    if (plan.options.start) {
-      startNode = jobs.find(({ id }) => id === plan.options.start)!;
+    if (plan.options?.start) {
+      startNode = jobs.find(({ id }) => id === plan.options?.start)!;
     }
 
     const initialRuns: string[] = [];

--- a/packages/ws-worker/test/api/execute.test.ts
+++ b/packages/ws-worker/test/api/execute.test.ts
@@ -459,7 +459,7 @@ test('execute should call all events on the socket', async (t) => {
         {
           id: 'trigger',
           configuration: 'a',
-          adaptor: '@openfn/language-common@1.0.0',
+          adaptors: ['@openfn/language-common@1.0.0'],
           expression: 'fn(() => console.log("x"))',
         },
       ],

--- a/packages/ws-worker/test/channels/run.test.ts
+++ b/packages/ws-worker/test/channels/run.test.ts
@@ -42,7 +42,7 @@ test('loadRun should return an execution plan and options', async (t) => {
           id: 'job-1',
           configuration: 'a',
           expression: 'fn(a => a)',
-          adaptor: '@openfn/language-common@1.0.0',
+          adaptors: ['@openfn/language-common@1.0.0'],
         },
       ],
     },

--- a/packages/ws-worker/test/lightning.test.ts
+++ b/packages/ws-worker/test/lightning.test.ts
@@ -49,7 +49,7 @@ test.before(async () => {
     backoff: {
       min: 1,
       max: 1000,
-    }
+    },
   });
 });
 
@@ -110,109 +110,98 @@ test.serial(
   }
 );
 
-test.serial(
-  `should not claim while at capacity, then resume`,
-  (t) => {
-    return new Promise((done) => {
+test.serial(`should not claim while at capacity, then resume`, (t) => {
+  return new Promise((done) => {
+    let runIsActive = false;
+    let runComplete = false;
+    let didClaimAfterComplete = false;
 
-      let runIsActive = false;
-      let runComplete = false;
-      let didClaimAfterComplete = false;
-
-      const run = {
-        id: `a${++rollingRunId}`,
-        jobs: [
-          {
-            id: 'j',
-            adaptor: '@openfn/language-common@1.0.0',
-            body: `fn(() => new Promise((resolve) => {
+    const run = {
+      id: `a${++rollingRunId}`,
+      jobs: [
+        {
+          id: 'j',
+          adaptor: '@openfn/language-common@1.0.0',
+          body: `fn(() => new Promise((resolve) => {
               setTimeout(resolve, 500)
             }))`,
-          },
-        ],
-      };
+        },
+      ],
+    };
 
+    lng.on(e.CLAIM, () => {
+      if (runIsActive) {
+        t.fail('Claimed while run is active');
+      }
+      if (runComplete) {
+        didClaimAfterComplete = true;
+      }
+    });
 
-      lng.on(e.CLAIM, () => {
-        if (runIsActive) {
-          t.fail('Claimed while run is active')
-        }
-        if (runComplete) {
-          didClaimAfterComplete = true;
-        }
-      });
+    lng.onSocketEvent(e.RUN_START, run.id, () => {
+      runIsActive = true;
+    });
 
-      lng.onSocketEvent(e.RUN_START, run.id, () => {
-        runIsActive = true;
-      })
+    lng.onSocketEvent(e.RUN_COMPLETE, run.id, () => {
+      runIsActive = false;
+      runComplete = true;
 
-      lng.onSocketEvent(e.RUN_COMPLETE, run.id, () => {
-        runIsActive = false;
-        runComplete = true;
+      setTimeout(() => {
+        t.true(didClaimAfterComplete);
+        done();
+      }, 10);
+    });
 
-        setTimeout(() => {
-          t.true(didClaimAfterComplete);
-          done()
-        }, 10)
-      });
+    lng.enqueueRun(run);
+  });
+});
+
+test.serial(`should reset backoff after claim`, (t) => {
+  return new Promise((done) => {
+    let lastClaim = Date.now();
+    let lastClaimDiff = 0;
+
+    const run = {
+      id: `a${++rollingRunId}`,
+      jobs: [
+        {
+          id: 'j',
+          adaptor: '@openfn/language-common@1.0.0',
+          body: `fn(() => new Promise((resolve) => {
+              setTimeout(resolve, 500)
+            }))`,
+        },
+      ],
+    };
+
+    lng.on(e.CLAIM, () => {
+      lastClaimDiff = Date.now() - lastClaim;
+      lastClaim = Date.now();
+    });
+
+    lng.onSocketEvent(e.RUN_COMPLETE, run.id, () => {
+      // set this articially high - if there are no more claims, the test will fail
+      lastClaimDiff = 10000;
+
+      // When the run is finished, the claims should resume
+      // but with a smaller backoff
+      setTimeout(() => {
+        t.log('Backoff after run:', lastClaimDiff);
+        t.true(lastClaimDiff < 5);
+        done();
+      }, 10);
+    });
+
+    setTimeout(() => {
+      t.log('Backoff before run:', lastClaimDiff);
+      // let the backoff increase a bit
+      // the last claim diff should be at least 20ms
+      t.true(lastClaimDiff > 20);
 
       lng.enqueueRun(run);
-    });
-  }
-);
-
-test.serial(
-  `should reset backoff after claim`,
-  (t) => {
-    return new Promise((done) => {
-
-      let lastClaim = Date.now()
-      let lastClaimDiff = 0;
-
-      const run = {
-        id: `a${++rollingRunId}`,
-        jobs: [
-          {
-            id: 'j',
-            adaptor: '@openfn/language-common@1.0.0',
-            body: `fn(() => new Promise((resolve) => {
-              setTimeout(resolve, 500)
-            }))`,
-          },
-        ],
-      };
-
-
-      lng.on(e.CLAIM, () => {
-        lastClaimDiff = Date.now() - lastClaim;
-        lastClaim = Date.now()
-      });
-
-      lng.onSocketEvent(e.RUN_COMPLETE, run.id, () => {
-         // set this articially high - if there are no more claims, the test will fail
-        lastClaimDiff = 10000;
-        
-        // When the run is finished, the claims should resume
-        // but with a smaller backoff
-        setTimeout(() => {
-          t.log('Backoff after run:', lastClaimDiff)
-          t.true(lastClaimDiff < 5)
-          done()
-        }, 10)
-      });
-
-      
-      setTimeout(() => {
-        t.log('Backoff before run:', lastClaimDiff)
-        // let the backoff increase a bit
-        // the last claim diff should be at least 30ms
-        t.true(lastClaimDiff > 30)
-
-        lng.enqueueRun(run);
-      }, 600)
-    });
-  }
-);
+    }, 600);
+  });
+});
 
 test.todo('worker should log when a run token is verified');
 

--- a/packages/ws-worker/test/mock/runtime-engine.test.ts
+++ b/packages/ws-worker/test/mock/runtime-engine.test.ts
@@ -17,7 +17,7 @@ const sampleWorkflow = {
     steps: [
       {
         id: 'j1',
-        adaptor: 'common@1.0.0',
+        adaptors: ['common@1.0.0'],
         expression: 'fn(() => ({ data: { x: 10 } }))',
       },
     ],
@@ -85,7 +85,7 @@ test.serial('Dispatch complete events for a job', async (t) => {
 test.serial('Dispatch error event for a crash', async (t) => {
   const wf = createPlan({
     id: 'j1',
-    adaptor: 'common@1.0.0',
+    adaptors: ['common@1.0.0'],
     expression: 'fn(() => ( @~!"@£!4 )',
   });
 
@@ -146,7 +146,7 @@ test.serial('listen to events', async (t) => {
 
   const wf = createPlan({
     id: 'j1',
-    adaptor: 'common@1.0.0',
+    adaptors: ['common@1.0.0'],
     expression: 'export default [() => { console.log("x"); }]',
   });
 
@@ -236,7 +236,7 @@ test.serial(
     // @ts-ignore
     const workflow = createPlan({
       id: 'j1',
-      adaptor: '@openfn/language-common@1.0.0',
+      adaptors: ['@openfn/language-common@1.0.0'],
     });
 
     let didCallEvent = false;

--- a/packages/ws-worker/test/reasons.test.ts
+++ b/packages/ws-worker/test/reasons.test.ts
@@ -209,7 +209,7 @@ test('exception: autoinstall error', async (t) => {
   const plan = createPlan({
     id: 'a',
     expression: '.',
-    adaptor: '@openfn/language-common@1.0.0',
+    adaptors: ['@openfn/language-common@1.0.0'],
   });
 
   // TODO I also need to ensure that this calls run:complete

--- a/packages/ws-worker/test/util.ts
+++ b/packages/ws-worker/test/util.ts
@@ -1,5 +1,5 @@
 import { ExecutionPlan, Job } from '@openfn/lexicon';
-import { Edge, Node } from '@openfn/lexicon/lightning';
+import { LightningEdge, LightningNode } from '@openfn/lexicon/lightning';
 import crypto from 'node:crypto';
 
 export const wait = (fn: () => any, maxRuns = 100) =>
@@ -34,7 +34,7 @@ export const sleep = (delay = 100) =>
     setTimeout(resolve, delay);
   });
 
-export const createPlan = (...steps: Job[]) =>
+export const createPlan = (...steps: Partial<Job>[]) =>
   ({
     id: crypto.randomUUID(),
     workflow: {
@@ -48,13 +48,13 @@ export const createEdge = (from: string, to: string) =>
     id: `${from}-${to}`,
     source_job_id: from,
     target_job_id: to,
-  } as Edge);
+  } as LightningEdge);
 
 export const createJob = (body?: string, id?: string) =>
   ({
     id: id || crypto.randomUUID(),
     body: body || `fn((s) => s)`,
-  } as Node);
+  } as LightningNode);
 
 export const createRun = (jobs = [], edges = [], triggers = []) => ({
   id: crypto.randomUUID(),

--- a/packages/ws-worker/test/util/convert-lightning-plan.test.ts
+++ b/packages/ws-worker/test/util/convert-lightning-plan.test.ts
@@ -1,5 +1,9 @@
 import test from 'ava';
-import type { LightningPlan, Node } from '@openfn/lexicon/lightning';
+import type {
+  LightningPlan,
+  LightningJob,
+  LightningTrigger,
+} from '@openfn/lexicon/lightning';
 import convertPlan, { conditions } from '../../src/util/convert-lightning-plan';
 import { ConditionalStepEdge, Job } from '@openfn/lexicon';
 
@@ -11,7 +15,7 @@ const createNode = (props = {}) =>
     adaptor: 'common',
     credential_id: 'y',
     ...props,
-  } as Node);
+  } as LightningJob);
 
 const createEdge = (from: string, to: string, props = {}) => ({
   id: `${from}-${to}`,
@@ -26,13 +30,13 @@ const createTrigger = (props = {}) =>
     id: 't',
     type: 'cron',
     ...props,
-  } as Node);
+  } as LightningTrigger);
 
 // Creates a runtime job node
 const createJob = (props = {}) => ({
   id: 'a',
   expression: 'x',
-  adaptor: 'common',
+  adaptors: ['common'],
   configuration: 'y',
   ...props,
 });

--- a/packages/ws-worker/test/util/create-run-state.test.ts
+++ b/packages/ws-worker/test/util/create-run-state.test.ts
@@ -9,7 +9,7 @@ const createPlan = (jobs: Partial<Job>[]) =>
       steps: jobs.map((j) => ({ expression: '.', ...j })),
     },
     options: {},
-  } as ExecutionPlan);
+  } as Required<ExecutionPlan>);
 
 test('create run', (t) => {
   const plan = createPlan([{ id: 'a' }]);

--- a/packages/ws-worker/test/worker.test.ts
+++ b/packages/ws-worker/test/worker.test.ts
@@ -44,7 +44,7 @@ const execute = async (plan: ExecutionPlan, input = {}, options = {}) =>
       [STEP_START]: async () => true,
       [RUN_LOG]: async (_evt) => {
         //console.log(evt.source, evt.message)
-        return true
+        return true;
       },
       [STEP_COMPLETE]: async () => true,
       [RUN_COMPLETE]: async () => true,
@@ -59,7 +59,6 @@ const execute = async (plan: ExecutionPlan, input = {}, options = {}) =>
 
     doExecute(channel, engine, logger, plan, input, options, onFinish);
   });
-
 
 // Repro for https://github.com/OpenFn/kit/issues/616
 // This will not run in CI unless the env is set
@@ -80,21 +79,21 @@ if (process.env.OPENFN_TEST_SF_TOKEN && process.env.OPENFN_TEST_SF_PASSWORD) {
             "email": "test@test.com"
           }])
         )`,
-      adaptor: '@openfn/language-salesforce@4.5.0',
+      adaptors: ['@openfn/language-salesforce@4.5.0'],
       configuration: {
         username: 'demo@openfn.org',
         securityToken: process.env.OPENFN_TEST_SF_TOKEN,
         password: process.env.OPENFN_TEST_SF_PASSWORD,
         loginUrl: 'https://login.salesforce.com',
-      }
+      },
     });
 
     const input = { data: { result: 42 } };
 
-    const result= await execute(plan, input);
-    t.log(result)
+    const result = await execute(plan, input);
+    t.log(result);
 
     // Actually this fails right but it's a permissions thing on the sandbox
     t.is(result.reason.reason, 'success');
-  })
+  });
 }


### PR DESCRIPTION
## Short Description

This PR enables the compiler to generate import statements for two adaptors.

This basically just means turning the `adaptor` option (which days which adaptor to use) into `adaptors` and making it an array. This turns out  to have a huge ripple effect in the typings but it's sorted now: the "entry points" tend to ensure that `adaptors` is an array, massing the original input in to the right format.

One issue which arises out of this work is the possibility of conflict. If you import `http` and `fhir`, for example, do we import `fn` from `http` or `fhir`? Fortunately with collections we don't really need to address this issue. But if somehow it ever does come up, it'll result in  compiled javascript code being invalid. So we can deal with this later.

This is part of #777

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
