### PR TITLE
compiler: don't extract common exports

### DIFF
--- a/.changeset/spicy-parents-guess.md
+++ b/.changeset/spicy-parents-guess.md
@@ -1,0 +1,5 @@
+---
+'@openfn/compiler': minor
+---
+
+Be more accurate in calculating exports from an adaptor"

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -124,11 +124,7 @@ export const loadTransformOptions = async (
     const path = await resolveSpecifierPath(pattern, opts.repoDir, log);
     if (path) {
       try {
-        exports = await preloadAdaptorExports(
-          path,
-          opts.useAdaptorsMonorepo,
-          log
-        );
+        exports = await preloadAdaptorExports(path, log);
       } catch (e) {
         log.error(`Failed to load adaptor typedefs from path ${path}`);
         log.error(e);

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -24,7 +24,7 @@ export const isRelativeSpecifier = (specifier: string) =>
 // But we may relax this  later.
 export const preloadAdaptorExports = async (
   pathToModule: string,
-  useMonorepo?: boolean,
+  _useMonorepo?: boolean,
   log?: Logger
 ) => {
   const project = new Project();
@@ -36,28 +36,6 @@ export const preloadAdaptorExports = async (
     pkg = JSON.parse(pkgSrc);
     if (pkg.types) {
       const functionDefs = {} as Record<string, true>;
-
-      // load common definitions into the project
-      if (pkg.name !== '@openfn/language-common') {
-        try {
-          const common = await findExports(
-            path.resolve(
-              pathToModule,
-              useMonorepo ? '../common' : '../language-common'
-            ),
-            'types/index.d.ts',
-            project
-          );
-          if (common) {
-            common.forEach(({ name }) => {
-              functionDefs[name] = true;
-            });
-          }
-        } catch (e) {
-          log?.debug('Failed to load types from language common');
-          log?.debug(e);
-        }
-      }
 
       const adaptor = await findExports(pathToModule, pkg.types, project);
       adaptor.forEach(({ name }) => {

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -24,7 +24,6 @@ export const isRelativeSpecifier = (specifier: string) =>
 // But we may relax this  later.
 export const preloadAdaptorExports = async (
   pathToModule: string,
-  _useMonorepo?: boolean,
   log?: Logger
 ) => {
   const project = new Project();

--- a/packages/engine-multi/src/api/compile.ts
+++ b/packages/engine-multi/src/api/compile.ts
@@ -56,7 +56,7 @@ const compileJob = async (
   if (adaptor && repoDir) {
     // TODO I probably dont want to log this stuff
     const pathToAdaptor = await getModulePath(adaptor, repoDir, logger);
-    const exports = await preloadAdaptorExports(pathToAdaptor!, false, logger);
+    const exports = await preloadAdaptorExports(pathToAdaptor!, logger);
     compilerOptions['add-imports'] = {
       adaptor: {
         name: stripVersionSpecifier(adaptor),


### PR DESCRIPTION
## Short Description

There's a very gnarly bit of compiler code called `preloadAdaptorExports` which tries to work out the list of valid exports from an adaptor.

We've had a lot of trouble around this historically - it doesn't actually work terrible well, and relies on some ropey, poorly tested code in `describe-adaptor`

The problem right now is that the list of exports for an adaptor is very generous. We basically list every export listed in the d.ts (regardless of how or where it's exported). And for some reason we also list everything exported from common, regardless of whether it's actually exported from the adaptor. Frankly I forget what this is all about.

Now this is a problem when we have multiple adaptors, a la collections, because the compiler things that both `http` and collections export `fn`, so it'll try to import it from both packages. Resulting in all kinds of trouble.

My solution is the lowest effort, lowest risk thing I can see:  only work out the exports for `index.d.ts` and `adaptor.ts`, because those two files are all that really matter for job code.

Now we're cheating a bit on the adaptors.d.ts thing, it's not a generic solution and makes an assumption about adaptor structure. But it's a fair one. And working out the exports properly, even with typescript, is actually really hard.

One day, when we re-write `describe-package`, we'll have a much more robust and generic solution for this sort of thing. But for now, I'll settle for this.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
