### PR TITLE
Global credentials

### DIFF
--- a/.changeset/eleven-cougars-exist.md
+++ b/.changeset/eleven-cougars-exist.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': minor
+---
+
+Support collections

--- a/.changeset/healthy-laws-sniff.md
+++ b/.changeset/healthy-laws-sniff.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': major
+---
+
+Support global credential object on a workflow

--- a/.changeset/loud-crabs-walk.md
+++ b/.changeset/loud-crabs-walk.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Append the collections adaptor to steps that need it

--- a/packages/lexicon/core.d.ts
+++ b/packages/lexicon/core.d.ts
@@ -23,6 +23,10 @@ export type Workflow = {
   name?: string;
 
   steps: Array<Job | Trigger>;
+
+  // global credentials
+  // (gets applied to every configuration object)
+  credentials?: Record<string, any>;
 };
 
 /**

--- a/packages/runtime/src/execute/compile-plan.ts
+++ b/packages/runtime/src/execute/compile-plan.ts
@@ -106,6 +106,9 @@ export default (plan: ExecutionPlan) => {
       start: options.start ?? workflow.steps[0]?.id!,
     },
   };
+  if (workflow.credentials) {
+    newPlan.workflow.credentials = workflow.credentials;
+  }
 
   const maybeAssign = (a: any, b: any, keys: Array<keyof Job>) => {
     keys.forEach((key) => {

--- a/packages/runtime/src/execute/step.ts
+++ b/packages/runtime/src/execute/step.ts
@@ -80,7 +80,7 @@ const executeStep = async (
   step: CompiledStep,
   input: State = {}
 ): Promise<{ next: StepId[]; state: any }> => {
-  const { opts, notify, logger, report } = ctx;
+  const { opts, notify, logger, report, plan } = ctx;
 
   const duration = Date.now();
 
@@ -104,12 +104,16 @@ const executeStep = async (
       opts.callbacks?.resolveCredential! // cheat - we need to handle the error case here
     );
 
-    const globals = await loadState(
+    const globalState = await loadState(
       job,
       opts.callbacks?.resolveState! // and here
     );
-
-    const state = assembleState(clone(input), configuration, globals);
+    const state = assembleState(
+      clone(input),
+      configuration,
+      globalState,
+      plan.workflow.credentials
+    );
 
     notify(NOTIFY_INIT_COMPLETE, {
       jobId,

--- a/packages/runtime/src/execute/step.ts
+++ b/packages/runtime/src/execute/step.ts
@@ -112,7 +112,7 @@ const executeStep = async (
       clone(input),
       configuration,
       globalState,
-      plan.workflow.credentials
+      plan.workflow?.credentials
     );
 
     notify(NOTIFY_INIT_COMPLETE, {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -36,6 +36,7 @@ export type Lazy<T> = string | T;
 export type CompiledExecutionPlan = {
   workflow: {
     steps: Record<StepId, CompiledStep>;
+    credentials?: Record<string, any>;
   };
   options: WorkflowOptions & {
     start: StepId;

--- a/packages/runtime/src/util/assemble-state.ts
+++ b/packages/runtime/src/util/assemble-state.ts
@@ -13,7 +13,8 @@ const assembleData = (initialData: any, defaultData = {}) => {
 const assembleState = (
   initialState: any = {}, // previous or initial state
   configuration = {},
-  defaultState: any = {} // This is default state provided by the job
+  defaultState: any = {}, // This is default state provided by the job
+  globalCredentials: any = {}
 ) => {
   const obj = {
     ...defaultState,
@@ -29,11 +30,7 @@ const assembleState = (
   }
 
   Object.assign(obj, {
-    configuration: Object.assign(
-      {},
-      initialState.configuration ?? {},
-      configuration
-    ),
+    configuration: Object.assign({}, globalCredentials, configuration),
     data: assembleData(initialState.data, defaultState.data),
   });
 

--- a/packages/runtime/test/execute/compile-plan.test.ts
+++ b/packages/runtime/test/execute/compile-plan.test.ts
@@ -33,6 +33,20 @@ const planWithEdge = (edge: Partial<StepEdge>) => ({
   },
 });
 
+test('should preserve global credentials ', (t) => {
+  const compiledPlan = compilePlan({
+    id: 'a',
+    workflow: {
+      steps: [{ id: 'a', expression: 'a' }],
+      credentials: { collections_token: 'j.w.t.' },
+    },
+  });
+
+  t.deepEqual(compiledPlan.workflow.credentials, {
+    collections_token: 'j.w.t.',
+  });
+});
+
 test('should preserve the start option', (t) => {
   const compiledPlan = compilePlan({
     id: 'a',

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -12,8 +12,6 @@ import {
 } from '../src';
 import run from '../src/runtime';
 
-type ExecutionPlanNoOptions = Omit<ExecutionPlan, 'options'>;
-
 test('run simple expression', async (t) => {
   const expression = 'export default [(s) => {s.data.done = true; return s}]';
 
@@ -22,7 +20,7 @@ test('run simple expression', async (t) => {
 });
 
 test('run a simple workflow', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         { expression: 'export default [(s) => ({ data: { done: true } })]' },
@@ -32,6 +30,22 @@ test('run a simple workflow', async (t) => {
 
   const result: any = await run(plan);
   t.true(result.data.done);
+});
+
+test('run a workflow with global config', async (t) => {
+  const plan: ExecutionPlan = {
+    workflow: {
+      steps: [{ expression: 'export default [(s) => state.configuration];' }],
+      credentials: {
+        collection_token: 'j.w.t',
+      },
+    },
+  };
+
+  const result: any = await run(plan);
+  t.deepEqual(result, {
+    collection_token: 'j.w.t',
+  });
 });
 
 test('run a workflow and notify major events', async (t) => {
@@ -47,7 +61,7 @@ test('run a workflow and notify major events', async (t) => {
     notify,
   };
 
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [{ expression: 'export default [(s) => s]' }],
     },
@@ -76,7 +90,7 @@ test('notify job error even after fail', async (t) => {
     notify,
   };
 
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         { id: 'a', expression: 'export default [(s) => s.data.x = s.err.z ]' },
@@ -102,7 +116,7 @@ test('notify job error even after crash', async (t) => {
     notify,
   };
 
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: { steps: [{ id: 'a', expression: 'export default [() => s]' }] },
   };
 
@@ -139,7 +153,7 @@ test('resolve a credential', async (t) => {
 });
 
 test('resolve initial state', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {
@@ -174,7 +188,7 @@ test('run a workflow with two jobs and call callbacks', async (t) => {
     notify,
   };
 
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         { id: 'a', expression: 'export default [(s) => s]', next: { b: true } },
@@ -192,7 +206,7 @@ test('run a workflow with two jobs and call callbacks', async (t) => {
 });
 
 test('run a workflow with state and parallel branching', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {
@@ -239,7 +253,7 @@ test('run a workflow with state and parallel branching', async (t) => {
 });
 
 test('run a workflow with a leaf step called multiple times', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {
@@ -294,7 +308,7 @@ test('run a workflow with a leaf step called multiple times', async (t) => {
 // TODO this test sort of shows why input state on the plan object is a bit funky
 // running the same plan with two inputs is pretty clunky
 test('run a workflow with state and conditional branching', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {
@@ -422,7 +436,7 @@ test('run a workflow with a start and end', async (t) => {
 });
 
 test('run a workflow with a trigger node', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {
@@ -442,7 +456,7 @@ test('run a workflow with a trigger node', async (t) => {
 });
 
 test('prefer initial state to inline state', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {
@@ -464,7 +478,7 @@ test('prefer initial state to inline state', async (t) => {
 });
 
 test('Allow a job to return undefined', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [{ expression: 'export default [() => {}]' }],
     },
@@ -475,7 +489,7 @@ test('Allow a job to return undefined', async (t) => {
 });
 
 test('log errors, write to state, and continue', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {
@@ -507,7 +521,7 @@ test('log errors, write to state, and continue', async (t) => {
 });
 
 test('log job code to the job logger', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {
@@ -529,7 +543,7 @@ test('log job code to the job logger', async (t) => {
 });
 
 test('log and serialize an error to the job logger', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {
@@ -556,7 +570,7 @@ test('log and serialize an error to the job logger', async (t) => {
 });
 
 test('error reports can be overwritten', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {
@@ -580,7 +594,7 @@ test('error reports can be overwritten', async (t) => {
 
 // This tracks current behaviour but I don't know if it's right
 test('stuff written to state before an error is preserved', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {
@@ -609,7 +623,7 @@ test('data can be an array (expression)', async (t) => {
 });
 
 test('data can be an array (workflow)', async (t) => {
-  const plan: ExecutionPlanNoOptions = {
+  const plan: ExecutionPlan = {
     workflow: {
       steps: [
         {

--- a/packages/runtime/test/util/assemble-state.test.ts
+++ b/packages/runtime/test/util/assemble-state.test.ts
@@ -67,7 +67,7 @@ test('Initial data does not have to be an object', (t) => {
   });
 });
 
-test('merges default and initial config objects', (t) => {
+test('does not merge default and initial config objects', (t) => {
   const initial = { configuration: { x: 1 } };
   const defaultState = undefined;
   const config = { y: 1 };
@@ -75,7 +75,6 @@ test('merges default and initial config objects', (t) => {
   const result = assembleState(initial, config, defaultState);
   t.deepEqual(result, {
     configuration: {
-      x: 1,
       y: 1,
     },
     data: {},
@@ -91,6 +90,52 @@ test('configuration overrides initialState.configuration', (t) => {
   t.deepEqual(result, {
     configuration: {
       x: 2,
+    },
+    data: {},
+  });
+});
+
+test('global credentials should be added', (t) => {
+  const initial = {};
+  const defaultState = undefined;
+  const config = undefined;
+  const global = { collection_token: 'j.w.t' };
+
+  const result = assembleState(initial, config, defaultState, global);
+  t.deepEqual(result, {
+    configuration: {
+      collection_token: 'j.w.t',
+    },
+    data: {},
+  });
+});
+
+test('global credentials should be merged in', (t) => {
+  const initial = { configuration: { x: 1 } };
+  const defaultState = undefined;
+  const config = { x: 2 };
+  const global = { collection_token: 'j.w.t' };
+
+  const result = assembleState(initial, config, defaultState, global);
+  t.deepEqual(result, {
+    configuration: {
+      x: 2,
+      collection_token: 'j.w.t',
+    },
+    data: {},
+  });
+});
+
+test('local credentials should override global credentials', (t) => {
+  const initial = { configuration: { x: 1 } };
+  const defaultState = undefined;
+  const config = { collection_token: 'x.y.z' };
+  const global = { collection_token: 'j.w.t' };
+
+  const result = assembleState(initial, config, defaultState, global);
+  t.deepEqual(result, {
+    configuration: {
+      collection_token: 'x.y.z',
     },
     data: {},
   });

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,16 @@
 # ws-worker
 
+## 1.7.1
+
+### Patch Changes
+
+- 1c79dc1: Append the collections adaptor to steps that need it
+- b15f151: Update worker to use adaptors as an array on xplans. Internal only change.
+- Updated dependencies [3463ff9]
+- Updated dependencies [7245bf7]
+  - @openfn/runtime@2.0.0
+  - @openfn/engine-multi@1.4.0
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -202,6 +202,15 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
           input,
         } = await joinRunChannel(app.socket, token, id, logger);
 
+        // Setup collections
+        if (plan.workflow.credentials?.collections_token) {
+          plan.workflow.credentials.collections_token = token;
+        }
+        if (plan.workflow.credentials?.collections_endpoint) {
+          plan.workflow.credentials.collections_endpoint =
+            app.options.lightning;
+        }
+
         // Default the payload limit if it's not otherwise set on the run options
         if (!('payloadLimitMb' in options)) {
           options.payloadLimitMb = app.options.payloadLimitMb;

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -42,13 +42,16 @@ const mapTriggerEdgeCondition = (edge: LightningEdge) => {
 // This function will look at every step and decide whether the collections adaptor
 // should be added to the array
 const appendCollectionsAdaptor = (plan: ExecutionPlan) => {
+  let hasCollections;
   plan.workflow.steps.forEach((step) => {
     const job = step as Job;
     if (job.expression?.match(/(collections\.)/)) {
+      hasCollections = true;
       job.adaptors ??= [];
       job.adaptors.push('@openfn/language-collections'); //  what about version? Is this safe?
     }
   });
+  return hasCollections;
 };
 
 // Options which relate to this execution but are not part of the plan
@@ -182,7 +185,13 @@ export default (
     plan.workflow.name = run.name;
   }
 
-  appendCollectionsAdaptor(plan as ExecutionPlan);
+  const hasCollections = appendCollectionsAdaptor(plan as ExecutionPlan);
+  if (hasCollections) {
+    plan.workflow.credentials = {
+      collections_token: true,
+      collections_endpoint: 'https://app.openfn.org',
+    };
+  }
 
   return {
     plan: plan as ExecutionPlan,

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -39,6 +39,18 @@ const mapTriggerEdgeCondition = (edge: LightningEdge) => {
   return condition;
 };
 
+// This function will look at every step and decide whether the collections adaptor
+// should be added to the array
+const appendCollectionsAdaptor = (plan: ExecutionPlan) => {
+  plan.workflow.steps.forEach((step) => {
+    const job = step as Job;
+    if (job.expression?.match(/(collections\.)/)) {
+      job.adaptors ??= [];
+      job.adaptors.push('@openfn/language-collections'); //  what about version? Is this safe?
+    }
+  });
+};
+
 // Options which relate to this execution but are not part of the plan
 export type WorkerRunOptions = ExecuteOptions & {
   // Defaults to true - must be explicity false to stop dataclips being sent
@@ -169,6 +181,8 @@ export default (
   if (run.name) {
     plan.workflow.name = run.name;
   }
+
+  appendCollectionsAdaptor(plan as ExecutionPlan);
 
   return {
     plan: plan as ExecutionPlan,

--- a/packages/ws-worker/test/lightning.test.ts
+++ b/packages/ws-worker/test/lightning.test.ts
@@ -258,6 +258,29 @@ test.serial('should run a run which returns initial state', async (t) => {
   });
 });
 
+test.serial('should run a run with the collections adaptor', async (t) => {
+  return new Promise((done) => {
+    const run = {
+      id: 'run-1',
+      jobs: [
+        {
+          // This should be enough to fake the worker into
+          // loading the collections machinery
+          body: 'fn((s) => /* collections.get */ s.configuration)',
+        },
+      ],
+    };
+
+    lng.waitForResult(run.id).then((result: any) => {
+      t.is(result.collections_endpoint, urls.lng);
+      t.is(typeof result.collections_token, 'string');
+      done();
+    });
+
+    lng.enqueueRun(run);
+  });
+});
+
 // A basic high level integration test to ensure the whole loop works
 // This checks the events received by the lightning websocket
 test.serial(

--- a/packages/ws-worker/test/util/convert-lightning-plan.test.ts
+++ b/packages/ws-worker/test/util/convert-lightning-plan.test.ts
@@ -588,3 +588,24 @@ test('convert edge condition always', (t) => {
   const edge = job.next as Record<string, ConditionalStepEdge>;
   t.false(edge.b.hasOwnProperty('condition'));
 });
+
+test('append the collections adaptor to jobs that use it', (t) => {
+  const run: Partial<LightningPlan> = {
+    id: 'w',
+    jobs: [
+      createNode({ id: 'a' }),
+      createNode({
+        id: 'b',
+        body: 'collections.each("c", "k", (state) => state)',
+      }),
+    ],
+    triggers: [{ id: 't', type: 'cron' }],
+    edges: [createEdge('a', 'b')],
+  };
+  const { plan } = convertPlan(run as LightningPlan);
+
+  const [_t, a, b] = plan.workflow.steps;
+
+  t.deepEqual(a.adaptors, ['common']);
+  t.deepEqual(b.adaptors, ['common', '@openfn/language-collections']);
+});

--- a/packages/ws-worker/test/util/convert-lightning-plan.test.ts
+++ b/packages/ws-worker/test/util/convert-lightning-plan.test.ts
@@ -606,7 +606,9 @@ test('append the collections adaptor to jobs that use it', (t) => {
 
   const [_t, a, b] = plan.workflow.steps;
 
+  // @ts-ignore
   t.deepEqual(a.adaptors, ['common']);
+  // @ts-ignore
   t.deepEqual(b.adaptors, ['common', '@openfn/language-collections']);
 });
 

--- a/packages/ws-worker/test/util/convert-lightning-plan.test.ts
+++ b/packages/ws-worker/test/util/convert-lightning-plan.test.ts
@@ -609,3 +609,26 @@ test('append the collections adaptor to jobs that use it', (t) => {
   t.deepEqual(a.adaptors, ['common']);
   t.deepEqual(b.adaptors, ['common', '@openfn/language-collections']);
 });
+
+test('append the collections credential to jobs that use it', (t) => {
+  const run: Partial<LightningPlan> = {
+    id: 'w',
+    jobs: [
+      createNode({ id: 'a' }),
+      createNode({
+        id: 'b',
+        body: 'collections.each("c", "k", (state) => state)',
+      }),
+    ],
+    triggers: [{ id: 't', type: 'cron' }],
+    edges: [createEdge('a', 'b')],
+  };
+  const { plan } = convertPlan(run as LightningPlan);
+
+  const creds = plan.workflow.credentials;
+
+  t.deepEqual(creds, {
+    collections_token: true,
+    collections_endpoint: 'https://app.openfn.org',
+  });
+});


### PR DESCRIPTION
## Short Description

This PR adds the capability for what I'm calling "global credentials" in the runtime.

What that means is you can specify a credential on root of the workflow JSON, and it'll automatically be grafted into every step in state.configuration.

This feels like a logical and intuitive feature - but it's also a great use-case for collections. It provides a really neat mechanism for the worker to add system-level credentials.

I mean the alternative is to support `credentials` as an array, which is sort of covered in #802. But this is  gnarly change and too big for what I was looking for with collections.

Fixes #

## Implementation Details

If we detect possible use of the collections API in job code (literally just the string `collections.`), the worker create a global credential on the execution plan, adding `collections_token` and `collections_endpoint`. The endpoint is set to the lightning base URL used by the worker.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
