### PR TITLE
Worker: set or lookup the collections adaptor version

### DIFF
--- a/.changeset/stale-taxis-attack.md
+++ b/.changeset/stale-taxis-attack.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': minor
+---
+
+Support for collection versions (as arg or auto-looked-up on startup)

--- a/integration-tests/worker/src/init.ts
+++ b/integration-tests/worker/src/init.ts
@@ -43,6 +43,7 @@ export const initWorker = async (
     port: workerPort,
     lightning: `ws://localhost:${lightningPort}/worker`,
     secret: crypto.randomUUID(),
+    collectionsVersion: '1.0.0',
     ...workerArgs,
   });
 

--- a/integration-tests/worker/test/server.test.ts
+++ b/integration-tests/worker/test/server.test.ts
@@ -21,6 +21,7 @@ const spawnServer = (port: string | number = 1, args: string[] = []) => {
         '--backoff 0.001/0.01',
         '--log debug',
         '-s secretsquirrel',
+        '--collections-token=1.0.0',
         ...args,
       ],
       options

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -9,7 +9,7 @@ import koaLogger from 'koa-logger';
 import Router from '@koa/router';
 import { humanId } from 'human-id';
 import { createMockLogger, Logger } from '@openfn/logger';
-import { ClaimRun, LightningPlan } from '@openfn/lexicon/lightning';
+import { ClaimRun } from '@openfn/lexicon/lightning';
 import { INTERNAL_RUN_COMPLETE } from './events';
 import destroy from './api/destroy';
 import startWorkloop, { Workloop } from './api/workloop';

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -1,4 +1,8 @@
 import { EventEmitter } from 'node:events';
+
+import { promisify } from 'node:util';
+import { exec as _exec } from 'node:child_process';
+
 import Koa from 'koa';
 import bodyParser from 'koa-bodyparser';
 import koaLogger from 'koa-logger';
@@ -19,6 +23,8 @@ import type { Server } from 'http';
 import type { RuntimeEngine } from '@openfn/engine-multi';
 import type { Socket, Channel } from './types';
 import { convertRun } from './util';
+
+const exec = promisify(_exec);
 
 export type ServerOptions = {
   maxWorkflows?: number;
@@ -153,7 +159,11 @@ async function lookupCollectionsVersion(
     );
     return options.collectionsVersion;
   }
-  return;
+  const { stdout: version } = await exec(
+    'npm view @openfn/language-collections@next version'
+  );
+  logger.log('Using collections version from @latest: ', version);
+  return version;
 }
 
 function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -42,6 +42,7 @@ function engineReady(engine: any) {
     },
     maxWorkflows: args.capacity,
     payloadLimitMb: args.payloadMemory,
+    collectionsVersion: args.collectionsVersion,
   };
 
   if (args.lightningPublicKey) {

--- a/packages/ws-worker/src/util/cli.ts
+++ b/packages/ws-worker/src/util/cli.ts
@@ -23,6 +23,7 @@ type Args = {
   statePropsToRemove?: string[];
   maxRunDurationSeconds: number;
   socketTimeoutSeconds?: number;
+  collectionsVersion?: string;
 };
 
 type ArgTypes = string | string[] | number | undefined;
@@ -51,6 +52,7 @@ export default function parseArgs(argv: string[]): Args {
   const {
     WORKER_BACKOFF,
     WORKER_CAPACITY,
+    WORKER_COLLECTIONS_VERSION,
     WORKER_LIGHTNING_PUBLIC_KEY,
     WORKER_LIGHTNING_SERVICE_URL,
     WORKER_LOG_LEVEL,
@@ -135,6 +137,11 @@ export default function parseArgs(argv: string[]): Args {
       description:
         'Default run timeout for the server, in seconds. Env: WORKER_MAX_RUN_DURATION_SECONDS',
       type: 'number',
+    })
+    .option('collections-version', {
+      description:
+        'The verison of the collections adaptor to use for all runs on this worker instance.Env: WORKER_COLLECTIONS_VERSION',
+      type: 'string',
     });
 
   const args = parser.parse() as Args;
@@ -172,6 +179,10 @@ export default function parseArgs(argv: string[]): Args {
       args.socketTimeoutSeconds,
       WORKER_SOCKET_TIMEOUT_SECONDS,
       DEFAULT_SOCKET_TIMEOUT_SECONDS
+    ),
+    collectionsVersion: setArg(
+      args.collectionsVersion,
+      WORKER_COLLECTIONS_VERSION
     ),
   } as Args;
 }

--- a/packages/ws-worker/test/channels/run.test.ts
+++ b/packages/ws-worker/test/channels/run.test.ts
@@ -1,79 +1,24 @@
 import test from 'ava';
 import { mockSocket, mockChannel } from '../../src/mock/sockets';
-import joinRunChannel, { loadRun } from '../../src/channels/run';
+import joinRunChannel from '../../src/channels/run';
 import { GET_PLAN } from '../../src/events';
 import { runs } from '../mock/data';
 import { createMockLogger } from '@openfn/logger';
 
-test('loadRun should get the run body', async (t) => {
-  const run = runs['run-1'];
-  let didCallGetRun = false;
-  const channel = mockChannel({
-    [GET_PLAN]: () => {
-      // TODO should be no payload (or empty payload)
-      didCallGetRun = true;
-      return run;
-    },
-  });
-
-  await loadRun(channel);
-  t.true(didCallGetRun);
-});
-
-test('loadRun should return an execution plan and options', async (t) => {
-  const run = {
-    ...runs['run-1'],
-    options: {
-      sanitize: 'obfuscate',
-      run_timeout_ms: 10,
-    },
-  };
-
-  const channel = mockChannel({
-    [GET_PLAN]: () => run,
-  });
-
-  const { plan, options } = await loadRun(channel);
-  t.like(plan, {
-    id: 'run-1',
-    workflow: {
-      steps: [
-        {
-          id: 'job-1',
-          configuration: 'a',
-          expression: 'fn(a => a)',
-          adaptors: ['@openfn/language-common@1.0.0'],
-        },
-      ],
-    },
-  });
-  t.is(options.sanitize, 'obfuscate');
-  t.is(options.runTimeoutMs, 10);
-});
-
-test('should join an run channel with a token', async (t) => {
+test('should join a run channel with a token and return a raw lightning run', async (t) => {
   const logger = createMockLogger();
   const socket = mockSocket('www', {
     'run:a': mockChannel({
       // Note that the validation logic is all handled here
       join: () => ({ status: 'ok' }),
-      [GET_PLAN]: () => ({
-        id: 'a',
-        options: { run_timeout_ms: 10 },
-      }),
+      [GET_PLAN]: () => runs['run-1'],
     }),
   });
 
-  const { channel, plan, options } = await joinRunChannel(
-    socket,
-    'x.y.z',
-    'a',
-    logger
-  );
+  const { channel, run } = await joinRunChannel(socket, 'x.y.z', 'a', logger);
 
   t.truthy(channel);
-  t.deepEqual(plan, { id: 'a', workflow: { steps: [] }, options: {} });
-  t.deepEqual(options, { runTimeoutMs: 10 });
+  t.deepEqual(run, runs['run-1']);
 });
 
 test('should fail to join an run channel with an invalid token', async (t) => {

--- a/packages/ws-worker/test/util/convert-lightning-plan.test.ts
+++ b/packages/ws-worker/test/util/convert-lightning-plan.test.ts
@@ -602,14 +602,14 @@ test('append the collections adaptor to jobs that use it', (t) => {
     triggers: [{ id: 't', type: 'cron' }],
     edges: [createEdge('a', 'b')],
   };
-  const { plan } = convertPlan(run as LightningPlan);
+  const { plan } = convertPlan(run as LightningPlan, '1.0.0');
 
   const [_t, a, b] = plan.workflow.steps;
 
   // @ts-ignore
   t.deepEqual(a.adaptors, ['common']);
   // @ts-ignore
-  t.deepEqual(b.adaptors, ['common', '@openfn/language-collections']);
+  t.deepEqual(b.adaptors, ['common', '@openfn/language-collections@1.0.0']);
 });
 
 test('append the collections credential to jobs that use it', (t) => {


### PR DESCRIPTION
## Short Description

This PR levelsup the worker to know about which version of the collections adaptor to be used.

You can pass in a version explicitly, via the cli or env var. If no version is provided, the server will look up the latest version on npm.

This arises because of #462, where in the worker needs to know a specific adaptor version to autoinstall (using latest all the time just doesn't work very well).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
