### PR TITLE
Runtime: Fix input state assembly

### DIFF
--- a/.changeset/curly-lions-prove.md
+++ b/.changeset/curly-lions-prove.md
@@ -1,0 +1,7 @@
+---
+'@openfn/runtime': patch
+'@openfn/cli': patch
+'@openfn/ws-worker': patch
+---
+
+Fix an issue from previous patch where initial state.configuration could be lost at the start of a step

--- a/.changeset/curly-lions-prove.md
+++ b/.changeset/curly-lions-prove.md
@@ -1,7 +1,0 @@
----
-'@openfn/runtime': patch
-'@openfn/cli': patch
-'@openfn/ws-worker': patch
----
-
-Fix an issue from previous patch where initial state.configuration could be lost at the start of a step

--- a/integration-tests/execute/CHANGELOG.md
+++ b/integration-tests/execute/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/integration-tests-execute
 
+## 1.0.7
+
+### Patch Changes
+
+- Updated dependencies [eeb660d]
+  - @openfn/runtime@1.5.1
+
 ## 1.0.6
 
 ### Patch Changes

--- a/integration-tests/execute/package.json
+++ b/integration-tests/execute/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-execute",
   "private": true,
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Job execution tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openfn/integration-tests-worker
 
+## 1.0.64
+
+### Patch Changes
+
+- Updated dependencies [eeb660d]
+  - @openfn/ws-worker@1.8.1
+  - @openfn/engine-multi@1.4.1
+  - @openfn/lightning-mock@2.0.22
+
 ## 1.0.63
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.63",
+  "version": "1.0.64",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 1.8.7
+
+### Patch Changes
+
+- eeb660d: Fix an issue from previous patch where initial state.configuration could be lost at the start of a step
+- Updated dependencies [eeb660d]
+  - @openfn/runtime@1.5.1
+
 ## 1.8.6
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # engine-multi
 
+## 1.4.1
+
+### Patch Changes
+
+- Updated dependencies [eeb660d]
+  - @openfn/runtime@1.5.1
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/lightning-mock
 
+## 2.0.22
+
+### Patch Changes
+
+- Updated dependencies [eeb660d]
+  - @openfn/runtime@1.5.1
+  - @openfn/engine-multi@1.4.1
+
 ## 2.0.21
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/runtime
 
+## 1.5.1
+
+### Patch Changes
+
+- eeb660d: Fix an issue from previous patch where initial state.configuration could be lost at the start of a step
+
 ## 1.5.0
 
 ### Minor Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Job processing runtime.",
   "type": "module",
   "exports": {

--- a/packages/runtime/src/util/assemble-state.ts
+++ b/packages/runtime/src/util/assemble-state.ts
@@ -30,7 +30,12 @@ const assembleState = (
   }
 
   Object.assign(obj, {
-    configuration: Object.assign({}, globalCredentials, configuration),
+    configuration: Object.assign(
+      {},
+      globalCredentials,
+      initialState.configuration,
+      configuration
+    ),
     data: assembleData(initialState.data, defaultState.data),
   });
 

--- a/packages/runtime/test/util/assemble-state.test.ts
+++ b/packages/runtime/test/util/assemble-state.test.ts
@@ -67,7 +67,7 @@ test('Initial data does not have to be an object', (t) => {
   });
 });
 
-test('does not merge default and initial config objects', (t) => {
+test('merges default and initial config objects', (t) => {
   const initial = { configuration: { x: 1 } };
   const defaultState = undefined;
   const config = { y: 1 };
@@ -75,6 +75,7 @@ test('does not merge default and initial config objects', (t) => {
   const result = assembleState(initial, config, defaultState);
   t.deepEqual(result, {
     configuration: {
+      x: 1,
       y: 1,
     },
     data: {},
@@ -90,6 +91,20 @@ test('configuration overrides initialState.configuration', (t) => {
   t.deepEqual(result, {
     configuration: {
       x: 2,
+    },
+    data: {},
+  });
+});
+
+test('initialState.configuration is preserved', (t) => {
+  const initial = { configuration: { x: 1 } };
+  const defaultState = undefined;
+  const config = undefined;
+
+  const result = assembleState(initial, config, defaultState);
+  t.deepEqual(result, {
+    configuration: {
+      x: 1,
     },
     data: {},
   });
@@ -127,6 +142,21 @@ test('global credentials should be merged in', (t) => {
 });
 
 test('local credentials should override global credentials', (t) => {
+  const initial = { configuration: {} };
+  const defaultState = undefined;
+  const config = { collection_token: 'x.y.z' };
+  const global = { collection_token: 'j.w.t' };
+
+  const result = assembleState(initial, config, defaultState, global);
+  t.deepEqual(result, {
+    configuration: {
+      collection_token: 'x.y.z',
+    },
+    data: {},
+  });
+});
+
+test('local credentials should override global credentials but still preserve intial credentials', (t) => {
   const initial = { configuration: { x: 1 } };
   const defaultState = undefined;
   const config = { collection_token: 'x.y.z' };
@@ -135,6 +165,7 @@ test('local credentials should override global credentials', (t) => {
   const result = assembleState(initial, config, defaultState, global);
   t.deepEqual(result, {
     configuration: {
+      x: 1,
       collection_token: 'x.y.z',
     },
     data: {},

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # ws-worker
 
+## 1.8.1
+
+### Patch Changes
+
+- eeb660d: Fix an issue from previous patch where initial state.configuration could be lost at the start of a step
+- Updated dependencies [eeb660d]
+  - @openfn/runtime@1.5.1
+  - @openfn/engine-multi@1.4.1
+
 ## 1.8.0
 
 ### Minor Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Short Description

This PR fixes a critical new issue, introduced by the collections work, where the initial state from a job gets blatted wrongly.

This affects CLI 1.8.6 and the (unreleased) worker 1.8.0

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
