### PR TITLE
worker: allow steps to specify their own adaptor version

### DIFF
--- a/.changeset/chatty-clocks-relax.md
+++ b/.changeset/chatty-clocks-relax.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Allow steps to specify their own adaptor version

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -88,8 +88,16 @@ export default (
       const job = step as Job;
       if (job.expression?.match(/(collections\.)/)) {
         hasCollections = true;
-        job.adaptors ??= [];
-        job.adaptors.push(`@openfn/language-collections@${collectionsVersion}`);
+        if (
+          !job.adaptors?.find((v) =>
+            v.startsWith('@openfn/language-collections')
+          )
+        ) {
+          job.adaptors ??= [];
+          job.adaptors.push(
+            `@openfn/language-collections@${collectionsVersion}`
+          );
+        }
       }
     });
     return hasCollections;

--- a/packages/ws-worker/test/util/convert-lightning-plan.test.ts
+++ b/packages/ws-worker/test/util/convert-lightning-plan.test.ts
@@ -614,7 +614,36 @@ test('append the collections adaptor to jobs that use it', (t) => {
   t.deepEqual(b.adaptors, ['common', '@openfn/language-collections@1.0.0']);
 });
 
-test('append the collections credential to jobs that use it', (t) => {
+test('do not append the collections adaptor to jobs that already have it', (t) => {
+  const run: Partial<LightningPlan> = {
+    id: 'w',
+    jobs: [
+      createNode({
+        id: 'a',
+        body: 'collections.each("c", "k", (state) => state)',
+        adaptor: '@openfn/language-collections@latest',
+      }),
+    ],
+    triggers: [{ id: 't', type: 'cron' }],
+    edges: [createEdge('t', 'a')],
+  };
+
+  const { plan } = convertPlan(run as LightningPlan, {
+    collectionsVersion: '1.0.0',
+  });
+
+  const [_t, a] = plan.workflow.steps;
+
+  // @ts-ignore
+  t.deepEqual(a.adaptors, ['@openfn/language-collections@latest']);
+
+  t.deepEqual(plan.workflow.credentials, {
+    collections_token: true,
+    collections_endpoint: true,
+  });
+});
+
+test('append the collections credential to workflows that use it', (t) => {
   const run: Partial<LightningPlan> = {
     id: 'w',
     jobs: [


### PR DESCRIPTION
## Short Description

Little PR to allow a workflow step to provide its own collections version.

This isn't very useful really because Lightning would have to explicitly pass two adaptors into the attempt, which is a reasonably big change I would say.

Still, this was on my mind and I figure it's worth doing. It's not a big deal to the worker.


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
