### PR TITLE
Collections fix version lookup

### DIFF
--- a/.changeset/big-paws-tap.md
+++ b/.changeset/big-paws-tap.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': minor
+---
+
+Fix an issue running collections from an auto-loaded version

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -60,9 +60,6 @@ export interface ServerApp extends Koa {
   engine: RuntimeEngine;
   options: ServerOptions;
   workloop?: Workloop;
-  // What version of the collections adaptor should we use?
-  // Can be set through CLI, or else it'll look up latest on startup
-  collectionsVersion?: string;
 
   execute: ({ id, token }: ClaimRun) => Promise<void>;
   destroy: () => void;
@@ -174,7 +171,7 @@ async function setupCollections(options: ServerOptions, logger: Logger) {
     'npm view @openfn/language-collections@latest version'
   );
   logger.log('Using collections version from @latest: ', version);
-  return version;
+  return version.trim();
 }
 
 function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
@@ -322,7 +319,7 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
 
   if (options.lightning) {
     setupCollections(options, logger).then((version) => {
-      app.collectionsVersion = version;
+      app.options.collectionsVersion = version;
       connect(app, logger, options);
     });
   } else {


### PR DESCRIPTION
## Short Description

If you specify the collections versions number (as I do in local testing), everything works fine.

But if the worker looks up the latest collections version from npm, everything breaks!

This is because:

a) I am saving the adaptor version to the wrong place so it doesn't get used (whoops) 
b) the version number includes whitespace, which breaks the autoinstall command.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset version` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
