### PR TITLE
Fix Project Path Flag Issue

### DIFF
--- a/.changeset/angry-spoons-tie.md
+++ b/.changeset/angry-spoons-tie.md
@@ -1,5 +1,0 @@
----
-'@openfn/cli': patch
----
-
-Resolved an issue where the `-p` (project path) flag was ignored in the `deploy` command, causing the CLI to default to `project.yaml` instead of the specified file.

--- a/.changeset/angry-spoons-tie.md
+++ b/.changeset/angry-spoons-tie.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Resolved an issue where the `-p` (project path) flag was ignored in the `deploy` command, causing the CLI to default to `project.yaml` instead of the specified file.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/cli
 
+## 1.8.8
+
+### Patch Changes
+
+- 1f13d8f: Resolved an issue where the `-p` (project path) flag was ignored in the `deploy` command, causing the CLI to default to `project.yaml` instead of the specified file.
+
 ## 1.8.7
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/cli/src/deploy/handler.ts
+++ b/packages/cli/src/deploy/handler.ts
@@ -76,6 +76,7 @@ function mergeOverrides(
     apiKey: pickFirst(process.env['OPENFN_API_KEY'], config.apiKey),
     endpoint: pickFirst(process.env['OPENFN_ENDPOINT'], config.endpoint),
     statePath: pickFirst(options.statePath, config.statePath),
+    specPath: pickFirst(options.projectPath, config.specPath),
     configPath: options.configPath,
     requireConfirmation: pickFirst(options.confirm, config.requireConfirmation),
   };

--- a/packages/cli/test/deploy/options.test.ts
+++ b/packages/cli/test/deploy/options.test.ts
@@ -36,3 +36,13 @@ test('pass a config path (shortform)', (t) => {
   const options = parse('deploy -c other_config.json');
   t.deepEqual(options.configPath, 'other_config.json');
 });
+
+test('pass a spec path (longform)', (t) => {
+  const options = parse('deploy --project-path test-project.yaml');
+  t.deepEqual(options.projectPath, 'test-project.yaml');
+});
+
+test('pass a spec path (shortform)', (t) => {
+  const options = parse('deploy -p test-project.yaml');
+  t.deepEqual(options.projectPath, 'test-project.yaml');
+});


### PR DESCRIPTION
## Short Description

Fixes an issue where the -p (project path) flag in the deploy command would default to `project.yaml` instead of using the specified file.

Fixes #286 

## Implementation Details

## QA Notes

- Verify that running openfn deploy -p test1.yaml now correctly uses test1.yaml as the project file, without defaulting to project.yaml.
- Test other commands to ensure no unintended impact on flag handling.
- Check for cases where project.yaml should still be used as a default if the -p flag is omitted.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
