### PR TITLE
Compiler: allow function calls on lazy state

### DIFF
--- a/integration-tests/execute/CHANGELOG.md
+++ b/integration-tests/execute/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/integration-tests-execute
 
+## 1.0.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/compiler@0.4.2
+
 ## 1.0.10
 
 ### Patch Changes

--- a/integration-tests/execute/ava.config.js
+++ b/integration-tests/execute/ava.config.js
@@ -1,0 +1,13 @@
+export default {
+  extensions: {
+    ts: 'module',
+  },
+
+  environmentVariables: {
+    TS_NODE_TRANSPILE_ONLY: 'true',
+  },
+
+  nodeArguments: ['--loader=ts-node/esm', '--no-warnings', '--experimental-vm-modules'],
+
+  files: ['test/**/*test.ts'],
+};

--- a/integration-tests/execute/package.json
+++ b/integration-tests/execute/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-execute",
   "private": true,
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Job execution tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/integration-tests/execute/test/lazy-state.test.ts
+++ b/integration-tests/execute/test/lazy-state.test.ts
@@ -1,0 +1,51 @@
+import test from 'ava';
+import execute from '../src/execute';
+
+test.serial(
+  'use lazy-state in template literal & property access',
+  async (t) => {
+    const state = {
+      keyName: 'someKey',
+      firstName: 'John',
+      lastName: 'Doe',
+    };
+    const job = `
+fnIf(\`$\{$.keyName\}\` === 'someKey', state => {
+  state.literal = true;
+  return state;
+})
+
+fnIf($.firstName + $['lastName'] === 'JohnDoe', state=> {
+  state.concat = true;
+  return state;
+})`;
+
+    const result = await execute(job, state);
+    t.is(result.literal, true);
+    t.is(result.concat, true);
+  }
+);
+
+test.serial('state function called with lazy-state', async (t) => {
+  const state = { data: {} };
+
+  const job = `
+fn((state) => {
+    state.callMeMaybe = (value) => {
+        state.data.greetings = "Hello " + value
+		return state;
+    }
+    return state
+});
+
+fn(state => {
+    state.data.name = "John"
+    return state;
+})
+
+fn($.callMeMaybe($.data.name))`;
+
+  const result = await execute(job, state);
+
+  t.deepEqual(result, { data: { name: 'John', greetings: 'Hello John' } });
+});

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openfn/integration-tests-worker
 
+## 1.0.69
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/ws-worker@1.8.6
+  - @openfn/engine-multi@1.4.5
+  - @openfn/lightning-mock@2.0.26
+
 ## 1.0.68
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 1.8.12
+
+### Patch Changes
+
+- When using lazy state in job code, allow functions to be called directly on the state object, ie, `$.generateUUID()`
+- Updated dependencies
+  - @openfn/compiler@0.4.2
+
 ## 1.8.11
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.8.11",
+  "version": "1.8.12",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/compiler
 
+## 0.4.2
+
+### Patch Changes
+
+- When using lazy state in job code, allow functions to be called directly on the state object, ie, `$.generateUUID()`
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/compiler",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Compiler and language tooling for openfn jobs.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/compiler/src/transforms/lazy-state.ts
+++ b/packages/compiler/src/transforms/lazy-state.ts
@@ -29,7 +29,15 @@ const ensureParentArrow = (path: NodePath<n.MemberExpression>) => {
   }
 
   if (root && n.CallExpression.check(root.node)) {
-    const arg = last as NodePath;
+    let arg = last as NodePath;
+    if (
+      arg.parentPath &&
+      n.CallExpression.check(arg.parentPath.node) &&
+      n.MemberExpression.check(arg.parentPath.node.callee) &&
+      arg.parentPath.node.callee.object.name === 'state'
+    ) {
+      arg = arg.parentPath;
+    }
 
     if (!isOpenFunction(arg)) {
       const params = b.identifier('state');

--- a/packages/compiler/test/transforms/lazy-state.test.ts
+++ b/packages/compiler/test/transforms/lazy-state.test.ts
@@ -219,3 +219,21 @@ test('convert logical not', (t) => {
 
   t.is(code, 'get(state => !state.data.x)');
 });
+
+test('convert function call on state', (t) => {
+  const ast = parse('fn($.callMeMaybe())');
+
+  const transformed = transform(ast, [visitors]);
+  const { code } = print(transformed);
+
+  t.is(code, 'fn(state => state.callMeMaybe())');
+});
+
+test('convert function call on state with state argument', (t) => {
+  const ast = parse('fn($.callMeMaybe($.age))');
+
+  const transformed = transform(ast, [visitors]);
+  const { code } = print(transformed);
+
+  t.is(code, 'fn(state => state.callMeMaybe(state.age))');
+});

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # engine-multi
 
+## 1.4.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @openfn/compiler@0.4.2
+
 ## 1.4.4
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/lightning-mock
 
+## 2.0.26
+
+### Patch Changes
+
+- @openfn/engine-multi@1.4.5
+
 ## 2.0.25
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ws-worker
 
+## 1.8.6
+
+### Patch Changes
+
+- When using lazy state in job code, allow functions to be called directly on the state object, ie, `$.generateUUID()`
+  - @openfn/engine-multi@1.4.5
+
 ## 1.8.5
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Short Description

Currently function calls on lazy-state do not work. 
eg. 
```js
fn((state) => {
   state.callMeMaybe = () => {}
  return state
});
// does not work before this PR
fn($.callMeMaybe())
```
This is because, we fail to wrap the state callback well. This update fixes that.
#### How it worked before and after
Given the source code `fn($.callMeMaybe())`
| Before this PR                             | After this PR                            |
|--------------------------------------------|------------------------------------------|
| ``` fn((state => state.callMeMaybe)()) ``` | ``` fn(state => state.callMeMaybe()) ``` |

Fixes #684 

## Implementation Details

#### Steps
1. after finding the MemberExpression with $, we start walking up the tree to find a CallExpression to wrap. 
2. when we find this CallExpression, a simple check is done to find out whether the parent of this CallExpression is another CallExpression with callee being state. (that's how we know it's a function called on a lazy-state)
3. we then want to wrap the state stuff at an additional level up for it to work!

## QA Notes

List any considerations/cases/advice for testing/QA here.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

