### PR TITLE
describe-package: fix examples

### DIFF
--- a/.changeset/sweet-bugs-breathe.md
+++ b/.changeset/sweet-bugs-breathe.md
@@ -1,5 +1,0 @@
----
-'@openfn/describe-package': patch
----
-
-Fix an issue which causes malformed examples to throw an error

--- a/.changeset/sweet-bugs-breathe.md
+++ b/.changeset/sweet-bugs-breathe.md
@@ -1,0 +1,5 @@
+---
+'@openfn/describe-package': patch
+---
+
+Fix an issue which causes malformed examples to throw an error

--- a/examples/dts-inspector/CHANGELOG.md
+++ b/examples/dts-inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # dts-inspector
 
+## 1.0.21
+
+### Patch Changes
+
+- Updated dependencies [ddda182]
+  - @openfn/describe-package@0.1.3
+
 ## 1.0.20
 
 ### Patch Changes

--- a/examples/dts-inspector/package.json
+++ b/examples/dts-inspector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dts-inspector",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/integration-tests/execute/CHANGELOG.md
+++ b/integration-tests/execute/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/integration-tests-execute
 
+## 1.0.10
+
+### Patch Changes
+
+- @openfn/compiler@0.4.1
+
 ## 1.0.9
 
 ### Patch Changes

--- a/integration-tests/execute/package.json
+++ b/integration-tests/execute/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-execute",
   "private": true,
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Job execution tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/integration-tests-worker
 
+## 1.0.68
+
+### Patch Changes
+
+- @openfn/engine-multi@1.4.4
+- @openfn/lightning-mock@2.0.25
+- @openfn/ws-worker@1.8.5
+
 ## 1.0.67
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.67",
+  "version": "1.0.68",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 1.8.11
+
+### Patch Changes
+
+- Updated dependencies [ddda182]
+  - @openfn/describe-package@0.1.3
+  - @openfn/compiler@0.4.1
+
 ## 1.8.10
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.8.10",
+  "version": "1.8.11",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/compiler
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies [ddda182]
+  - @openfn/describe-package@0.1.3
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/compiler",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Compiler and language tooling for openfn jobs.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/describe-package/CHANGELOG.md
+++ b/packages/describe-package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/describe-package
 
+## 0.1.3
+
+### Patch Changes
+
+- ddda182: Fix an issue which causes malformed examples to throw an error
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/describe-package/package.json
+++ b/packages/describe-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/describe-package",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Utilities to inspect an npm package.",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/describe-package/src/describe-project.ts
+++ b/packages/describe-package/src/describe-project.ts
@@ -48,15 +48,19 @@ const describeFunction = (
     parameters: symbol.parameters.map((p) => describeParameter(project, p)),
     magic: symbol.jsDocTags.some((tag) => tag.tagName.escapedText === 'magic'),
     isOperation: false,
-    examples: symbol.examples.map((eg: string) => {
-      if (eg.startsWith('<caption>')) {
-        let [caption, code] = eg.split('</caption>');
-        caption = caption.replace('<caption>', '');
+    examples: symbol.examples
+      // Some cases can produce non-string examples
+      // Ie if an @{link} declaration is inside a caption, which breaks parsing (for some reason)
+      .filter((eg) => typeof eg === 'string')
+      .map((eg: string) => {
+        if (eg.startsWith('<caption>')) {
+          let [caption, code] = eg.split('</caption>');
+          caption = caption.replace('<caption>', '');
 
-        return { caption: caption.trim(), code: code.trim() };
-      }
-      return { code: eg.trim() };
-    }),
+          return { caption: caption.trim(), code: code.trim() };
+        }
+        return { code: eg.trim() };
+      }),
   };
 };
 

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # engine-multi
 
+## 1.4.4
+
+### Patch Changes
+
+- @openfn/compiler@0.4.1
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/lightning-mock
 
+## 2.0.25
+
+### Patch Changes
+
+- @openfn/engine-multi@1.4.4
+
 ## 2.0.24
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ws-worker
 
+## 1.8.5
+
+### Patch Changes
+
+- @openfn/engine-multi@1.4.4
+
 ## 1.8.4
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Short Description

If an example includes a `{@link }` tag (and it shouldn't!), it'll trigger an error and docs won't show up in Lightning.

This fix makes the example parser more stable - but note that any offending examples will not be displayed in lightning's adaptor docs.

Fixes https://github.com/OpenFn/adaptors/issues/854

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
