### PR TITLE
Sourcemapping adaptor errors

### DIFF
--- a/.changeset/hungry-windows-search.md
+++ b/.changeset/hungry-windows-search.md
@@ -1,0 +1,5 @@
+---
+'@openfn/compiler': minor
+---
+
+Append positional information to top level operations

--- a/integration-tests/cli/test/fixtures/errors.json
+++ b/integration-tests/cli/test/fixtures/errors.json
@@ -1,0 +1,21 @@
+{
+  "workflow": {
+    "steps": [
+      {
+        "id": "ref",
+        "adaptor": "common",
+        "expression": "fn((state) => state.x.y)"
+      },
+      {
+        "id": "not-function",
+        "adaptor": "common",
+        "expression": "fn((state) => state())"
+      },
+      {
+        "id": "assign-const",
+        "adaptor": "common",
+        "expression": "fn((state) => {  const x = 10; x = 20; })"
+      }
+    ]
+  }
+}

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -1,12 +1,16 @@
 import compile, { preloadAdaptorExports, Options } from '@openfn/compiler';
-import { getModulePath, SourceMap } from '@openfn/runtime';
-import type { ExecutionPlan, Job } from '@openfn/lexicon';
+import { getModulePath } from '@openfn/runtime';
+import type {
+  ExecutionPlan,
+  Job,
+  SourceMapWithOperations,
+} from '@openfn/lexicon';
 
 import createLogger, { COMPILER, Logger } from '../util/logger';
 import abort from '../util/abort';
 import type { CompileOptions } from './command';
 
-export type CompiledJob = { code: string; map?: SourceMap };
+export type CompiledJob = { code: string; map?: SourceMapWithOperations };
 
 export default async function (
   job: ExecutionPlan,

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@openfn/describe-package": "workspace:*",
+    "@openfn/lexicon": "workspace:^",
     "@openfn/logger": "workspace:*",
     "acorn": "^8.8.0",
     "ast-types": "^0.14.2",

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -1,8 +1,11 @@
 import { print } from 'recast';
 import createLogger, { Logger } from '@openfn/logger';
+
 import parse from './parse';
 import transform, { TransformOptions } from './transform';
 import { isPath, loadFile } from './util';
+
+import type { SourceMapWithOperations } from '@openfn/lexicon';
 
 const defaultLogger = createLogger();
 
@@ -18,7 +21,13 @@ export type Options = TransformOptions & {
   logCompiledSource?: boolean;
 };
 
-export default function compile(pathOrSource: string, options: Options = {}) {
+export default function compile(
+  pathOrSource: string,
+  options: Options = {}
+): {
+  code: string;
+  map?: SourceMapWithOperations;
+} {
   const logger = options.logger || defaultLogger;
 
   let source = pathOrSource;
@@ -31,12 +40,14 @@ export default function compile(pathOrSource: string, options: Options = {}) {
 
   const name = options.name ?? 'src';
   const ast = parse(source, { name });
-
   const transformedAst = transform(ast, undefined, options);
 
   const { code, map } = print(transformedAst, {
     sourceMapName: `${name}.map.js`,
   });
+
+  // write the operations index to the source map
+  map.operations = (transformedAst.program as any).operations ?? [];
 
   if (options.logCompiledSource) {
     logger.debug('Compiled source:');

--- a/packages/compiler/src/parse.ts
+++ b/packages/compiler/src/parse.ts
@@ -10,14 +10,18 @@
  */
 import recast from 'recast';
 import * as acorn from 'acorn';
+import { namedTypes } from 'ast-types';
 
 type Options = {
   /** Name of the source job (no file extension). This triggers source map generation */
   name?: string;
 };
 
-export default function parse(source: string, options: Options = {}) {
-  // This is copied from v1 but I am unsure the usecase
+export default function parse(
+  source: string,
+  options: Options = {}
+): namedTypes.File {
+  // This is copied from v1 but I am unsure the use-case
   const escaped = source.replace(/\ $/, '');
 
   const ast = recast.parse(escaped, {

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -45,7 +45,7 @@ export type TransformOptions = {
 const defaultLogger = createLogger();
 
 export default function transform(
-  ast: namedTypes.Node,
+  ast: namedTypes.File,
   transformers?: Transformer[],
   options: TransformOptions = {}
 ) {

--- a/packages/compiler/test/compile.test.ts
+++ b/packages/compiler/test/compile.test.ts
@@ -8,11 +8,25 @@ import compile from '../src/compile';
 test('generate a source map', (t) => {
   const source = 'fn();';
   const { map } = compile(source);
+
   t.truthy(map);
-  t.deepEqual(map.sources, ['src.js']);
-  t.is(map.file, 'src.map.js');
+  t.deepEqual(map!.sources, ['src.js']);
+  t.is(map!.file, 'src.map.js');
 });
 
+test('generate a source map with operations', (t) => {
+  const source = 'fn();';
+  const { map } = compile(source);
+
+  t.truthy(map);
+  t.deepEqual(map!.operations, [
+    {
+      name: 'fn',
+      order: 1,
+      line: 1,
+    },
+  ]);
+});
 
 test('generate a named source map if a file name is passed', (t) => {
   const source = 'fn();';

--- a/packages/compiler/test/compile.test.ts
+++ b/packages/compiler/test/compile.test.ts
@@ -31,9 +31,10 @@ test('generate a source map with operations', (t) => {
 test('generate a named source map if a file name is passed', (t) => {
   const source = 'fn();';
   const { map } = compile(source, { name: 'job' });
+
   t.truthy(map);
-  t.deepEqual(map.sources, ['job.js']);
-  t.is(map.file, 'job.map.js');
+  t.deepEqual(map!.sources, ['job.js']);
+  t.is(map!.file, 'job.map.js');
 });
 
 test('ensure default exports is created', (t) => {

--- a/packages/lexicon/core.d.ts
+++ b/packages/lexicon/core.d.ts
@@ -46,7 +46,7 @@ export interface Job extends Step {
   configuration?: object | string;
   state?: Omit<State, 'configuration'> | string;
 
-  sourceMap?: SourceMap;
+  sourceMap?: SourceMapWithOperations;
 
   // Internal use only
   // Allow module paths and versions to be overridden in the linker

--- a/packages/lexicon/core.d.ts
+++ b/packages/lexicon/core.d.ts
@@ -1,5 +1,11 @@
 import { SanitizePolicies } from '@openfn/logger';
-import type { RawSourceMap } from 'source-map'
+import type { RawSourceMap } from 'source-map';
+
+export type SourceMap = RawSourceMap;
+
+export type SourceMapWithOperations = RawSourceMap & {
+  operations: [{ line: number; order: number; name: string }];
+};
 
 /**
  * An execution plan is a portable definition of a Work Order,
@@ -40,7 +46,7 @@ export interface Job extends Step {
   configuration?: object | string;
   state?: Omit<State, 'configuration'> | string;
 
-  sourceMap?: SourceMap
+  sourceMap?: SourceMap;
 
   // Internal use only
   // Allow module paths and versions to be overridden in the linker

--- a/packages/runtime/src/errors.ts
+++ b/packages/runtime/src/errors.ts
@@ -93,6 +93,9 @@ export class RTError extends Error {
     super();
 
     // automatically limit the stacktrace (?)
+    // TODO: actually what we want here is to online include frames
+    // from inside the VM
+    // Anything outside the VM should be cut
     Error.captureStackTrace(this, RTError.constructor);
   }
 }
@@ -142,7 +145,6 @@ export class RuntimeCrash extends RTError {
 
   constructor(error: Error) {
     super();
-    console.log(error);
     this.subtype = error.constructor.name;
     this.message = `${this.subtype}: ${error.message}`;
 

--- a/packages/runtime/src/execute/context.ts
+++ b/packages/runtime/src/execute/context.ts
@@ -48,7 +48,7 @@ export default (
   return context;
 };
 
-// Special, highly restricted cotext for a plan condition
+// Special, highly restricted context for a plan condition
 // Ie, a javascript expression
 export const conditionContext = () => {
   const context = vm.createContext(

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -42,7 +42,7 @@ export default (
   // allow custom linker options to be passed for this step
   // this lets us use multiple versions of the same adaptor in a workflow
   moduleOverrides?: ModuleInfoMap,
-  sourceMap: SourceMapWithOperations
+  sourceMap?: SourceMapWithOperations
 ) => {
   return new Promise(async (resolve, reject) => {
     let duration = Date.now();
@@ -115,20 +115,6 @@ export default (
   });
 };
 
-// Wrap an operation with various useful stuff
-// TODO: this function will have to catch an error thrown by adaptor code
-// and somehow relate it back to which operation call in the original source it was
-// This probably won't ever work for nested operations though?
-// The nested operation will just bubble up here to the top
-// If the error did NOT come from VM code, we need to map it back to the closest operation
-// and then all we can really say is: error thrown by the get on line 2
-// I have no idea how we're gonna relate this back though
-// Because it's an error in the returned function, not actually in the source
-// We should know the index of the operation here though - we know if it's the first, second or third
-// So the best we can hope for is:
-// - identify the nth operation that caught the error  and map that back to the source (not easy tbh)
-// - include the stack trace from WITHIN the adaptor code
-// Ie, I suppose, everything INSIDE the executeExpression call
 export const wrapOperation = (
   fn: Operation,
   logger: Logger,

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -95,7 +95,6 @@ export default (
 
       resolve(result);
     } catch (e: any) {
-      debugger;
       // whatever initial state looks like now, clean it and report it back
       duration = Date.now() - duration;
       let finalError;
@@ -149,7 +148,6 @@ export const wrapOperation = (
         // (this cuts out low level language errors and stuff)
         do {
           const next = frames.shift();
-          debugger;
           if (/^\s+at (file:\/\/)|(vm:module)/.test(next)) {
             frame = next;
             break;

--- a/packages/runtime/src/execute/plan.ts
+++ b/packages/runtime/src/execute/plan.ts
@@ -36,7 +36,6 @@ const executePlan = async (
     logger,
     report: createErrorReporter(logger),
     notify: opts.callbacks?.notify ?? (() => {}),
-    sourceMap: opts.sourceMap,
   };
 
   // Record of state on leaf nodes (nodes with no next)

--- a/packages/runtime/src/execute/step.ts
+++ b/packages/runtime/src/execute/step.ts
@@ -79,7 +79,6 @@ const prepareFinalState = (
   logger: Logger,
   statePropsToRemove?: string[]
 ) => {
-  debugger;
   if (isNullState(state)) return undefined;
   if (state) {
     if (!statePropsToRemove) {

--- a/packages/runtime/src/execute/step.ts
+++ b/packages/runtime/src/execute/step.ts
@@ -79,6 +79,7 @@ const prepareFinalState = (
   logger: Logger,
   statePropsToRemove?: string[]
 ) => {
+  debugger;
   if (isNullState(state)) return undefined;
   if (state) {
     if (!statePropsToRemove) {
@@ -163,7 +164,13 @@ const executeStep = async (
     try {
       // TODO include the upstream job?
       notify(NOTIFY_JOB_START, { jobId });
-      result = await executeExpression(ctx, job.expression, state, step.linker);
+      result = await executeExpression(
+        ctx,
+        job.expression,
+        state,
+        step.linker,
+        job.sourceMap
+      );
     } catch (e: any) {
       didError = true;
       if (e.hasOwnProperty('error') && e.hasOwnProperty('state')) {

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -1,6 +1,10 @@
 import { createMockLogger, Logger } from '@openfn/logger';
-import type { ExecutionPlan, State } from '@openfn/lexicon';
-import type { ExecutionCallbacks, SourceMap } from './types';
+import type {
+  ExecutionPlan,
+  State,
+  SourceMapWithOperations,
+} from '@openfn/lexicon';
+import type { ExecutionCallbacks } from './types';
 import type { LinkerOptions } from './modules/linker';
 import executePlan from './execute/plan';
 import { defaultState, parseRegex, clone } from './util/index';
@@ -21,7 +25,10 @@ export type Options = {
   globals?: any;
   statePropsToRemove?: string[];
   defaultRunTimeoutMs?: number;
-  sourceMap?: SourceMap;
+
+  // SourceMap is only passed directly if the expression is a string
+  // Usually a sourcemap is passed on a step
+  sourceMap?: SourceMapWithOperations;
 };
 
 type RawOptions = Omit<Options, 'linker'> & {
@@ -36,7 +43,7 @@ const defaultLogger = createMockLogger();
 const loadPlanFromString = (
   expression: string,
   logger: Logger,
-  sourceMap?: SourceMap
+  sourceMap?: SourceMapWithOperations
 ) => {
   const plan: ExecutionPlan = {
     workflow: {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -12,9 +12,6 @@ import {
   NOTIFY_STATE_LOAD,
 } from './events';
 import { ModuleInfoMap } from './modules/linker';
-import { RawSourceMap } from 'source-map';
-
-export type SourceMap = RawSourceMap;
 
 export type ErrorPosition = {
   line: number;
@@ -67,7 +64,6 @@ export type ExecutionContext = {
   plan: CompiledExecutionPlan;
   logger: Logger;
   opts: Options;
-  sourceMap?: SourceMap;
   report: ErrorReporter;
   notify: NotifyHandler;
 };

--- a/packages/runtime/src/util/log-error.ts
+++ b/packages/runtime/src/util/log-error.ts
@@ -64,10 +64,18 @@ const createErrorReporter = (logger: Logger): ErrorReporter => {
         logger.error(`${prefix}${src}`);
         logger.error(`${prefix.replace(/./g, ' ')}${pointer.join('')}`);
       }
+    } else if (error.line && error.operationName) {
+      // handle adaptor errors where we don't have a position that corresponds nicely to the sourcemapped code
+      logger.error(
+        `Error reported by "${error.operationName}()" operation line ${error.line}:`
+      );
+      logger.error(error.message);
     } else {
       logger.error(error.message);
     }
 
+    // TODO we probably don't want to show all of this serialized error
+    // details if it exists, maybe source and severity but probably not?
     const serializedError = serialize(error);
     logger.error(serializedError);
 

--- a/packages/runtime/src/util/log-error.ts
+++ b/packages/runtime/src/util/log-error.ts
@@ -58,9 +58,11 @@ const createErrorReporter = (logger: Logger): ErrorReporter => {
         const pointer = new Array(src.length).fill(' ');
         pointer[error.pos.column - 1] = '^';
 
-        logger.print();
-        logger.print(src);
-        logger.print(pointer.join(''));
+        const prefix = `${error.pos.line}: `;
+
+        logger.error();
+        logger.error(`${prefix}${src}`);
+        logger.error(`${prefix.replace(/./g, ' ')}${pointer.join('')}`);
       }
     } else {
       logger.error(error.message);

--- a/packages/runtime/test/__modules__/test/index.js
+++ b/packages/runtime/test/__modules__/test/index.js
@@ -3,9 +3,12 @@ export const x = 'test';
 export default x;
 
 export const err = () => {
-  const e = new Error('adaptor err');
-  e.code = 1234;
-  throw e;
+  return async (state) => {
+    debugger;
+    const e = new Error('adaptor err');
+    e.code = 1234;
+    throw e;
+  };
 };
 
 export const err2 = () => {

--- a/packages/runtime/test/__modules__/test/index.js
+++ b/packages/runtime/test/__modules__/test/index.js
@@ -4,7 +4,6 @@ export default x;
 
 export const err = () => {
   return async (state) => {
-    debugger;
     const e = new Error('adaptor err');
     e.code = 1234;
     throw e;
@@ -25,3 +24,5 @@ export function call(fn) {
     }
   };
 }
+
+export const fn = (f) => (state) => f(state);

--- a/packages/runtime/test/errors.test.ts
+++ b/packages/runtime/test/errors.test.ts
@@ -350,11 +350,24 @@ test('fail on user error with throw "abort"', async (t) => {
 
 test('fail on adaptor error (with throw new Error())', async (t) => {
   const expression = `
-  import { err } from 'x';
-  export default [(s) => err()];
-  `;
+
+  err();`;
+
+  // Compile the code so that we get a source map
+  const { code, map } = compile(expression, {
+    name: 'src',
+    'add-imports': {
+      adaptors: [
+        {
+          name: 'x',
+          exportAll: true,
+        },
+      ],
+    },
+  });
+
   const result: any = await run(
-    expression,
+    code,
     {},
     {
       linker: {
@@ -362,11 +375,11 @@ test('fail on adaptor error (with throw new Error())', async (t) => {
           x: { path: path.resolve('test/__modules__/test') },
         },
       },
+      sourceMap: map,
     }
   );
 
   const error = result.errors['job-1'];
-  t.log(error);
 
   t.deepEqual(error, {
     details: {
@@ -376,6 +389,8 @@ test('fail on adaptor error (with throw new Error())', async (t) => {
     name: 'AdaptorError',
     source: 'runtime',
     severity: 'fail',
+    line: 3,
+    operationName: 'err',
   });
 });
 

--- a/packages/runtime/test/execute/wrap-operation.test.ts
+++ b/packages/runtime/test/execute/wrap-operation.test.ts
@@ -3,14 +3,15 @@ import { createMockLogger } from '@openfn/logger';
 
 import execute from '../../src/util/execute';
 import { wrapOperation } from '../../src/execute/expression';
-import { Operation } from '../../src/types';
+
+import type { Operation } from '@openfn/lexicon';
 
 const logger = createMockLogger();
 
 // This function mimics the reducer created in src/execute/expression.ts
 const reducer = async (operations: Operation[], state: any) => {
   const mapped = operations.map((op, idx) =>
-    wrapOperation(op, logger, `${idx + 1}`)
+    wrapOperation(op, logger, `${idx + 1}`, idx)
   );
 
   return execute(...mapped)(state);
@@ -50,7 +51,7 @@ test('call several operations', async (t) => {
   t.deepEqual(result, 3);
 });
 
-test('catch a thrown error', async (t) => {
+test('rethrow a thrown error', async (t) => {
   const op = () => {
     throw new Error('err');
   };
@@ -60,7 +61,7 @@ test('catch a thrown error', async (t) => {
   });
 });
 
-test('catch a thrown error async', async (t) => {
+test('rethrow a thrown error async', async (t) => {
   const op = async () => {
     throw new Error('err');
   };
@@ -70,8 +71,8 @@ test('catch a thrown error async', async (t) => {
   });
 });
 
-test('catch a thrown nested reference error', async (t) => {
-  const op = () => {
+test('rethrow a thrown nested reference error', async (t) => {
+  const op = async () => {
     const doTheThing = () => {
       // @ts-ignore
       unknown.doTheThing();
@@ -81,12 +82,14 @@ test('catch a thrown nested reference error', async (t) => {
   };
 
   await t.throwsAsync(() => reducer([op], {}), {
-    name: 'ReferenceError',
+    // This will look like an adaptor error to the runtime code
+    // this is fine
+    name: 'AdaptorError',
     message: 'unknown is not defined',
   });
 });
 
-test('catch a thrown nested reference error in a promise', async (t) => {
+test('rethrow a thrown nested reference error in a promise', async (t) => {
   const op = () =>
     new Promise(() => {
       const doTheThing = () => {
@@ -98,25 +101,42 @@ test('catch a thrown nested reference error in a promise', async (t) => {
     });
 
   await t.throwsAsync(() => reducer([op], {}), {
-    name: 'ReferenceError',
+    name: 'AdaptorError',
     message: 'unknown is not defined',
   });
 });
 
-test('catch an illegal function call', async (t) => {
+test('rethrow an illegal function call', async (t) => {
   const op = async (s: any) => {
     s();
   };
 
   await t.throwsAsync(() => reducer([op], {}), {
-    name: 'TypeError',
+    name: 'AdaptorError',
     message: 's is not a function',
   });
 });
 
-test('catch an indirect type error', async (t) => {
+test('rethrow an indirect type error', async (t) => {
   const op = (x: any) => {
     return async (_s: any) => x();
+  };
+
+  await t.throwsAsync(() => reducer([op('jam')], {}), {
+    name: 'AdaptorError',
+    message: 'x is not a function',
+  });
+});
+
+test('rethrow a job error', async (t) => {
+  const op = (x: any) => {
+    return async (_s: any) => {
+      // Create something that looks like an error thrown from VM code
+      const e = new TypeError('x is not a function');
+      e.stack = `TypeError: x is not a function
+        at vm:module(0)`;
+      throw e;
+    };
   };
 
   await t.throwsAsync(() => reducer([op('jam')], {}), {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,7 +266,7 @@ importers:
         version: 2.8.1
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(@swc/core@1.10.1)(typescript@5.7.2)
+        version: 7.3.0(@swc/core@1.10.1)(ts-node@10.9.1)(typescript@5.7.2)
       typescript:
         specifier: ^5.1.6
         version: 5.7.2
@@ -276,6 +276,9 @@ importers:
       '@openfn/describe-package':
         specifier: workspace:*
         version: link:../describe-package
+      '@openfn/lexicon':
+        specifier: workspace:^
+        version: link:../lexicon
       '@openfn/logger':
         specifier: workspace:*
         version: link:../logger
@@ -303,7 +306,7 @@ importers:
         version: 2.8.1
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(@swc/core@1.10.1)(typescript@5.7.2)
+        version: 7.3.0(@swc/core@1.10.1)(ts-node@10.9.1)(typescript@5.7.2)
       typescript:
         specifier: ^5.1.6
         version: 5.7.2
@@ -358,7 +361,7 @@ importers:
         version: 2.8.1
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(@swc/core@1.10.1)(typescript@5.7.2)
+        version: 7.3.0(@swc/core@1.10.1)(ts-node@10.9.1)(typescript@5.7.2)
       typescript:
         specifier: ^5.1.6
         version: 5.7.2
@@ -410,7 +413,7 @@ importers:
         version: 2.3.0
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(@swc/core@1.10.1)(typescript@5.7.2)
+        version: 7.3.0(@swc/core@1.10.1)(ts-node@10.9.1)(typescript@5.7.2)
 
   packages/engine-multi:
     dependencies:
@@ -447,7 +450,7 @@ importers:
         version: 2.3.0
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(@swc/core@1.10.1)(typescript@5.7.2)
+        version: 7.3.0(@swc/core@1.10.1)(ts-node@10.9.1)(typescript@5.7.2)
       typescript:
         specifier: ^5.1.6
         version: 5.7.2
@@ -597,7 +600,7 @@ importers:
         version: 2.8.1
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(@swc/core@1.10.1)(typescript@5.7.2)
+        version: 7.3.0(@swc/core@1.10.1)(ts-node@10.9.1)(typescript@5.7.2)
       typescript:
         specifier: ^5.1.6
         version: 5.7.2
@@ -646,13 +649,13 @@ importers:
         version: 0.21.5
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.19.68)(typescript@5.7.2)
+        version: 10.9.1(@swc/core@1.10.1)(@types/node@18.19.68)(typescript@5.7.2)
       tslib:
         specifier: ^2.4.0
         version: 2.8.1
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(ts-node@10.9.1)(typescript@5.7.2)
+        version: 7.3.0(@swc/core@1.10.1)(ts-node@10.9.1)(typescript@5.7.2)
       typescript:
         specifier: ^5.1.6
         version: 5.7.2
@@ -6091,7 +6094,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 3.1.3
-      ts-node: 10.9.1(@types/node@18.19.68)(typescript@5.7.2)
+      ts-node: 10.9.1(@swc/core@1.10.1)(@types/node@18.19.68)(typescript@5.7.2)
       yaml: 2.6.1
     dev: true
 
@@ -6930,7 +6933,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-node@10.9.1(@types/node@18.19.68)(typescript@5.7.2):
+  /ts-node@10.9.1(@swc/core@1.10.1)(@types/node@18.19.68)(typescript@5.7.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -6945,6 +6948,7 @@ packages:
         optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
+      '@swc/core': 1.10.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
@@ -7014,7 +7018,7 @@ packages:
       - ts-node
     dev: true
 
-  /tsup@7.3.0(@swc/core@1.10.1)(typescript@5.7.2):
+  /tsup@7.3.0(@swc/core@1.10.1)(ts-node@10.9.1)(typescript@5.7.2):
     resolution: {integrity: sha512-Ja1eaSRrE+QarmATlNO5fse2aOACYMBX+IZRKy1T+gpyH+jXgRrl5l4nHIQJQ1DoDgEjHDTw8cpE085UdBZuWQ==}
     engines: {node: '>=18'}
     deprecated: Breaking node 16
@@ -7032,43 +7036,6 @@ packages:
         optional: true
     dependencies:
       '@swc/core': 1.10.1
-      bundle-require: 4.2.1(esbuild@0.19.12)
-      cac: 6.7.14
-      chokidar: 3.6.0
-      debug: 4.4.0
-      esbuild: 0.19.12
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.49)
-      resolve-from: 5.0.0
-      rollup: 4.28.1
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tree-kill: 1.2.2
-      typescript: 5.7.2
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    dev: true
-
-  /tsup@7.3.0(ts-node@10.9.1)(typescript@5.7.2):
-    resolution: {integrity: sha512-Ja1eaSRrE+QarmATlNO5fse2aOACYMBX+IZRKy1T+gpyH+jXgRrl5l4nHIQJQ1DoDgEjHDTw8cpE085UdBZuWQ==}
-    engines: {node: '>=18'}
-    deprecated: Breaking node 16
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.5.0'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
       bundle-require: 4.2.1(esbuild@0.19.12)
       cac: 6.7.14
       chokidar: 3.6.0


### PR DESCRIPTION
## Short Description

Hit a bit of a problem in source mapping.

The whole idea was to map against the error position in the original source, based mostly on finding errors which come out of the vm and simply mapping the position back.

But errors which occur from adaptor code - from top level operations -  don't actually have vm code in the stack. The operation is initialised in the vm, but the actual runtime callstack only has runtime call code.

The problem is that in the source code, we just call operations at the top level and they look like function calls. But actually they're compiled into an array and exported from the "module" and executed in series. The code that's actually executed is really not part of the VM.

This makes it super hard to map back to the VM.

This PR does a couple of things to help this:

- In the compiler, it's easy to build a map of which order the operations occur in, and on what line each operation is on
- So we take that information and tack it into the source map
- Then, in the runtime, if we think error  came from an adaptor [on a top level operation], instead of doing doing regular positional source mapping, we report the name and line of the operation in question
- This then gets logged out through the logger with a different template to regular errors

## TODO

Maybe not in this PR but I want a couple of notes here:

- DONE If an error comes from a nested operation, this solution will attribute it to the top level operation. But actually, if it's come from the nested operation, we should have a position in the VM. So I can handle this better.
- We're currently cutting all stack traces off of errors. But I want to always include all frames inside the VM. And, if I can figure it out, inside the adaptor too.
- I'm really not happy about how messy and verbose error output is right now. I'd like to clean it up, ignore most of the error wrapping stuff.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
