### PR TITLE
Fix errors when using the monorepo

### DIFF
--- a/.changeset/eleven-owls-decide.md
+++ b/.changeset/eleven-owls-decide.md
@@ -1,0 +1,7 @@
+---
+'@openfn/runtime': patch
+'@openfn/cli': patch
+'@openfn/ws-worker': patch
+---
+
+Fix error reporting when loading adaptors from the monorepo

--- a/.changeset/eleven-owls-decide.md
+++ b/.changeset/eleven-owls-decide.md
@@ -1,7 +1,0 @@
----
-'@openfn/runtime': patch
-'@openfn/cli': patch
-'@openfn/ws-worker': patch
----
-
-Fix error reporting when loading adaptors from the monorepo

--- a/integration-tests/execute/CHANGELOG.md
+++ b/integration-tests/execute/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/integration-tests-execute
 
+## 1.0.14
+
+### Patch Changes
+
+- Updated dependencies [70e3d7a]
+  - @openfn/runtime@1.6.1
+
 ## 1.0.13
 
 ### Patch Changes

--- a/integration-tests/execute/package.json
+++ b/integration-tests/execute/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-execute",
   "private": true,
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Job execution tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openfn/integration-tests-worker
 
+## 1.0.74
+
+### Patch Changes
+
+- Updated dependencies [70e3d7a]
+  - @openfn/ws-worker@1.9.1
+  - @openfn/engine-multi@1.4.8
+  - @openfn/lightning-mock@2.0.29
+
 ## 1.0.73
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.73",
+  "version": "1.0.74",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 1.10.1
+
+### Patch Changes
+
+- 70e3d7a: Fix error reporting when loading adaptors from the monorepo
+- Updated dependencies [70e3d7a]
+  - @openfn/runtime@1.6.1
+
 ## 1.10.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # engine-multi
 
+## 1.4.8
+
+### Patch Changes
+
+- Updated dependencies [70e3d7a]
+  - @openfn/runtime@1.6.1
+
 ## 1.4.7
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/lightning-mock
 
+## 2.0.29
+
+### Patch Changes
+
+- Updated dependencies [70e3d7a]
+  - @openfn/runtime@1.6.1
+  - @openfn/engine-multi@1.4.8
+
 ## 2.0.28
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/runtime
 
+## 1.6.1
+
+### Patch Changes
+
+- 70e3d7a: Fix error reporting when loading adaptors from the monorepo
+
 ## 1.6.0
 
 ### Minor Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Job processing runtime.",
   "type": "module",
   "exports": {

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -146,11 +146,16 @@ export const wrapOperation = (
 
         let firstFrame;
 
-        // find the first error from a file or the VM
-        // (this cuts out low level language errors and stuff)
+        // find the first frame from an adaptor or the VM
+        // (this cuts out low level language errors like TypeError)
         do {
           const next = frames.shift();
-          if (/(@openfn\/language-)|(vm:module)/.test(next)) {
+          if (
+            // detect an adaptor prod, adaptor monorepo, or vm frame
+            /(@openfn\/language-)|(adaptors\/packages\/.+\/dist)|(vm:module)/.test(
+              next
+            )
+          ) {
             firstFrame = next;
             break;
           }

--- a/packages/runtime/src/execute/expression.ts
+++ b/packages/runtime/src/execute/expression.ts
@@ -137,6 +137,7 @@ export const wrapOperation = (
     try {
       result = await fn(newState);
     } catch (e: any) {
+      console.log(e);
       if (e.stack) {
         const containsVMFrame = e.stack.match(/at vm:module\(0\)/);
 
@@ -152,9 +153,7 @@ export const wrapOperation = (
           const next = frames.shift();
           if (
             // detect an adaptor prod, adaptor monorepo, or vm frame
-            /(@openfn\/language-)|(adaptors\/packages\/.+\/dist)|(vm:module)/.test(
-              next
-            )
+            /(@openfn\/language-)|(packages\/.+\/dist)|(vm:module)/.test(next)
           ) {
             firstFrame = next;
             break;

--- a/packages/runtime/test/execute/wrap-operation.test.ts
+++ b/packages/runtime/test/execute/wrap-operation.test.ts
@@ -142,3 +142,41 @@ test('rethrow a job error', async (t) => {
     message: 'x is not a function',
   });
 });
+
+test('throw an adaptor error from a prod callstack', async (t) => {
+  const op = (x: any) => {
+    return async (_s: any) => {
+      // Create something that looks like an error thrown from adaptor code
+      const e = new TypeError('x is not a function');
+      e.stack = `TypeError: x is not a function
+  at /repo/@openfn/language-common/dist/index.cjs:573:5
+  at file:///repo/openfn/kit/packages/runtime/dist/index.js:649:22
+  at async file:///repo/openfn/kit/packages/runtime/dist/index.js:614:22;`;
+      throw e;
+    };
+  };
+
+  await t.throwsAsync(() => reducer([op('jam')], {}), {
+    name: 'AdaptorError',
+    message: 'x is not a function',
+  });
+});
+
+test('throw an adaptor error from a monorepo callstack', async (t) => {
+  const op = (x: any) => {
+    return async (_s: any) => {
+      // Create something that looks like an error thrown from adaptor code
+      const e = new TypeError('x is not a function');
+      e.stack = `TypeError: x is not a function
+  at /repo/openfn/adaptors/packages/common/dist/index.cjs:573:5
+  at file:///repo/openfn/kit/packages/runtime/dist/index.js:649:22
+  at async file:///repo/openfn/kit/packages/runtime/dist/index.js:614:22;`;
+      throw e;
+    };
+  };
+
+  await t.throwsAsync(() => reducer([op('jam')], {}), {
+    name: 'AdaptorError',
+    message: 'x is not a function',
+  });
+});

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # ws-worker
 
+## 1.9.1
+
+### Patch Changes
+
+- 70e3d7a: Fix error reporting when loading adaptors from the monorepo
+- Updated dependencies [70e3d7a]
+  - @openfn/runtime@1.6.1
+  - @openfn/engine-multi@1.4.8
+
 ## 1.9.0
 
 ### Minor Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Short Description

When the vm throws an error, we try and determine if that error comes from an adaptor. This makes assumptions about the callstack and the path of the file. It works fine for production adaptors, but when loading from the monorepo these tests fail.

Fixes #855 

## QA Notes

I am reproducing like this:

* In the monorepo, add this to common:
```
```
* Create a simple job which just calls `tmp()`
* From `packages/cli`, run `pnpm openfn tmp/job.js -ma common` (where tmp/job.js points to the simple job)
* Against production, the error contains no details. Here, you get output like:
```
[CLI] ♦ Versions:
         ▸ node.js                    22.12.0
         ▸ cli                        1.10.0
         ▸ @openfn/language-common    monorepo
[CLI] ✔ Loading adaptors from monorepo at /home/joe/repo/openfn/adaptors
[CLI] ⚠ Skipping auto-install as monorepo is being used
[CLI] ✔ Compiled all expressions in workflow
[R/T] ✘ job-1 aborted with error (100ms)

[R/T] ✘ Error reported by "tmp()" operation line 1:
[R/T] ✘ Error: TEST_ERROR: this is a test
[R/T] ✘ Additional error details:
{
  type: 'Error',
  message: 'TEST_ERROR: this is a test',
  code: 'TEST_ERROR',
  description: 'this is a test',
  jam: 'jar'
}

[R/T] ✘ Check state.errors.job-1 for details
[CLI] ✔ State written to tmp/errors/output.json
[CLI] ⚠ Errors reported in 1 jobs
[CLI] ✔ Finished in 152ms
```

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
