### PR TITLE
fix: replace adaptors in plan with resolved adaptors at install

### DIFF
--- a/integration-tests/cli/test/autoinstall.test.ts
+++ b/integration-tests/cli/test/autoinstall.test.ts
@@ -49,6 +49,10 @@ test.serial(
     t.regex(stdout, /Installing packages.../);
     t.regex(stdout, /Will install @openfn\/language-common version/);
     t.regex(stdout, /Installed @openfn\/language-common@/);
+    t.regex(
+      stdout,
+      /Resolved adaptor @openfn\/language-common to version \d+(\.\d+)*/
+    );
   }
 );
 
@@ -68,6 +72,10 @@ test.serial(
       stdout,
       /Skipping @openfn\/language-common@(.+) as already installed/
     );
+    t.regex(
+      stdout,
+      /Resolved adaptor @openfn\/language-common to version \d+(\.\d+)*/
+    );
   }
 );
 
@@ -78,7 +86,6 @@ test.serial(
     const { stdout, err } = await run(t.title);
 
     // t.falsy(err); // TODO I think this is a broken adaptor build?
-
     t.regex(stdout, /Auto-installing language adaptors/);
     t.regex(stdout, /Looked up latest version of @openfn\/language-testing/);
     t.regex(stdout, /Installing packages.../);
@@ -91,6 +98,12 @@ test.serial(
     t.regex(
       stdout,
       new RegExp(`Installed @openfn\/language-testing@${TEST_LATEST}`)
+    );
+    t.regex(
+      stdout,
+      new RegExp(
+        `Resolved adaptor @openfn/language-testing to version ${TEST_LATEST}`
+      )
     );
   }
 );

--- a/integration-tests/cli/test/execute-workflow.test.ts
+++ b/integration-tests/cli/test/execute-workflow.test.ts
@@ -199,3 +199,25 @@ test.serial(
     });
   }
 );
+
+test.serial(
+  `openfn ${jobsPath}/different-adaptor-versions.json -l debug`,
+  async (t) => {
+    const { err, stdout } = await run(t.title);
+    t.falsy(err);
+
+    t.regex(
+      stdout,
+      /Resolved adaptor @openfn\/language-common to version 2.1.0/
+    );
+    t.regex(
+      stdout,
+      /Resolved adaptor @openfn\/language-common to version 2.0.3/
+    );
+
+    const out = getJSON();
+    t.deepEqual(out, {
+      z: 1,
+    });
+  }
+);

--- a/integration-tests/cli/test/fixtures/different-adaptor-versions.json
+++ b/integration-tests/cli/test/fixtures/different-adaptor-versions.json
@@ -1,0 +1,24 @@
+{
+  "options": {},
+  "workflow": {
+    "name": "Steps with different adaptor versions",
+    "steps": [
+      {
+        "id": "lesser",
+        "adaptor": "common@2.1.0",
+        "state": {
+          "x": 1
+        },
+        "expression": "fn(state=> ({y: state.x}))",
+        "next": {
+          "latest-again": true
+        }
+      },
+      {
+        "id": "latest-again",
+        "adaptor": "common@2.0.3",
+        "expression": "fn(state=> ({z: state.y}))"
+      }
+    ]
+  }
+}

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/cli
 
+## 1.10.1
+
+### Patch Changes
+
+- Properly resolve adaptor versions when they are explicitly set to @latest
+
 ## 1.10.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/cli/src/util/override-plan-adaptors.ts
+++ b/packages/cli/src/util/override-plan-adaptors.ts
@@ -1,0 +1,28 @@
+import { ExecutionPlan, Job, Step } from '@openfn/lexicon';
+
+function overridePlanAdaptors(
+  plan: ExecutionPlan,
+  resolutions: Record<string, string>
+): ExecutionPlan {
+  return {
+    ...plan,
+    workflow: {
+      ...plan.workflow,
+      steps: plan.workflow.steps.map((step) => {
+        if (isJob(step))
+          return {
+            ...step,
+            adaptors: step.adaptors?.map((a) => resolutions[a] || a),
+          };
+        else return step;
+      }),
+    },
+  };
+}
+
+function isJob(step: Step): step is Job {
+  // @ts-ignore
+  return step && typeof step.expression === 'string';
+}
+
+export default overridePlanAdaptors;

--- a/packages/cli/src/util/override-plan-adaptors.ts
+++ b/packages/cli/src/util/override-plan-adaptors.ts
@@ -4,6 +4,12 @@ function overridePlanAdaptors(
   plan: ExecutionPlan,
   resolutions: Record<string, string>
 ): ExecutionPlan {
+  const hasRes = Object.entries(resolutions).some(
+    ([key, value]) => key !== value
+  );
+
+  // there's nothing to override when resolutions have the same values
+  if (!hasRes) return plan;
   return {
     ...plan,
     workflow: {
@@ -20,7 +26,7 @@ function overridePlanAdaptors(
   };
 }
 
-function isJob(step: Step): step is Job {
+export function isJob(step: Step): step is Job {
   // @ts-ignore
   return step && typeof step.expression === 'string';
 }

--- a/packages/cli/test/util/override-plan-adaptor.test.ts
+++ b/packages/cli/test/util/override-plan-adaptor.test.ts
@@ -1,0 +1,110 @@
+import { ExecutionPlan } from '@openfn/lexicon';
+import test from 'ava';
+import overridePlanAdaptors, {
+  isJob,
+} from '../../src/util/override-plan-adaptors';
+
+// validates adaptors in a plan against an array.
+function getAdaptors(plan: ExecutionPlan) {
+  // check for a given id whether the
+  const steps = plan.workflow.steps;
+
+  const adaptors = steps.map((step) => {
+    if (isJob(step)) return step.adaptors;
+    return undefined;
+  });
+  return adaptors;
+}
+
+test('replace adaptors in plan using provided resolutions', (t) => {
+  const plan: ExecutionPlan = {
+    workflow: {
+      steps: [
+        {
+          id: 'one',
+          expression: 'fn(state=> state)',
+          adaptors: ['@openfn/language-http@latest'],
+        },
+        {
+          id: 'two',
+          expression: 'fn(state=> state)',
+          adaptors: ['@openfn/language-common@next'],
+        },
+        {
+          expression: 'fn(state=> state)',
+          adaptors: ['@openfn/language-common@2.1.0'],
+        },
+      ],
+    },
+  };
+
+  const resolutions = {
+    '@openfn/language-http@latest': '@openfn/language-http@2.9.0',
+    '@openfn/language-common@next': '@openfn/language-common@2.2.0',
+  };
+  const finalPlan = overridePlanAdaptors(plan, resolutions);
+
+  t.deepEqual(getAdaptors(finalPlan), [
+    ['@openfn/language-http@2.9.0'],
+    ['@openfn/language-common@2.2.0'],
+    ['@openfn/language-common@2.1.0'],
+  ]);
+});
+
+test("ignore override when there's nothing to override", (t) => {
+  const plan: ExecutionPlan = {
+    workflow: {
+      steps: [
+        {
+          id: 'one',
+          expression: 'fn(state=> state)',
+          adaptors: ['@openfn/language-http@latest'],
+        },
+        {
+          id: 'two',
+          expression: 'fn(state=> state)',
+          adaptors: ['@openfn/language-common@next'],
+        },
+        {
+          expression: 'fn(state=> state)',
+          adaptors: ['@openfn/language-common@2.1.0'],
+        },
+      ],
+    },
+  };
+
+  const resolutions = {
+    '@openfn/language-http@2.9.0': '@openfn/language-http@2.9.0',
+    '@openfn/language-common@2.2.0': '@openfn/language-common@2.2.0',
+  };
+
+  const finalPlan = overridePlanAdaptors(plan, resolutions);
+  t.is(plan, finalPlan);
+});
+
+test('replace adaptors on only job steps', (t) => {
+  const plan: ExecutionPlan = {
+    workflow: {
+      steps: [
+        {
+          id: 'x',
+          next: 'two',
+        },
+        {
+          id: 'two',
+          expression: 'fn(state=> state)',
+          adaptors: ['@openfn/language-common@next'],
+        },
+      ],
+    },
+  };
+  const resolutions = {
+    '@openfn/language-common@next': '@openfn/language-common@2.2.0',
+  };
+
+  const finalPlan = overridePlanAdaptors(plan, resolutions);
+  t.deepEqual(getAdaptors(finalPlan), [
+    undefined,
+    ['@openfn/language-common@2.2.0'],
+  ]);
+});


### PR DESCRIPTION
## Short Description

When alias adaptor versions are used in cli, the runtime is unable to resolve them. resulting in the error below

<img width="558" alt="Screenshot 2025-01-14 at 11 55 13 AM" src="https://github.com/user-attachments/assets/cb7ea414-fa28-44fa-adf6-fd8547cc06a6" />

This is because, During the installation step, `@latest` is resolved to the latest version but then during execution, we try linking `@latest` instead of the resolved version.

Fixes #853 

## Implementation Details
Replacing adaptors in a plan with already resolved adaptors before the plan gets passed to the compiler and the runtime.

<table><thead>
  <tr>
    <th>Workflow</th>
    <th>Logs</th>
  </tr></thead>
<tbody>
  <tr>
    <td><img width="558" alt="Screenshot 2025-01-14 at 11 55 13 AM" src="https://github.com/user-attachments/assets/0936d412-9722-4b7a-b727-08d0c124ed2b" /></td>
    <td><img width="558" alt="Screenshot 2025-01-14 at 11 55 13 AM" src="https://github.com/user-attachments/assets/cb3971ff-29fa-4a6a-b78c-22318692df7d" /></td>
  </tr>
</tbody>
</table>

`@latest` at the point of writing is `v2.2.0`

## QA Notes

Run CLI by passing any adaptor with an alias version like `-a http@next`

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI
You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset version` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
