### PR TITLE
CLI Deploy: Don't send empty collections

### DIFF
--- a/.changeset/shiny-swans-care.md
+++ b/.changeset/shiny-swans-care.md
@@ -1,6 +1,0 @@
----
-'@openfn/deploy': minor
-'@openfn/cli': minor
----
-
-CLI Deploy: Don't send empty collections

--- a/.changeset/shiny-swans-care.md
+++ b/.changeset/shiny-swans-care.md
@@ -1,0 +1,6 @@
+---
+'@openfn/deploy': minor
+'@openfn/cli': minor
+---
+
+CLI Deploy: Don't send empty collections

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 1.10.4
+
+### Patch Changes
+
+- 295ceed: CLI Deploy: Don't send empty collections
+- Updated dependencies [295ceed]
+  - @openfn/deploy@0.10.0
+
 ## 1.10.3
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "CLI devtools for the openfn toolchain.",
   "engines": {
     "node": ">=18",

--- a/packages/deploy/CHANGELOG.md
+++ b/packages/deploy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/deploy
 
+## 0.10.0
+
+### Minor Changes
+
+- 295ceed: CLI Deploy: Don't send empty collections
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/deploy",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Deploy projects to Lightning instances",
   "type": "module",
   "exports": {

--- a/packages/deploy/src/stateTransform.ts
+++ b/packages/deploy/src/stateTransform.ts
@@ -502,7 +502,7 @@ export function mergeProjectPayloadIntoState(
   );
 
   const nextCollections = Object.fromEntries(
-    idKeyPairs(project.collections || {}, state.collections || {}).map(
+    idKeyPairs(project.collections || [], state.collections || {}).map(
       ([key, nextCollection, _state]) => {
         return [key, nextCollection];
       }
@@ -557,10 +557,12 @@ export function toProjectPayload(state: ProjectState): ProjectPayload {
     state.collections
   );
 
+  const { collections: _, ...stateWithoutCollections } = state;
+
   return {
-    ...state,
-    collections,
+    ...stateWithoutCollections,
     project_credentials,
     workflows,
+    ...(collections.length > 0 && { collections }),
   };
 }

--- a/packages/deploy/src/types.ts
+++ b/packages/deploy/src/types.ts
@@ -139,7 +139,7 @@ export interface ProjectPayload {
   id: string;
   name: string;
   description: string;
-  collections: Concrete<CollectionState>[];
+  collections?: Concrete<CollectionState>[];
   project_credentials: Concrete<CredentialState>[];
   workflows: {
     id: string;

--- a/packages/deploy/test/stateTransform.test.ts
+++ b/packages/deploy/test/stateTransform.test.ts
@@ -4,6 +4,7 @@ import {
   getStateFromProjectPayload,
   mergeProjectPayloadIntoState,
   mergeSpecIntoState,
+  toProjectPayload,
 } from '../src/stateTransform';
 import { ProjectPayload } from '../src/types';
 import {
@@ -616,10 +617,21 @@ test('getStateFromProjectPayload with minimal project', (t) => {
 });
 
 test('getStateFromProjectPayload with full lightning project', (t) => {
-  const project = lightningProjectPayload;
   const expectedState = lightningProjectState;
+
+  const project = lightningProjectPayload;
 
   const state = getStateFromProjectPayload(project);
 
   t.deepEqual(state, expectedState);
+});
+
+test('toProjectPayload drops empty collections key', (t) => {
+  const { collections: _, ...projectState } = lightningProjectState;
+  projectState.collections = {};
+  const { collections: _c, ...expectedPayload } = lightningProjectPayload;
+
+  const payload = toProjectPayload(projectState);
+
+  t.deepEqual(payload, expectedPayload);
 });


### PR DESCRIPTION
## Short Description

This PR makes the `collections` key optional in the `ProjectPayload`. When the `ProjectState` has an empty collections key, `[]`, the key gets dropped from the payload.

Fixes #861

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset version` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
