### PR TITLE
Fix CircleCI install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - run:
           name: Install pnpm
-          command: npm install -g corepack@latest && sudo corepack enable
+          command: sudo npm install -g corepack@latest && sudo corepack enable
       - checkout
       - restore_cache:
           # See the configuration reference documentation for more details on using restore_cache and save_cache steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - run:
           name: Install pnpm
-          command: sudo npm install -g corepack@latest && sudo corepack enable
+          command: npm install -g corepack@latest && sudo corepack enable
       - checkout
       - restore_cache:
           # See the configuration reference documentation for more details on using restore_cache and save_cache steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - run:
           name: Install pnpm
-          command: sudo corepack enable
+          command: sudo npm install -g corepack@latest && sudo corepack enable
       - checkout
       - restore_cache:
           # See the configuration reference documentation for more details on using restore_cache and save_cache steps

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We use [`pnpm`](https://pnpm.io/installation), a fast, disk space efficient pack
 
 ## Installing
 
-This repo uses node corepack to ensure pnpm v8 is used.
+This repo uses node corepack to ensure pnpm v8 is used
 
 - `$ corepack enable`
 - `$ pnpm install`


### PR DESCRIPTION
## Short Description

Corepack has updated npm registry keys and some older versions have expired.

This PR forces a bump of the corepack version

See https://github.com/nodejs/corepack/issues/612
And see https://github.com/nodejs/corepack/issues/616

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
