### PR TITLE
fix: wrong formatting of run complete time

### DIFF
--- a/.changeset/fair-deers-marry.md
+++ b/.changeset/fair-deers-marry.md
@@ -1,0 +1,7 @@
+---
+'@openfn/runtime': patch
+'@openfn/cli': patch
+'@openfn/ws-worker': patch
+---
+
+Fix an issue where step completion time is logged with double units (ie, `2msms`)

--- a/packages/runtime/src/execute/step.ts
+++ b/packages/runtime/src/execute/step.ts
@@ -207,7 +207,7 @@ const executeStep = async (
 
     if (!didError) {
       const humanDuration = logger.timer(timerId);
-      logger.success(`${jobName} completed in ${humanDuration}ms`);
+      logger.success(`${jobName} completed in ${humanDuration}`);
       result = prepareFinalState(result, logger, ctx.opts.statePropsToRemove);
 
       // Take a memory snapshot


### PR DESCRIPTION
## Short Description

Removes wrong formatting of run complete duration.

Fixes #875 

## Implementation Details

Easy fix.

## QA Notes

Do you see msms anymore on run complete logs?

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset version` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
