### PR TITLE
Fix worker log level

### DIFF
--- a/.changeset/beige-kings-speak.md
+++ b/.changeset/beige-kings-speak.md
@@ -1,0 +1,6 @@
+---
+'@openfn/engine-multi': patch
+'@openfn/ws-worker': patch
+---
+
+Fix an issue where Lightning log level options don't get fed to the engine properly

--- a/integration-tests/worker/src/init.ts
+++ b/integration-tests/worker/src/init.ts
@@ -5,7 +5,7 @@ import createLightningServer, { toBase64 } from '@openfn/lightning-mock';
 import createEngine from '@openfn/engine-multi';
 import createWorkerServer from '@openfn/ws-worker';
 import { createMockLogger } from '@openfn/logger';
-import createLogger from '@openfn/logger';
+// import createLogger from '@openfn/logger';
 
 export const randomPort = () => Math.round(2000 + Math.random() * 1000);
 
@@ -39,8 +39,8 @@ export const initWorker = async (
   });
 
   const worker = createWorkerServer(engine, {
-    // logger: createMockLogger(),
-    logger: createLogger('worker', { level: 'debug' }),
+    logger: createMockLogger(),
+    // logger: createLogger('worker', { level: 'debug' }),
     port: workerPort,
     lightning: `ws://localhost:${lightningPort}/worker`,
     secret: crypto.randomUUID(),

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -996,19 +996,23 @@ test.serial(
         },
       };
 
+      const jobLogs = [];
+      const rtLogs = [];
+
+      lightning.on('run:log', (e) => {
+        if (e.payload.source === 'JOB') {
+          jobLogs.push(e.payload);
+        } else if (e.payload.source === 'R/T') {
+          rtLogs.push(e.payload);
+        }
+      });
+
       lightning.once('run:complete', () => {
-        const jsonLogs = engineLogger._history;
-        // The engine logger shouldn't print out any job logs
-        const jobLog = jsonLogs.find((l) => l.name === 'JOB');
-        t.falsy(jobLog);
-        const jobLog2 = jsonLogs.find((l) => l.message[0] === message);
-        t.falsy(jobLog2);
+        // Ensure no run logs got sent back to lightning
+        t.falsy(jobLogs.length);
 
         // But it SHOULD log engine stuff
-        const runtimeLog = jsonLogs.find(
-          (l) => l.name === 'engine' && l.message[0].match(/complete workflow/i)
-        );
-        t.truthy(runtimeLog);
+        t.truthy(rtLogs.length);
         done();
       });
 

--- a/packages/engine-multi/src/api/execute.ts
+++ b/packages/engine-multi/src/api/execute.ts
@@ -109,7 +109,6 @@ const execute = async (context: ExecutionContext) => {
         jobError(context, evt);
       },
       [workerEvents.LOG]: (evt: workerEvents.LogEvent) => {
-        console.log(evt.log.name, evt.log.message);
         log(context, evt);
       },
       // TODO this is also untested

--- a/packages/engine-multi/src/api/execute.ts
+++ b/packages/engine-multi/src/api/execute.ts
@@ -50,6 +50,7 @@ const execute = async (context: ExecutionContext) => {
     const runOptions = {
       statePropsToRemove: options.statePropsToRemove,
       whitelist,
+      jobLogLevel: options.jobLogLevel,
     } as RunOptions;
 
     const workerOptions = {
@@ -108,7 +109,7 @@ const execute = async (context: ExecutionContext) => {
         jobError(context, evt);
       },
       [workerEvents.LOG]: (evt: workerEvents.LogEvent) => {
-        // console.log(evt.log.name, evt.log.message);
+        console.log(evt.log.name, evt.log.message);
         log(context, evt);
       },
       // TODO this is also untested

--- a/packages/engine-multi/src/engine.ts
+++ b/packages/engine-multi/src/engine.ts
@@ -157,6 +157,7 @@ const createEngine = async (
     opts: ExecuteOptions = {}
   ) => {
     options.logger!.debug('executing plan ', plan?.id ?? '<no id>');
+    console.log(' >> engine opts', opts);
     const workflowId = plan.id!;
     // TODO throw if plan is invalid
     // Wait, don't throw because the server will die
@@ -173,6 +174,7 @@ const createEngine = async (
         resolvers: opts.resolvers,
         runTimeoutMs: opts.runTimeoutMs ?? defaultTimeout,
         memoryLimitMb: opts.memoryLimitMb ?? defaultMemoryLimit,
+        jobLogLevel: opts.jobLogLevel,
       },
     });
 

--- a/packages/engine-multi/src/engine.ts
+++ b/packages/engine-multi/src/engine.ts
@@ -157,7 +157,6 @@ const createEngine = async (
     opts: ExecuteOptions = {}
   ) => {
     options.logger!.debug('executing plan ', plan?.id ?? '<no id>');
-    console.log(' >> engine opts', opts);
     const workflowId = plan.id!;
     // TODO throw if plan is invalid
     // Wait, don't throw because the server will die

--- a/packages/engine-multi/src/types.ts
+++ b/packages/engine-multi/src/types.ts
@@ -49,11 +49,10 @@ export type ExecuteOptions = {
   resolvers?: LazyResolvers;
   runTimeoutMs?: number;
   sanitize?: SanitizePolicies;
+  jobLogLevel?: string;
 };
 
-export type ExecutionContextOptions = EngineOptions & {
-  sanitize?: SanitizePolicies;
-};
+export type ExecutionContextOptions = ExecuteOptions & EngineOptions;
 
 export interface EngineAPI extends EventEmitter {
   callWorker: CallWorker;

--- a/packages/engine-multi/test/api/execute.test.ts
+++ b/packages/engine-multi/test/api/execute.test.ts
@@ -347,3 +347,28 @@ test.serial('should stringify the whitelist array', async (t) => {
   t.truthy(passedOptions);
   t.deepEqual(passedOptions.whitelist, ['/abc/']);
 });
+
+test.serial('should forward the jobLogLevel option', async (t) => {
+  let passedOptions: any;
+
+  const state = {
+    id: 'x',
+    plan,
+  } as WorkflowState;
+
+  const opts = {
+    ...options,
+    jobLogLevel: 'none',
+  };
+
+  const context = createContext({ state, options: opts });
+  // @ts-ignore
+  context.callWorker = (_command, args) => {
+    passedOptions = args[2];
+  };
+
+  await execute(context);
+
+  t.truthy(passedOptions);
+  t.deepEqual(passedOptions.jobLogLevel, 'none');
+});


### PR DESCRIPTION
This PR fixes an issue with the new `jobLogLevel` option sent from Lightning, which it turns out isn't working ¯\\_(ツ)_/¯

Two problems:

1) The `jobLogLevel` option wasn't getting properly fed through to the engine's options
2) The integration test was accidentally passing because it checked the logger's stdout to see  if the job log was present. But the engine actually doesn't send job logs to stdout, it just forwards them straight to the worker. Confusing!

https://github.com/OpenFn/kit/blob/10ad46888bec8a4333de6481940f54907f8ceac1/packages/engine-multi/src/api/lifecycle.ts#L127-L150

So to fix the test, we instead listen to the log events that Lightning receives. Which is a better test anyway because taht's actually the thing we care about.


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
