### PR TITLE
Logger: ignore empty lines in JSON Mode

### DIFF
--- a/.changeset/eight-parents-add.md
+++ b/.changeset/eight-parents-add.md
@@ -1,0 +1,5 @@
+---
+'@openfn/logger': patch
+---
+
+In JSON mode, don't log empty messages

--- a/.changeset/old-swans-clean.md
+++ b/.changeset/old-swans-clean.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Ignore empty log lines (don't send them to lightning)

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -561,6 +561,31 @@ test.serial("Don't send job logs to stdout", (t) => {
   });
 });
 
+// This is a test against job logs - but it should work
+// exactly the same way for all logs
+test.serial("Don't send empty logs to lightning", (t) => {
+  return new Promise(async (done) => {
+    const attempt = {
+      id: crypto.randomUUID(),
+      jobs: [
+        {
+          adaptor: '@openfn/language-common@latest',
+          body: 'fn((s) =>  { console.log(); return s })',
+        },
+      ],
+    };
+
+    lightning.once('run:complete', () => {
+      // The engine logger shouldn't print out any job logs
+      const jobLogs = engineLogger._history.filter((l) => l.name === 'JOB');
+      t.is(jobLogs.length, 0);
+      done();
+    });
+
+    lightning.enqueueRun(attempt);
+  });
+});
+
 test.serial('Include timestamps on basically everything', (t) => {
   return new Promise(async (done) => {
     const attempt = {

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -158,6 +158,14 @@ export default function (name?: string, options: LogOptions = {}): Logger {
     level: LogFns,
     ...args: LogArgs
   ) => {
+    if (args.length === 0) {
+      // In JSON mode, don't log empty lines
+      // (mostly because this spams Lightning with nonsense, but more generally
+      // if you have machine readable logs then "whitespace" or "formatting" logs,
+      // like console.break(), are meaningless)
+      return;
+    }
+
     const message = args.map((o) =>
       sanitize(o, {
         stringify: false,

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -354,6 +354,17 @@ test('json mode should serialize errors nicely', (t) => {
   t.deepEqual(result.message[0], { name: 'Error', message: 'wibble' });
 });
 
+test('json mode should not log empty lines', (t) => {
+  const logger = createLogger<JSONLog>(undefined, {
+    level: 'info',
+    json: true,
+  });
+
+  logger.info();
+
+  t.is(logger._history.length, 0);
+});
+
 test('with level=default, logs success, error and warning but not info and debug', (t) => {
   const logger = createLogger<StringLog>('x', { level: 'default' });
 


### PR DESCRIPTION
## Short Description

In the logger, when running in json mode (ie, emit JSON objects, not strings), ignore anything with an empty message.

Fixes #899

## Implementation Details

This PR is a little misleading because _really_ what it does is prevents the worker sending empty log lines to Lightning.

But the implementation can be handled very neatly by the low level logging component. It'll simply not emit any empty log lines.

This makes sense: json logging is designed for tools to consume logs. And those tools don't need formatting log lines. Usually in the runtime we print empty lines to make the CLI pretty.

Note that `console.log(undefined)` will still log.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
