### PR TITLE
Worker: support timeout on run channel

### DIFF
--- a/packages/ws-worker/src/channels/run.ts
+++ b/packages/ws-worker/src/channels/run.ts
@@ -28,6 +28,7 @@ const joinRunChannel = (
 
     // TODO use proper logger
     const channelName = `run:${runId}`;
+    logger.info(`JOINING ${channelName}`);
     logger.debug(`connecting to ${channelName} with timeout ${timeout}s`);
     const channel = socket.channel(channelName, { token });
     channel
@@ -46,11 +47,13 @@ const joinRunChannel = (
       .receive('error', (err: any) => {
         Sentry.captureException(err);
         logger.error(`error connecting to ${channelName}`, err);
+        channel?.leave();
         reject(err);
       })
       .receive('timeout', (err: any) => {
         Sentry.captureException(err);
         logger.error(`Timeout for ${channelName}`, err);
+        channel?.leave();
         reject(err);
       });
     channel.onClose(() => {

--- a/packages/ws-worker/src/channels/run.ts
+++ b/packages/ws-worker/src/channels/run.ts
@@ -15,7 +15,8 @@ const joinRunChannel = (
   socket: Socket,
   token: string,
   runId: string,
-  logger: Logger
+  logger: Logger,
+  timeout: number = 1
 ) => {
   return new Promise<{
     channel: Channel;
@@ -27,10 +28,10 @@ const joinRunChannel = (
 
     // TODO use proper logger
     const channelName = `run:${runId}`;
-    logger.debug('connecting to ', channelName);
+    logger.debug(`connecting to ${channelName} with timeout ${timeout}s`);
     const channel = socket.channel(channelName, { token });
     channel
-      .join()
+      .join(timeout * 1000)
       .receive('ok', async (e: any) => {
         if (!didReceiveOk) {
           didReceiveOk = true;

--- a/packages/ws-worker/src/events/step-complete.ts
+++ b/packages/ws-worker/src/events/step-complete.ts
@@ -54,6 +54,8 @@ export default async function onStepComplete(
     timestamp: timeInMicroseconds(event.time),
   } as StepCompletePayload;
 
+  console.log(event.state.data.length);
+
   if (event.redacted) {
     state.withheldDataclips[dataclipId] = true;
     evt.output_dataclip_error = 'DATACLIP_TOO_LARGE';

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -260,6 +260,7 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
         const start = Date.now();
         app.workflows[id] = true;
 
+        // const { channel: runChannel, run }) = await joinRunChannel(
         const { channel: runChannel, run } = await joinRunChannel(
           app.socket,
           token,
@@ -313,6 +314,12 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
 
         app.workflows[id] = context;
       } catch (e) {
+        delete app.workflows[id];
+
+        // TODO should we try and send a workflow complete message here?
+
+        app.resumeWorkloop();
+
         // Trap errors coming out of the socket
         // These are likely to be comms errors with Lightning
         logger.error(`Unexpected error executing ${id}`);

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -46,6 +46,7 @@ export type ServerOptions = {
   sentryEnv?: string;
 
   socketTimeoutSeconds?: number;
+  messageTimeoutSeconds?: number;
   payloadLimitMb?: number; // max memory limit for socket payload (ie, step:complete, log)
   collectionsVersion?: string;
   collectionsUrl?: string;
@@ -263,7 +264,8 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
           app.socket,
           token,
           id,
-          logger
+          logger,
+          app.options.messageTimeoutSeconds
         );
 
         const { plan, options, input } = convertRun(run, {

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -28,6 +28,7 @@ const [minBackoff, maxBackoff] = args.backoff
 
 function engineReady(engine: any) {
   logger.debug('Creating worker instance');
+  console.log(args);
   const workerOptions: ServerOptions = {
     port: args.port,
     lightning: args.lightning,
@@ -46,6 +47,8 @@ function engineReady(engine: any) {
     collectionsVersion: args.collectionsVersion,
     collectionsUrl: args.collectionsUrl,
     monorepoDir: args.monorepoDir,
+    messageTimeoutSeconds: args.messageTimeoutSeconds,
+    socketTimeoutSeconds: args.socketTimeoutSeconds,
   };
 
   if (args.lightningPublicKey) {

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -28,7 +28,6 @@ const [minBackoff, maxBackoff] = args.backoff
 
 function engineReady(engine: any) {
   logger.debug('Creating worker instance');
-  console.log(args);
   const workerOptions: ServerOptions = {
     port: args.port,
     lightning: args.lightning,

--- a/packages/ws-worker/src/util/cli.ts
+++ b/packages/ws-worker/src/util/cli.ts
@@ -5,6 +5,7 @@ import { hideBin } from 'yargs/helpers';
 const DEFAULT_PORT = 2222;
 const DEFAULT_WORKER_CAPACITY = 5;
 const DEFAULT_SOCKET_TIMEOUT_SECONDS = 10;
+const DEFAULT_MESSAGE_TIMEOUT_SECONDS = 1;
 
 type Args = {
   _: string[];
@@ -25,6 +26,7 @@ type Args = {
   runMemory?: number;
   secret?: string;
   socketTimeoutSeconds?: number;
+  messageTimeoutSeconds?: number;
   statePropsToRemove?: string[];
   sentryDsn?: string;
   sentryEnv?: string;
@@ -54,24 +56,25 @@ function setArg(
 
 export default function parseArgs(argv: string[]): Args {
   const {
+    OPENFN_ADAPTORS_REPO,
     WORKER_BACKOFF,
     WORKER_CAPACITY,
-    WORKER_COLLECTIONS_VERSION,
     WORKER_COLLECTIONS_URL,
+    WORKER_COLLECTIONS_VERSION,
     WORKER_LIGHTNING_PUBLIC_KEY,
     WORKER_LIGHTNING_SERVICE_URL,
     WORKER_LOG_LEVEL,
     WORKER_MAX_PAYLOAD_MB,
     WORKER_MAX_RUN_DURATION_SECONDS,
     WORKER_MAX_RUN_MEMORY_MB,
+    WORKER_MESSAGE_TIMEOUT_SECONDS,
     WORKER_PORT,
     WORKER_REPO_DIR,
     WORKER_SECRET,
     WORKER_SENTRY_DSN,
     WORKER_SENTRY_ENV,
-    WORKER_STATE_PROPS_TO_REMOVE,
     WORKER_SOCKET_TIMEOUT_SECONDS,
-    OPENFN_ADAPTORS_REPO,
+    WORKER_STATE_PROPS_TO_REMOVE,
   } = process.env;
 
   const parser = yargs(hideBin(argv))
@@ -94,7 +97,7 @@ export default function parseArgs(argv: string[]): Args {
     .option('monorepo-dir', {
       alias: 'm',
       description:
-        'Path to the adaptors mono repo, from where @local adaptors will be loaded. Env: OPENFN_ADAPTORS_REPO',
+        'Path to the adaptors monorepo, from where @local adaptors will be loaded. Env: OPENFN_ADAPTORS_REPO',
     })
     .option('secret', {
       alias: 's',
@@ -110,7 +113,10 @@ export default function parseArgs(argv: string[]): Args {
         "Sentry environment. Defaults to 'dev'. Env: WORKER_SENTRY_ENV",
     })
     .option('socket-timeout', {
-      description: `Timeout for websockets to Lighting, in seconds. Defaults to 10.`,
+      description: `Timeout for websockets to Lightning, in seconds. Defaults to 10.Env: WORKER_SOCKET_TIMEOUT_SECONDS`,
+    })
+    .option('message-timeout', {
+      description: `Timeout for messages in the run channel in seconds. Defaults to 1. Env: WORKER_MESSAGE_TIMEOUT_SECONDS`,
     })
     .option('lightning-public-key', {
       description:
@@ -208,6 +214,11 @@ export default function parseArgs(argv: string[]): Args {
       args.socketTimeoutSeconds,
       WORKER_SOCKET_TIMEOUT_SECONDS,
       DEFAULT_SOCKET_TIMEOUT_SECONDS
+    ),
+    messageTimeoutSeconds: setArg(
+      args.messageTimeoutSeconds,
+      WORKER_MESSAGE_TIMEOUT_SECONDS,
+      DEFAULT_MESSAGE_TIMEOUT_SECONDS
     ),
     collectionsVersion: setArg(
       args.collectionsVersion,


### PR DESCRIPTION
## Short Description

Add support for a custom (longer!) timeout on run channel messages

No issue for this really, but it's related to #914

Also fixes #916

## Implementation Details

We already have a timeout for the websocket to lightning. That's 10 seconds by default and affects connections to the socket generally.

Pass `WORKER_MESSAGE_TIMEOUT_SECONDS` on startup to increase the timeout for individual messages.

According to phoenix [docs](https://hexdocs.pm/phoenix/js) (see Pushing Messages) the default is 10  seconds, but I'm not so sure, based on local testing.

Anyway if the message DOES timeout on a key event like step:complete, then the run will be lost and that's bad for everyone. This at least exposes  some control


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
