### PR TITLE
Report podname

### DIFF
--- a/.changeset/tough-buttons-vanish.md
+++ b/.changeset/tough-buttons-vanish.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Include pod name in logs when claiming

--- a/packages/lexicon/lightning.d.ts
+++ b/packages/lexicon/lightning.d.ts
@@ -122,7 +122,7 @@ export type CHANNEL_LEAVE = 'socket:channel-leave';
 export type CLAIM = 'claim';
 
 // This is the payload in the message sent to lightning
-export type ClaimPayload = { demand?: number };
+export type ClaimPayload = { demand?: number; pod_name?: string };
 
 // This is the response from lightning
 export type ClaimReply = { runs: Array<ClaimRun> };

--- a/packages/ws-worker/src/api/claim.ts
+++ b/packages/ws-worker/src/api/claim.ts
@@ -51,7 +51,7 @@ const claim = (
 
     const start = Date.now();
     app.queueChannel
-      .push<ClaimPayload>(CLAIM, { demand: 1 })
+      .push<ClaimPayload>(CLAIM, { demand: 1, pod_name: DEPLOYED_POD_NAME })
       .receive('ok', ({ runs }: ClaimReply) => {
         const duration = Date.now() - start;
         logger.debug(

--- a/packages/ws-worker/src/api/claim.ts
+++ b/packages/ws-worker/src/api/claim.ts
@@ -34,7 +34,7 @@ const claim = (
 ) => {
   return new Promise<void>((resolve, reject) => {
     const { maxWorkers = 5 } = options;
-    const podName = DEPLOYED_POD_NAME ? `${DEPLOYED_POD_NAME} ` : '';
+    const podName = DEPLOYED_POD_NAME ? `[${DEPLOYED_POD_NAME}] ` : '';
 
     const activeWorkers = Object.keys(app.workflows).length;
     if (activeWorkers >= maxWorkers) {
@@ -83,7 +83,7 @@ const claim = (
             logger.debug('skipping run token validation for', run.id);
           }
 
-          logger.debug(`{podName} starting run %{run.id}`);
+          logger.debug(`${podName} starting run ${run.id}`);
           app.execute(run);
           resolve();
         });

--- a/packages/ws-worker/src/api/claim.ts
+++ b/packages/ws-worker/src/api/claim.ts
@@ -24,6 +24,9 @@ type ClaimOptions = {
   maxWorkers?: number;
 };
 
+// used to report the pod name in logging, for tracking
+const { DEPLOYED_POD_NAME } = process.env;
+
 const claim = (
   app: ServerApp,
   logger: Logger = mockLogger,
@@ -31,6 +34,7 @@ const claim = (
 ) => {
   return new Promise<void>((resolve, reject) => {
     const { maxWorkers = 5 } = options;
+    const podName = DEPLOYED_POD_NAME ? `${DEPLOYED_POD_NAME} ` : '';
 
     const activeWorkers = Object.keys(app.workflows).length;
     if (activeWorkers >= maxWorkers) {
@@ -51,7 +55,7 @@ const claim = (
       .receive('ok', ({ runs }: ClaimReply) => {
         const duration = Date.now() - start;
         logger.debug(
-          `claimed ${runs.length} runs in ${duration}ms (${
+          `${podName}claimed ${runs.length} runs in ${duration}ms (${
             runs.length ? runs.map((r) => r.id).join(',') : '-'
           })`
         );
@@ -79,7 +83,7 @@ const claim = (
             logger.debug('skipping run token validation for', run.id);
           }
 
-          logger.debug('starting run', run.id);
+          logger.debug(`{podName} starting run %{run.id}`);
           app.execute(run);
           resolve();
         });


### PR DESCRIPTION
## Short Description

On claim report the pod name from the environment. This is harmless if no env var is set.

The logs look like this:
```
[SRV] ❯ [Joe's cool pod] claimed 1 runs in 8ms (2fa0a8e0-12b0-4d6e-9e5d-f1720a4f2a7e)
[SRV] ❯ verified run token for 2fa0a8e0-12b0-4d6e-9e5d-f1720a4f2a7e
[SRV] ❯ [Joe's cool pod]  starting run 2fa0a8e0-12b0-4d6e-9e5d-f1720a4f2a7e
```


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
