### PR TITLE
worker: by default, exclude references from statePropsToRemove

### DIFF
--- a/.changeset/eight-tips-admire.md
+++ b/.changeset/eight-tips-admire.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Update default statePropsToRemove value to exclude references

--- a/packages/ws-worker/src/util/cli.ts
+++ b/packages/ws-worker/src/util/cli.ts
@@ -201,7 +201,7 @@ export default function parseArgs(argv: string[]): Args {
     statePropsToRemove: setArg(
       args.statePropsToRemove,
       WORKER_STATE_PROPS_TO_REMOVE,
-      ['configuration', 'response', 'references']
+      ['configuration', 'references']
     ),
     runMemory: setArg(args.runMemory, WORKER_MAX_RUN_MEMORY_MB, 500),
     payloadMemory: setArg(args.payloadMemory, WORKER_MAX_PAYLOAD_MB, 10),

--- a/packages/ws-worker/src/util/cli.ts
+++ b/packages/ws-worker/src/util/cli.ts
@@ -201,7 +201,7 @@ export default function parseArgs(argv: string[]): Args {
     statePropsToRemove: setArg(
       args.statePropsToRemove,
       WORKER_STATE_PROPS_TO_REMOVE,
-      ['configuration', 'response']
+      ['configuration', 'response', 'references']
     ),
     runMemory: setArg(args.runMemory, WORKER_MAX_RUN_MEMORY_MB, 500),
     payloadMemory: setArg(args.payloadMemory, WORKER_MAX_PAYLOAD_MB, 10),

--- a/packages/ws-worker/test/util/cli.test.ts
+++ b/packages/ws-worker/test/util/cli.test.ts
@@ -60,7 +60,11 @@ test('cli should set default values for unspecified options', (t) => {
   t.is(args.capacity, 5);
   t.is(args.sentryEnv, 'dev');
   t.falsy(args.sentryDsn);
-  t.deepEqual(args.statePropsToRemove, ['configuration', 'response']);
+  t.deepEqual(args.statePropsToRemove, [
+    'configuration',
+    'response',
+    'references',
+  ]);
   t.is(args.runMemory, 500);
   t.is(args.maxRunDurationSeconds, 300);
 });

--- a/packages/ws-worker/test/util/cli.test.ts
+++ b/packages/ws-worker/test/util/cli.test.ts
@@ -60,11 +60,7 @@ test('cli should set default values for unspecified options', (t) => {
   t.is(args.capacity, 5);
   t.is(args.sentryEnv, 'dev');
   t.falsy(args.sentryDsn);
-  t.deepEqual(args.statePropsToRemove, [
-    'configuration',
-    'response',
-    'references',
-  ]);
+  t.deepEqual(args.statePropsToRemove, ['configuration', 'references']);
   t.is(args.runMemory, 500);
   t.is(args.maxRunDurationSeconds, 300);
 });


### PR DESCRIPTION
## Short Description

Simple PR to update the default worker to remove the `references` key from state at the end of each step. This closes #487

I've also updated the environments in deployment

Update: also don't exclude `reponse`

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

Tags may need updating if commits come in after the tags are first generated.
