### PR TITLE
Fix claim after sigterm

### DIFF
--- a/.changeset/late-snakes-happen.md
+++ b/.changeset/late-snakes-happen.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Fix an issue where the server can attempt to claim even while it's waiting to shut down

--- a/.changeset/weak-teachers-give.md
+++ b/.changeset/weak-teachers-give.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Fix an issue where the --backoff server argument only accepts integer values

--- a/integration-tests/worker/src/init.ts
+++ b/integration-tests/worker/src/init.ts
@@ -17,6 +17,7 @@ export const initLightning = (port = 4000, privateKey?: string) => {
     // @ts-ignore
     opts.runPrivateKey = toBase64(privateKey);
   }
+  // opts.logger = createLogger('LTG', { level: 'debug' });
   return createLightningServer(opts);
 };
 
@@ -45,6 +46,7 @@ export const initWorker = async (
     lightning: `ws://localhost:${lightningPort}/worker`,
     secret: crypto.randomUUID(),
     collectionsVersion: '1.0.0',
+    messageTimeoutSeconds: 0.01,
     ...workerArgs,
   });
 

--- a/integration-tests/worker/test/server.test.ts
+++ b/integration-tests/worker/test/server.test.ts
@@ -124,8 +124,6 @@ test.serial('should join attempts queue channel', (t) => {
   });
 });
 
-// TODO: test this after two jobs are active
-// because once the first one completes, it must not restore the claim loop
 test('allow a job to complete after receiving a sigterm', (t) => {
   return new Promise(async (done) => {
     let didKill = false;
@@ -226,8 +224,6 @@ test("don't restore the claim loop after a sigterm", (t) => {
       }
     });
 
-    // TODO I can't find any reliable way to see if this is working from here
-    // I can't use sentry because the worker runs in a different process
     await waitForWorkerExit(workerProcess).then(() => {
       // This is about the only way I can find to
       // see if the worker attempted to claim after shutdown

--- a/integration-tests/worker/test/server.test.ts
+++ b/integration-tests/worker/test/server.test.ts
@@ -19,8 +19,8 @@ const spawnServer = (port: string | number = 1, args: string[] = []) => {
       './node_modules/@openfn/ws-worker/dist/start.js',
       [
         `-l ws://localhost:${port}/worker`,
-        '--backoff 0.001/0.01',
-        '--log debug',
+        '--backoff=0.0001/0.01',
+        '--log=debug',
         '--collections-version=1.0.0',
         '--debug', // alow us to run without keys
         ...args,
@@ -35,9 +35,9 @@ const spawnServer = (port: string | number = 1, args: string[] = []) => {
     });
 
     // Uncomment for logs
-    // workerProcess.stdout.on('data', (data) => {
-    //   console.log(data.toString());
-    // });
+    workerProcess.stdout.on('data', (data) => {
+      console.log(data.toString());
+    });
   });
 };
 
@@ -50,9 +50,14 @@ let portgen = 3000;
 
 const getPort = () => ++portgen;
 
-function waitForWorkerExit(worker) {
+function waitForWorkerExit(worker, limit = 10000) {
   return new Promise((resolve, reject) => {
+    let timeout = setTimeout(() => {
+      reject(new Error('timeout'));
+    }, limit);
+
     worker.on('exit', (code) => {
+      clearTimeout(timeout);
       if (code === 0) {
         resolve('Worker exited successfully');
       } else {
@@ -61,6 +66,7 @@ function waitForWorkerExit(worker) {
     });
 
     worker.on('error', (err) => {
+      clearTimeout(timeout);
       reject(err); // Reject if an error occurs
     });
   });
@@ -113,6 +119,8 @@ test.serial('should join attempts queue channel', (t) => {
   });
 });
 
+// TODO: test this after two jobs are active
+// because once the first one completes, it must not restore the claim loop
 test('allow a job to complete after receiving a sigterm', (t) => {
   return new Promise(async (done) => {
     let didKill = false;
@@ -158,7 +166,68 @@ test('allow a job to complete after receiving a sigterm', (t) => {
     setTimeout(() => {
       didKill = true;
       workerProcess.kill('SIGTERM');
-    }, 100);
+    }, 300);
+  });
+});
+
+// This test doesn't really work because of a bug in the mock, I think
+// Something in the mock lightning is stalled/awaiting
+// So even though the worker has triggered a claim event,
+// the mock doesn't emit it back out to the test until the job is finished
+// It's like the mock socket is waiting for run-complete before it'll respond to any claim events
+test.skip("don't restore the claim loop after a sigterm", (t) => {
+  return new Promise(async (done) => {
+    let didKill = false;
+    let abort = false;
+    const port = getPort();
+
+    const job = createJob({
+      // This job needs no adaptor (no autoinstall here!) and returns state after 1 second
+      adaptor: '',
+      body: 'export default [(s) => new Promise((resolve) => setTimeout(() => resolve(s), 500))]',
+    });
+
+    const a = createRun([], [job], []);
+    const b = createRun(
+      [],
+      [
+        {
+          ...job,
+          body: job.body.replace('500', '1000'), // TODO should be able to shorten these delays once I fix the test
+        },
+      ],
+      []
+    );
+
+    workerProcess = await spawnServer(port, ['--capacity=2']);
+    lightning = initLightning(port);
+
+    // After the second run starts, there should be no more claims
+    lightning.on('run:start', (evt) => {
+      if (evt.runId === b.id) {
+        // Kill the worker once the second job has started
+        // This will force an overlap of two pending runs at full capacity
+        workerProcess.kill('SIGTERM');
+
+        lightning.on('claim', () => {
+          abort = true;
+          t.fail('Claim triggered after sigterm');
+          done();
+        });
+      }
+    });
+
+    // We can end the test when the worker has shut down
+
+    lightning.enqueueRun(a);
+    lightning.enqueueRun(b);
+
+    await waitForWorkerExit(workerProcess).then(() => {
+      if (!abort) {
+        t.pass();
+        done();
+      }
+    });
   });
 });
 

--- a/integration-tests/worker/test/server.test.ts
+++ b/integration-tests/worker/test/server.test.ts
@@ -124,7 +124,7 @@ test.serial('should join attempts queue channel', (t) => {
   });
 });
 
-test('allow a job to complete after receiving a sigterm', (t) => {
+test.serial('allow a job to complete after receiving a sigterm', (t) => {
   return new Promise(async (done) => {
     let didKill = false;
     const port = getPort();
@@ -173,7 +173,7 @@ test('allow a job to complete after receiving a sigterm', (t) => {
   });
 });
 
-test("don't restore the claim loop after a sigterm", (t) => {
+test.serial("don't restore the claim loop after a sigterm", (t) => {
   return new Promise(async (done) => {
     let abort = false;
     let didSendSigterm = false;

--- a/integration-tests/worker/test/server.test.ts
+++ b/integration-tests/worker/test/server.test.ts
@@ -2,10 +2,12 @@ import test from 'ava';
 import { fork } from 'node:child_process';
 
 import { createRun, createJob } from '../src/factories';
-import { initLightning, initWorker } from '../src/init';
+import { initLightning } from '../src/init';
 
 let lightning;
 let workerProcess;
+
+let workerLogs = [];
 
 const spawnServer = (port: string | number = 1, args: string[] = []) => {
   return new Promise(async (resolve) => {
@@ -34,14 +36,17 @@ const spawnServer = (port: string | number = 1, args: string[] = []) => {
       }
     });
 
-    // Uncomment for logs
     workerProcess.stdout.on('data', (data) => {
-      console.log(data.toString());
+      workerLogs.push(data.toString());
+
+      // Uncomment for logs
+      // console.log(data.toString());
     });
   });
 };
 
 test.afterEach(async () => {
+  workerLogs = [];
   lightning?.destroy();
   await workerProcess?.kill();
 });
@@ -170,30 +175,26 @@ test('allow a job to complete after receiving a sigterm', (t) => {
   });
 });
 
-// This test doesn't really work because of a bug in the mock, I think
-// Something in the mock lightning is stalled/awaiting
-// So even though the worker has triggered a claim event,
-// the mock doesn't emit it back out to the test until the job is finished
-// It's like the mock socket is waiting for run-complete before it'll respond to any claim events
-test.skip("don't restore the claim loop after a sigterm", (t) => {
+test("don't restore the claim loop after a sigterm", (t) => {
   return new Promise(async (done) => {
-    let didKill = false;
     let abort = false;
+    let didSendSigterm = false;
     const port = getPort();
 
     const job = createJob({
-      // This job needs no adaptor (no autoinstall here!) and returns state after 1 second
       adaptor: '',
-      body: 'export default [(s) => new Promise((resolve) => setTimeout(() => resolve(s), 500))]',
+      body: 'export default [(s) => new Promise((resolve) => setTimeout(() => resolve(s), 100))]',
     });
 
+    // Set up two runs to run concurrently and fill the server capacity,
+    // but ensure that one ends before the other
     const a = createRun([], [job], []);
     const b = createRun(
       [],
       [
         {
           ...job,
-          body: job.body.replace('500', '1000'), // TODO should be able to shorten these delays once I fix the test
+          body: job.body.replace('100', '200'),
         },
       ],
       []
@@ -205,15 +206,10 @@ test.skip("don't restore the claim loop after a sigterm", (t) => {
     // After the second run starts, there should be no more claims
     lightning.on('run:start', (evt) => {
       if (evt.runId === b.id) {
+        didSendSigterm = true;
         // Kill the worker once the second job has started
         // This will force an overlap of two pending runs at full capacity
         workerProcess.kill('SIGTERM');
-
-        lightning.on('claim', () => {
-          abort = true;
-          t.fail('Claim triggered after sigterm');
-          done();
-        });
       }
     });
 
@@ -222,8 +218,27 @@ test.skip("don't restore the claim loop after a sigterm", (t) => {
     lightning.enqueueRun(a);
     lightning.enqueueRun(b);
 
+    lightning.on('claim', (e) => {
+      if (didSendSigterm && !abort) {
+        abort = true;
+        t.fail('Claim triggered after sigterm');
+        done();
+      }
+    });
+
+    // TODO I can't find any reliable way to see if this is working from here
+    // I can't use sentry because the worker runs in a different process
     await waitForWorkerExit(workerProcess).then(() => {
-      if (!abort) {
+      // This is about the only way I can find to
+      // see if the worker attempted to claim after shutdown
+      const didTryToClaim = workerLogs.find((l) =>
+        l.match(/skipping claim attempt: channel closed/)
+      );
+
+      if (didTryToClaim) {
+        t.fail('Worker attempted to claim after sigterm');
+        done();
+      } else if (!abort) {
         t.pass();
         done();
       }

--- a/packages/ws-worker/src/api/claim.ts
+++ b/packages/ws-worker/src/api/claim.ts
@@ -75,8 +75,6 @@ const claim = (
         runs.forEach(async (run) => {
           if (app.options?.runPublicKey) {
             try {
-              console.log('TOKEN', run.token);
-              console.log('KEY', app.options.runPublicKey);
               await verifyToken(run.token, app.options.runPublicKey);
               logger.debug('verified run token for', run.id);
             } catch (e) {

--- a/packages/ws-worker/src/api/claim.ts
+++ b/packages/ws-worker/src/api/claim.ts
@@ -75,6 +75,8 @@ const claim = (
         runs.forEach(async (run) => {
           if (app.options?.runPublicKey) {
             try {
+              console.log('TOKEN', run.token);
+              console.log('KEY', app.options.runPublicKey);
               await verifyToken(run.token, app.options.runPublicKey);
               logger.debug('verified run token for', run.id);
             } catch (e) {

--- a/packages/ws-worker/src/api/workloop.ts
+++ b/packages/ws-worker/src/api/workloop.ts
@@ -33,11 +33,15 @@ const startWorkloop = (
         }
       );
       // TODO this needs more unit tests I think
-      promise.then(() => {
-        if (!cancelled) {
-          setTimeout(workLoop, minBackoff);
-        }
-      });
+      promise
+        .then(() => {
+          if (!cancelled) {
+            setTimeout(workLoop, minBackoff);
+          }
+        })
+        .catch(() => {
+          // do nothing
+        });
     }
   };
   workLoop();

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -236,8 +236,6 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
 
   // Start the workloop (if not already started)
   app.resumeWorkloop = () => {
-    // TODO restore this to get the fix
-    // (leaving off now while I get my test to fail)
     if (options.noLoop || app.destroyed) {
       return;
     }

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -236,9 +236,11 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
 
   // Start the workloop (if not already started)
   app.resumeWorkloop = () => {
-    if (options.noLoop) {
-      return;
-    }
+    // TODO restore this to get the fix
+    // (leaving off now while I get my test to fail)
+    // if (options.noLoop || app.destroyed) {
+    //   return;
+    // }
 
     if (!app.workloop || app.workloop?.isStopped()) {
       logger.info('Starting workloop');
@@ -369,7 +371,7 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
       shutdown = true;
       logger.always(`${signal} RECEIVED: CLOSING SERVER`);
       await app.destroy();
-      process.exit();
+      process.exit(0);
     }
   };
 

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -238,9 +238,9 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
   app.resumeWorkloop = () => {
     // TODO restore this to get the fix
     // (leaving off now while I get my test to fail)
-    // if (options.noLoop || app.destroyed) {
-    //   return;
-    // }
+    if (options.noLoop || app.destroyed) {
+      return;
+    }
 
     if (!app.workloop || app.workloop?.isStopped()) {
       logger.info('Starting workloop');

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -17,7 +17,7 @@ if (args.lightning === 'mock') {
     // Set a fake secret to stop the console warning
     args.secret = 'abdefg';
   }
-} else if (!args.secret) {
+} else if (!args.debug && !args.secret) {
   logger.error('WORKER_SECRET is not set');
   process.exit(1);
 }

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -24,7 +24,7 @@ if (args.lightning === 'mock') {
 
 const [minBackoff, maxBackoff] = args.backoff
   .split('/')
-  .map((n: string) => parseInt(n, 10) * 1000);
+  .map((n: string) => parseFloat(n) * 1000);
 
 function engineReady(engine: any) {
   logger.debug('Creating worker instance');
@@ -36,7 +36,6 @@ function engineReady(engine: any) {
     sentryDsn: args.sentryDsn,
     sentryEnv: args.sentryEnv,
     noLoop: !args.loop,
-    // TODO need to feed this through properly
     backoff: {
       min: minBackoff,
       max: maxBackoff,

--- a/packages/ws-worker/src/util/cli.ts
+++ b/packages/ws-worker/src/util/cli.ts
@@ -79,6 +79,10 @@ export default function parseArgs(argv: string[]): Args {
 
   const parser = yargs(hideBin(argv))
     .command('server', 'Start a ws-worker server')
+    .option('debug', {
+      hidden: true,
+      type: 'boolean',
+    })
     .option('port', {
       alias: 'p',
       description: `Port to run the server on. Default ${DEFAULT_PORT}. Env: WORKER_PORT`,

--- a/packages/ws-worker/src/util/cli.ts
+++ b/packages/ws-worker/src/util/cli.ts
@@ -181,7 +181,7 @@ export default function parseArgs(argv: string[]): Args {
     });
 
   const args = parser.parse() as Args;
-
+  console.log('---- !!!! ', args.backoff);
   return {
     ...args,
     port: setArg(args.port, WORKER_PORT, DEFAULT_PORT),

--- a/packages/ws-worker/src/util/cli.ts
+++ b/packages/ws-worker/src/util/cli.ts
@@ -10,6 +10,7 @@ const DEFAULT_MESSAGE_TIMEOUT_SECONDS = 30;
 type Args = {
   _: string[];
   backoff: string;
+  debug?: boolean;
   capacity?: number;
   collectionsUrl?: string;
   collectionsVersion?: string;

--- a/packages/ws-worker/src/util/cli.ts
+++ b/packages/ws-worker/src/util/cli.ts
@@ -181,7 +181,6 @@ export default function parseArgs(argv: string[]): Args {
     });
 
   const args = parser.parse() as Args;
-  console.log('---- !!!! ', args.backoff);
   return {
     ...args,
     port: setArg(args.port, WORKER_PORT, DEFAULT_PORT),

--- a/packages/ws-worker/src/util/try-with-backoff.ts
+++ b/packages/ws-worker/src/util/try-with-backoff.ts
@@ -35,8 +35,8 @@ const tryWithBackoff = (fn: any, opts: Options = {}): CancelablePromise => {
     try {
       await fn();
       resolve();
-    } catch (e) {
-      if ((e as any).abort) {
+    } catch (e: any) {
+      if (e?.abort) {
         cancelled = true;
         return reject();
       }

--- a/packages/ws-worker/src/util/try-with-backoff.ts
+++ b/packages/ws-worker/src/util/try-with-backoff.ts
@@ -36,6 +36,11 @@ const tryWithBackoff = (fn: any, opts: Options = {}): CancelablePromise => {
       await fn();
       resolve();
     } catch (e) {
+      if ((e as any).abort) {
+        cancelled = true;
+        return reject();
+      }
+
       if (opts.isCancelled!()) {
         return resolve();
       }

--- a/packages/ws-worker/test/lightning.test.ts
+++ b/packages/ws-worker/test/lightning.test.ts
@@ -829,7 +829,7 @@ test.serial(
 );
 
 test.serial(
-  `should recieve worker:queue message events from lightning`,
+  `should receive worker:queue message events from lightning`,
   (t) => {
     t.plan(1);
 


### PR DESCRIPTION
The actual fix is dead simple: when we call `resumeWorkloop`, don't actually resume if the server is marked as destroyed.

The difficulty is getting the integration test to pass. There's a strange issue where the mock doesn't emit claim events while there's a run in progress, which is blocking the tests.

I might be able to create better tests against the worker directly. Or we'll leave the fix on faith and merge it.

Closes #946 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
