### PR TITLE
Purge unsupported adaptors in metadata cli with version-aware caching

### DIFF
--- a/.changeset/dirty-points-sparkle.md
+++ b/.changeset/dirty-points-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Better cache management in the metadata command

--- a/.changeset/dirty-points-sparkle.md
+++ b/.changeset/dirty-points-sparkle.md
@@ -1,5 +1,0 @@
----
-'@openfn/cli': patch
----
-
-Better cache management in the metadata command

--- a/.changeset/mighty-jeans-love.md
+++ b/.changeset/mighty-jeans-love.md
@@ -1,7 +1,0 @@
----
-'@openfn/integration-tests-cli': patch
-'@openfn/project': patch
-'@openfn/cli': patch
----
-
-Remove unsupported adaptors when used via CLI's metadata feature

--- a/.changeset/mighty-jeans-love.md
+++ b/.changeset/mighty-jeans-love.md
@@ -1,0 +1,7 @@
+---
+'@openfn/integration-tests-cli': patch
+'@openfn/project': patch
+'@openfn/cli': patch
+---
+
+Remove unsupported adaptors when used via CLI's metadata feature

--- a/.changeset/warm-fans-appear.md
+++ b/.changeset/warm-fans-appear.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+Fix an issue reading package.json on autoinstalled adaptors

--- a/.changeset/warm-fans-appear.md
+++ b/.changeset/warm-fans-appear.md
@@ -1,5 +1,0 @@
----
-'@openfn/runtime': patch
----
-
-Fix an issue reading package.json on autoinstalled adaptors

--- a/integration-tests/cli/CHANGELOG.md
+++ b/integration-tests/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/integration-tests-cli
 
+## 1.0.4
+
+### Patch Changes
+
+- @openfn/lightning-mock@2.2.2
+
 ## 1.0.3
 
 ### Patch Changes

--- a/integration-tests/cli/package.json
+++ b/integration-tests/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-cli",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "CLI integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/integration-tests/cli/test/metadata.test.ts
+++ b/integration-tests/cli/test/metadata.test.ts
@@ -144,7 +144,7 @@ test.serial(
 
 // This test validates that cached unsupported adaptors are not downloaded again
 test.serial(
-  `openfn metadata -f -S "${state}" -a common --log-json --log info`,
+  `openfn metadata -f -S "${state}" -a common --log info --log-json `,
   async (t) => {
     const { stdout } = await run(t.title);
 
@@ -168,15 +168,18 @@ test.serial(
     t.regex(stdout, /Installed @openfn\/language-http@/);
     t.regex(stdout, /Installation complete in \d+\.\d+s/);
     t.regex(stdout, /No metadata helper found/);
-    t.regex(stdout, /Keeping unsupported adaptor as requested by --keep-unsupported flag/);
+    t.regex(
+      stdout,
+      /Keeping unsupported adaptor as requested by --keep-unsupported flag/
+    );
     // Should NOT try to remove the package
     t.notRegex(stdout, /Removing unsupported adaptor from disk/);
   }
 );
 
 // This test validates that even with --keep-unsupported, the cache works
-test.serial(
-  `openfn metadata -f -S "${state}" -a http --keep-unsupported --log-json --log info`,
+test.serial.only(
+  `openfn metadata -fS "${state}" -a http --keep-unsupported --log-json --log info`,
   async (t) => {
     const { stdout } = await run(t.title);
 

--- a/integration-tests/cli/test/metadata.test.ts
+++ b/integration-tests/cli/test/metadata.test.ts
@@ -12,7 +12,15 @@ let lastCreated: Date;
 
 // For local dev, ensure the repo is clear
 test.before(async () => {
+  process.env.OPENFN_REPO_DIR = '/tmp/openfn/integration-tests/cli';
   await clean();
+});
+
+// Sleep after tests because weird exceptions keep popping up
+test.afterEach(async () => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 500);
+  });
 });
 
 // Generate metadata
@@ -126,43 +134,62 @@ test.serial('does not log credentials', async (t) => {
   t.notRegex(logString, new RegExp(sensitiveValue), 'i');
 });
 
-// This test validates the new purge and cache functionality
+// When installing an adaptor that doesn't support metadata, the adaptor should be removed
 test.serial(
-  `openfn metadata -f -S "${state}" -a common --log-json --log info`,
+  `openfn metadata -S "${state}" -a openfn@3.0.0 --log-json --log info`,
   async (t) => {
     const { stdout } = await run(t.title);
 
     t.regex(stdout, /Generating metadata/);
     t.regex(stdout, /Installing packages.../);
-    t.regex(stdout, /Installed @openfn\/language-common@/);
+    t.regex(stdout, /Installed @openfn\/language-openfn@/);
     t.regex(stdout, /Installation complete in \d+\.\d+s/);
     t.regex(stdout, /No metadata helper found/);
     t.regex(stdout, /Removing unsupported adaptor from disk/);
     t.regex(stdout, /Adaptor removed and marked as unsupported/);
+    t.regex(stdout, /successfully removed @openfn\/language-openfn_/i);
   }
 );
 
-// This test validates that cached unsupported adaptors are not downloaded again
+// Cached unsupported adaptors are not downloaded again
 test.serial(
-  `openfn metadata -f -S "${state}" -a common --log info --log-json `,
+  `openfn metadata -S "${state}" -a openfn@3.0.0 --log info --log-json `,
   async (t) => {
     const { stdout } = await run(t.title);
 
-    t.regex(stdout, /Generating metadata/);
     t.regex(stdout, /known to not support metadata \(cached\)/);
     t.regex(stdout, /No metadata helper found/);
     // Should NOT try to install or remove again
     t.notRegex(stdout, /Installing packages/);
     t.notRegex(stdout, /Removing unsupported adaptor from disk/);
+    t.notRegex(stdout, /successfully removed @openfn\/language-openfn_/);
   }
 );
 
-// This test validates the --keep-unsupported flag
-test.serial(
-  `openfn metadata -f -S "${state}" -a http --keep-unsupported --log-json --log info`,
+// metadata should work with implicit @latest (note that it'll still autoinstall)
+// TODO some kind of exception triggers here?? Can't repro standalone
+test.serial.skip(
+  `openfn metadata -S "${state}" -a openfn --log-json --log info`,
   async (t) => {
     const { stdout } = await run(t.title);
+    t.log(stdout);
 
+    t.regex(stdout, /Generating metadata/);
+    t.regex(stdout, /Installing packages.../);
+    t.regex(stdout, /Installed @openfn\/language-openfn@/);
+    t.regex(stdout, /Installation complete in \d+\.\d+s/);
+    t.regex(stdout, /No metadata helper found/);
+    t.regex(stdout, /Removing unsupported adaptor from disk/);
+    t.regex(stdout, /Adaptor removed and marked as unsupported/);
+    t.regex(stdout, /successfully removed @openfn\/language-openfn_/i);
+  }
+);
+
+// ignore cache with --keep-unsupported
+test.serial(
+  `openfn metadata -S "${state}" -a http@7.0.0 --keep-unsupported --log-json --log info`,
+  async (t) => {
+    const { stdout } = await run(t.title);
     t.regex(stdout, /Generating metadata/);
     t.regex(stdout, /Installing packages.../);
     t.regex(stdout, /Installed @openfn\/language-http@/);
@@ -178,13 +205,12 @@ test.serial(
 );
 
 // This test validates that even with --keep-unsupported, the cache works
-test.serial.only(
-  `openfn metadata -fS "${state}" -a http --keep-unsupported --log-json --log info`,
+test.serial(
+  `openfn metadata -fS "${state}" -a http@7.0.0 --keep-unsupported --log-json --log info`,
   async (t) => {
     const { stdout } = await run(t.title);
 
-    t.regex(stdout, /Generating metadata/);
-    t.regex(stdout, /known to not support metadata \(cached\)/);
+    t.regex(stdout, /known to not support metadata/);
     t.regex(stdout, /No metadata helper found/);
     // Should NOT try to install again
     t.notRegex(stdout, /Installing packages/);

--- a/integration-tests/cli/test/metadata.test.ts
+++ b/integration-tests/cli/test/metadata.test.ts
@@ -167,8 +167,7 @@ test.serial(
 );
 
 // metadata should work with implicit @latest (note that it'll still autoinstall)
-// TODO some kind of exception triggers here?? Can't repro standalone
-test.serial.skip(
+test.serial(
   `openfn metadata -S "${state}" -a openfn --log-json --log info`,
   async (t) => {
     const { stdout } = await run(t.title);

--- a/integration-tests/cli/tsconfig.json
+++ b/integration-tests/cli/tsconfig.json
@@ -6,6 +6,7 @@
     "allowJs": true,
     "isolatedModules": true,
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "sourceMap": true
   }
 }

--- a/integration-tests/execute/CHANGELOG.md
+++ b/integration-tests/execute/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/integration-tests-execute
 
+## 1.0.22
+
+### Patch Changes
+
+- Updated dependencies [f04acef]
+  - @openfn/runtime@1.7.1
+
 ## 1.0.21
 
 ### Patch Changes

--- a/integration-tests/execute/package.json
+++ b/integration-tests/execute/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-execute",
   "private": true,
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Job execution tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/integration-tests/worker/CHANGELOG.md
+++ b/integration-tests/worker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/integration-tests-worker
 
+## 1.0.91
+
+### Patch Changes
+
+- @openfn/engine-multi@1.6.8
+- @openfn/lightning-mock@2.2.2
+- @openfn/ws-worker@1.14.2
+
 ## 1.0.90
 
 ### Patch Changes

--- a/integration-tests/worker/package.json
+++ b/integration-tests/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/integration-tests-worker",
   "private": true,
-  "version": "1.0.90",
+  "version": "1.0.91",
   "description": "Lightning WOrker integration tests",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@swc-node/register": "^1.10.9",
     "@types/gunzip-maybe": "^1.4.0",
     "@types/rimraf": "^3.0.2",
+    "@types/semver": "~7.5.8",
     "@types/tar-stream": "^2.2.2",
     "gunzip-maybe": "^1.4.2",
     "prettier": "^2.8.8",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 1.13.1
+
+### Patch Changes
+
+- 6ec2c48: Better cache management in the metadata command
+- Updated dependencies [f04acef]
+  - @openfn/runtime@1.7.1
+
 ## 1.13.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfn/cli",
-  "version": "1.13.0",
-  "description": "CLI devtools for the openfn toolchain.",
+  "version": "1.13.1",
+  "description": "CLI devtools for the OpenFn toolchain",
   "engines": {
     "node": ">=18",
     "pnpm": ">=7"

--- a/packages/cli/src/metadata/cache.ts
+++ b/packages/cli/src/metadata/cache.ts
@@ -1,13 +1,49 @@
+import { getNameAndVersion } from '@openfn/runtime';
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { writeFile, mkdir } from 'node:fs/promises';
 
-const getPath = (repoDir: string, key: string) => `${repoDir}/meta/${key}.json`;
+const CACHE_DIR = '.cli-cache';
+
+export type AdaptorConfiguration = Record<string, any>;
+
+export interface AdaptorMetadata {
+  name: string;
+  type: string;
+  children: any[];
+  [key: string]: any; // Allow additional properties
+}
+
+export interface CachedMetadata extends AdaptorMetadata {
+  created: string; // ISO timestamp added by decorateMetadata
+}
+
+export type UnsupportedAdaptorCache = {
+  [adaptorName: string]: UnsupportedAdaptorEntry;
+};
+
+export interface UnsupportedAdaptorEntry {
+  lastCheckedVersion: string;
+  majorMinor: string;
+  timestamp: number;
+}
+
+export interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  majorMinor: string;
+}
+
+export type CacheResult<T> = T | null;
+
+const getPath = (repoDir: string, key: string): string => {
+  return `${repoDir}/${CACHE_DIR}/${key}.json`;
+};
 
 // Sort keys on a json object so that the same object with different key order returns the same cache id
 // At this stage we're not sorting values (apart from objects)
-const sortKeys = (obj: Record<string, any>) => {
+const sortKeys = (obj: Record<string, any>): Record<string, any> => {
   const newObj = {} as Record<string, any>;
   Object.keys(obj)
     .sort()
@@ -22,17 +58,20 @@ const sortKeys = (obj: Record<string, any>) => {
   return newObj;
 };
 
-const generateKey = (config: any, adaptor: string) => {
+const generateKey = (config: AdaptorConfiguration, adaptor: string): string => {
   const sorted = sortKeys(config);
-  const key = `${JSON.stringify(sorted)}-${adaptor}}`;
+  const key = `${JSON.stringify(sorted)}-${adaptor}`;
   return createHash('sha256').update(key).digest('hex');
 };
 
-const get = (repoPath: string, key: string) => {
+const get = async <T = CachedMetadata>(
+  repoPath: string,
+  key: string
+): Promise<CacheResult<T>> => {
+  const p = getPath(repoPath, key);
   try {
-    const data = readFileSync(getPath(repoPath, key), 'utf8');
-    const json = JSON.parse(data);
-    return json;
+    const result = await readFile(p, 'utf8');
+    return JSON.parse(result) as T;
   } catch (e) {
     return null;
   }
@@ -42,10 +81,168 @@ const get = (repoPath: string, key: string) => {
 // this is very similar to how docgen works
 // /const lock = async (repoPath: string, key: string) => {};
 
-const set = async (repoPath: string, key: string, data: any) => {
-  const fullPath = getPath(repoPath, key);
-  await mkdir(path.dirname(fullPath), { recursive: true });
-  await writeFile(fullPath, JSON.stringify(data));
+const set = async <T = CachedMetadata>(
+  repoPath: string,
+  key: string,
+  result: T
+): Promise<void> => {
+  const p = getPath(repoPath, key);
+  await mkdir(path.dirname(p), { recursive: true });
+  await writeFile(p, JSON.stringify(result));
 };
 
-export default { get, set, generateKey, getPath, sortKeys };
+const getUnsupportedCachePath = (repoDir: string): string => {
+  return path.join(repoDir, CACHE_DIR, 'unsupported-metadata.json');
+};
+
+const parseVersion = (version: string): ParsedVersion => {
+  const parts = version.split('.').map(Number);
+  return {
+    major: parts[0] || 0,
+    minor: parts[1] || 0,
+    patch: parts[2] || 0,
+    majorMinor: `${parts[0] || 0}.${parts[1] || 0}`,
+  };
+};
+
+const compareVersions = (version1: string, version2: string): number => {
+  const v1 = parseVersion(version1);
+  const v2 = parseVersion(version2);
+
+  if (v1.major !== v2.major) return v1.major - v2.major;
+  if (v1.minor !== v2.minor) return v1.minor - v2.minor;
+  return v1.patch - v2.patch;
+};
+
+export const isAdaptorUnsupported = async (
+  adaptorSpecifier: string,
+  repoDir: string
+): Promise<boolean> => {
+  const { name, version } = getNameAndVersion(adaptorSpecifier);
+  if (!version) return false;
+
+  const cachePath = getUnsupportedCachePath(repoDir);
+  let cache: UnsupportedAdaptorCache = {};
+
+  try {
+    const cacheContent = await readFile(cachePath, 'utf8');
+    cache = JSON.parse(cacheContent);
+  } catch (error) {
+    // Cache doesn't exist or is invalid, that's fine
+    return false;
+  }
+
+  const cached = cache[name];
+  if (!cached) return false;
+
+  const currentParsed = parseVersion(version);
+  const cachedParsed = parseVersion(cached.lastCheckedVersion);
+
+  // If current version's major.minor is higher than cached, we should check again
+  if (
+    currentParsed.major > cachedParsed.major ||
+    (currentParsed.major === cachedParsed.major &&
+      currentParsed.minor > cachedParsed.minor)
+  ) {
+    return false; // Allow checking this higher version
+  }
+
+  // If major.minor is same or lower, assume it doesn't support metadata
+  return true;
+};
+
+export const markAdaptorAsUnsupported = async (
+  adaptorSpecifier: string,
+  repoDir: string
+): Promise<void> => {
+  const { name, version } = getNameAndVersion(adaptorSpecifier);
+  if (!version) return;
+
+  const cachePath = getUnsupportedCachePath(repoDir);
+  let cache: UnsupportedAdaptorCache = {};
+
+  try {
+    const cacheContent = await readFile(cachePath, 'utf8');
+    cache = JSON.parse(cacheContent);
+  } catch (error) {
+    // Cache doesn't exist, start fresh
+  }
+
+  const parsed = parseVersion(version);
+
+  // Only update cache if this version is higher than what we've seen
+  const existing = cache[name];
+  if (!existing || compareVersions(version, existing.lastCheckedVersion) > 0) {
+    cache[name] = {
+      lastCheckedVersion: version,
+      majorMinor: parsed.majorMinor,
+      timestamp: Date.now(),
+    };
+
+    // Ensure cache directory exists
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await writeFile(cachePath, JSON.stringify(cache, null, 2));
+  }
+};
+
+export const getCacheInfo = async (
+  repoDir: string
+): Promise<{
+  supportedCount: number;
+  unsupportedCount: number;
+  cacheDir: string;
+}> => {
+  const cacheDir = path.join(repoDir, CACHE_DIR);
+  let supportedCount = 0;
+  let unsupportedCount = 0;
+
+  try {
+    const { readdir } = await import('node:fs/promises');
+    const files = await readdir(cacheDir);
+    // Count .json files (excluding unsupported-metadata.json)
+    supportedCount = files.filter(
+      (f: string) => f.endsWith('.json') && f !== 'unsupported-metadata.json'
+    ).length;
+  } catch (error) {
+    // Cache directory doesn't exist
+  }
+
+  try {
+    const unsupportedPath = getUnsupportedCachePath(repoDir);
+    const content = await readFile(unsupportedPath, 'utf8');
+    const cache: UnsupportedAdaptorCache = JSON.parse(content);
+    unsupportedCount = Object.keys(cache).length;
+  } catch (error) {
+    // Unsupported cache doesn't exist
+  }
+
+  return {
+    supportedCount,
+    unsupportedCount,
+    cacheDir,
+  };
+};
+
+export const clearCache = async (repoDir: string): Promise<void> => {
+  const cacheDir = path.join(repoDir, CACHE_DIR);
+  try {
+    const { rm } = await import('node:fs/promises');
+    await rm(cacheDir, { recursive: true, force: true });
+  } catch (error) {
+    // Cache directory might not exist, that's fine
+  }
+};
+
+export default {
+  get,
+  set,
+  getPath,
+  generateKey,
+  sortKeys,
+  isAdaptorUnsupported,
+  markAdaptorAsUnsupported,
+  getCacheInfo,
+  clearCache,
+  parseVersion,
+  compareVersions,
+};

--- a/packages/cli/src/metadata/command.ts
+++ b/packages/cli/src/metadata/command.ts
@@ -8,6 +8,7 @@ export type MetadataOpts = Required<Pick<Opts, 'adaptors' | 'repoDir'>> &
     Opts,
     | 'expandAdaptors'
     | 'force'
+    | 'keepUnsupported'
     | 'log'
     | 'logJson'
     | 'statePath'
@@ -20,6 +21,7 @@ const options = [
 
   o.adaptors,
   o.force,
+  o.keepUnsupported,
   o.log,
   o.logJson,
   o.repoDir,

--- a/packages/cli/src/metadata/handler.ts
+++ b/packages/cli/src/metadata/handler.ts
@@ -1,21 +1,27 @@
 import { Logger } from '../util/logger';
 import { MetadataOpts } from './command';
 import loadState from '../util/load-state';
-import cache from './cache';
+import cache, {
+  isAdaptorUnsupported,
+  markAdaptorAsUnsupported,
+  type AdaptorMetadata,
+  type CachedMetadata,
+  type AdaptorConfiguration,
+} from './cache';
 import { getModuleEntryPoint } from '@openfn/runtime';
 import { ExecutionPlan } from '@openfn/lexicon';
-import { install } from '../repo/handler';
+import { install, removePackage } from '../repo/handler';
 
 // Add extra, uh, metadata to the, uh, metadata object
-const decorateMetadata = (metadata: any) => {
-  metadata.created = new Date().toISOString();
+const decorateMetadata = (metadata: AdaptorMetadata): void => {
+  (metadata as CachedMetadata).created = new Date().toISOString();
 };
 
 export const getAdaptorPath = async (
   adaptor: string,
   logger: Logger,
   repoDir?: string
-) => {
+): Promise<string | undefined> => {
   let adaptorPath;
   let adaptorSpecifier;
 
@@ -52,9 +58,19 @@ export const getAdaptorPath = async (
 export const shouldAutoinstall = (adaptor: string): boolean =>
   adaptor?.length > 0 && !adaptor.startsWith('/') && !adaptor.includes('=');
 
-const metadataHandler = async (options: MetadataOpts, logger: Logger) => {
-  const { repoDir, adaptors } = options;
+const metadataHandler = async (
+  options: MetadataOpts,
+  logger: Logger
+): Promise<void> => {
+  const { repoDir, adaptors, keepUnsupported } = options;
   const adaptor = adaptors[0];
+
+  // Check cache first to avoid unnecessary downloads
+  if (await isAdaptorUnsupported(adaptor, repoDir)) {
+    logger.warn(`Adaptor ${adaptor} is known to not support metadata (cached)`);
+    logger.error('No metadata helper found');
+    process.exit(1);
+  }
 
   const state = await loadState({} as ExecutionPlan, options, logger);
   logger.success(`Generating metadata`);
@@ -62,13 +78,13 @@ const metadataHandler = async (options: MetadataOpts, logger: Logger) => {
   // Note that the config will be sanitised, so logging it may not be terrible helpful
   logger.info('config:', state);
 
-  const config = state.configuration;
+  const config: AdaptorConfiguration = state.configuration;
   if (!config || Object.keys(config).length === 0) {
     logger.error('ERROR: Invalid configuration passed');
     process.exit(1);
   }
 
-  const finish = () => {
+  const finish = (): void => {
     logger.success('Done!');
     logger.print(cache.getPath(repoDir, id));
   };
@@ -77,30 +93,49 @@ const metadataHandler = async (options: MetadataOpts, logger: Logger) => {
   if (!options.force) {
     // generate a hash for the config and check state
     logger.debug('config hash: ', id);
-    const cached = await cache.get(repoDir, id);
+    const cached = await cache.get<CachedMetadata>(repoDir, id);
     if (cached) {
       logger.success('Returning metadata from cache');
       return finish();
     }
   }
 
+  let wasAutoInstalled = false;
   try {
     if (shouldAutoinstall(adaptor)) {
       await install({ packages: [adaptor], repoDir }, logger);
+      wasAutoInstalled = true;
     }
 
     const adaptorPath = await getAdaptorPath(adaptor, logger, options.repoDir);
-    const mod = await import(adaptorPath!);
+    if (!adaptorPath) {
+      throw new Error(`Could not resolve adaptor path for ${adaptor}`);
+    }
+
+    const mod = await import(adaptorPath);
 
     // Does it export a metadata function?
-    if (mod.metadata) {
+    if (mod.metadata && typeof mod.metadata === 'function') {
       logger.info('Metadata function found. Generating metadata...');
-      const result = await mod.metadata(config);
+      const result: AdaptorMetadata = await mod.metadata(config);
       decorateMetadata(result);
-      await cache.set(repoDir, id, result);
+      await cache.set<CachedMetadata>(repoDir, id, result as CachedMetadata);
       finish();
     } else {
       logger.error('No metadata helper found');
+
+      // If we auto-installed this adaptor and user didn't opt out, remove it and cache the result
+      if (wasAutoInstalled && !keepUnsupported) {
+        logger.info('Removing unsupported adaptor from disk...');
+        await removePackage(adaptor, repoDir, logger);
+        await markAdaptorAsUnsupported(adaptor, repoDir);
+        logger.info('Adaptor removed and marked as unsupported');
+      } else if (wasAutoInstalled && keepUnsupported) {
+        logger.info(
+          'Keeping unsupported adaptor as requested by --keep-unsupported flag'
+        );
+        await markAdaptorAsUnsupported(adaptor, repoDir);
+      }
 
       process.exit(1); // TODO what's the correct error code?
     }

--- a/packages/cli/src/metadata/handler.ts
+++ b/packages/cli/src/metadata/handler.ts
@@ -1,20 +1,14 @@
 import { Logger } from '../util/logger';
 import { MetadataOpts } from './command';
 import loadState from '../util/load-state';
-import cache, {
-  isAdaptorUnsupported,
-  markAdaptorAsUnsupported,
-  type AdaptorMetadata,
-  type CachedMetadata,
-  type AdaptorConfiguration,
-} from './cache';
+import * as cache from './cache';
 import { getModuleEntryPoint } from '@openfn/runtime';
 import { ExecutionPlan } from '@openfn/lexicon';
 import { install, removePackage } from '../repo/handler';
 
-// Add extra, uh, metadata to the, uh, metadata object
-const decorateMetadata = (metadata: AdaptorMetadata): void => {
-  (metadata as CachedMetadata).created = new Date().toISOString();
+// Add created date stamp to the metadata object
+const decorateMetadata = (metadata: cache.AdaptorMetadata): void => {
+  (metadata as cache.CachedMetadata).created = new Date().toISOString();
 };
 
 export const getAdaptorPath = async (
@@ -66,7 +60,7 @@ const metadataHandler = async (
   const adaptor = adaptors[0];
 
   // Check cache first to avoid unnecessary downloads
-  if (await isAdaptorUnsupported(adaptor, repoDir)) {
+  if (await cache.isAdaptorUnsupported(adaptor, repoDir)) {
     logger.info(
       `Adaptor ${adaptor} is known to not support metadata (cached) - skipping lookup`
     );
@@ -80,7 +74,7 @@ const metadataHandler = async (
   // Note that the config will be sanitised, so logging it may not be terrible helpful
   logger.info('config:', state);
 
-  const config: AdaptorConfiguration = state.configuration;
+  const config: cache.AdaptorConfiguration = state.configuration;
   if (!config || Object.keys(config).length === 0) {
     logger.error('ERROR: Invalid configuration passed');
     process.exit(1);
@@ -88,14 +82,14 @@ const metadataHandler = async (
 
   const finish = (): void => {
     logger.success('Done!');
-    logger.print(cache.getPath(repoDir, id));
+    logger.print(cache.getCachePath(repoDir, id));
   };
 
   const id = cache.generateKey(config, adaptor);
   if (!options.force) {
     // generate a hash for the config and check state
     logger.debug('config hash: ', id);
-    const cached = await cache.get<CachedMetadata>(repoDir, id);
+    const cached = await cache.get<cache.CachedMetadata>(repoDir, id);
     if (cached) {
       logger.success('Returning metadata from cache');
       return finish();
@@ -119,9 +113,13 @@ const metadataHandler = async (
     // Does it export a metadata function?
     if (mod.metadata && typeof mod.metadata === 'function') {
       logger.info('Metadata function found. Generating metadata...');
-      const result: AdaptorMetadata = await mod.metadata(config);
+      const result: cache.AdaptorMetadata = await mod.metadata(config);
       decorateMetadata(result);
-      await cache.set<CachedMetadata>(repoDir, id, result as CachedMetadata);
+      await cache.set<cache.CachedMetadata>(
+        repoDir,
+        id,
+        result as cache.CachedMetadata
+      );
       finish();
     } else {
       logger.error('No metadata helper found');
@@ -130,13 +128,13 @@ const metadataHandler = async (
       if (wasAutoInstalled && !keepUnsupported) {
         logger.info('Removing unsupported adaptor from disk...');
         await removePackage(adaptor, repoDir, logger);
-        await markAdaptorAsUnsupported(adaptor, repoDir);
+        await cache.markAdaptorAsUnsupported(adaptor, repoDir);
         logger.info('Adaptor removed and marked as unsupported');
       } else if (wasAutoInstalled && keepUnsupported) {
         logger.info(
           'Keeping unsupported adaptor as requested by --keep-unsupported flag'
         );
-        await markAdaptorAsUnsupported(adaptor, repoDir);
+        await cache.markAdaptorAsUnsupported(adaptor, repoDir);
       }
 
       process.exit(1); // TODO what's the correct error code?

--- a/packages/cli/src/metadata/handler.ts
+++ b/packages/cli/src/metadata/handler.ts
@@ -67,7 +67,9 @@ const metadataHandler = async (
 
   // Check cache first to avoid unnecessary downloads
   if (await isAdaptorUnsupported(adaptor, repoDir)) {
-    logger.warn(`Adaptor ${adaptor} is known to not support metadata (cached)`);
+    logger.info(
+      `Adaptor ${adaptor} is known to not support metadata (cached) - skipping lookup`
+    );
     logger.error('No metadata helper found');
     process.exit(1);
   }

--- a/packages/cli/src/metadata/handler.ts
+++ b/packages/cli/src/metadata/handler.ts
@@ -150,7 +150,6 @@ const metadataHandler = async (
       process.exit(1);
     }
   } catch (e) {
-    console.log(e);
     logger.error('Exception while generating metadata');
     logger.error(e);
     process.exit(1);

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -38,6 +38,7 @@ export type Opts = {
   force?: boolean;
   ignoreImports?: boolean | string[];
   immutable?: boolean;
+  keepUnsupported?: boolean;
   log?: Record<string, LogLevel>;
   logJson?: boolean;
   monorepoPath?: string;
@@ -270,6 +271,16 @@ export const force: CLIOption = {
     alias: ['f'],
     boolean: true,
     description: 'Force metadata to be regenerated',
+    default: false,
+  },
+};
+
+export const keepUnsupported: CLIOption = {
+  name: 'keep-unsupported',
+  yargs: {
+    boolean: true,
+    description:
+      'Keep adaptors that do not support metadata (do not remove them)',
     default: false,
   },
 };

--- a/packages/cli/test/metadata/generate-key.test.ts
+++ b/packages/cli/test/metadata/generate-key.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import cache from '../../src/metadata/cache';
+import * as cache from '../../src/metadata/cache';
 
 const eg = {
   adaptor: 'common@1.0.0',

--- a/packages/cli/test/metadata/options.test.ts
+++ b/packages/cli/test/metadata/options.test.ts
@@ -1,0 +1,47 @@
+import test from 'ava';
+import yargs from 'yargs';
+
+import metadata from '../../src/metadata/command';
+
+const cmd = yargs().command(metadata as any);
+
+const parse = (command: string) => cmd.parse(command) as any;
+
+test('metadata: default keepUnsupported should be false', (t) => {
+  const options = parse('metadata -a common');
+  t.is(options.keepUnsupported, false);
+});
+
+test('metadata: keepUnsupported can be set to true', (t) => {
+  const options = parse('metadata -a common --keep-unsupported');
+  t.is(options.keepUnsupported, true);
+});
+
+test('metadata: force option should work', (t) => {
+  const options = parse('metadata -a common --force');
+  t.is(options.force, true);
+});
+
+test('metadata: both force and keepUnsupported can be set', (t) => {
+  const options = parse('metadata -a common --force --keep-unsupported');
+  t.is(options.force, true);
+  t.is(options.keepUnsupported, true);
+});
+
+test('metadata: adaptors option should be set', (t) => {
+  const options = parse('metadata -a common');
+  t.deepEqual(options.adaptors, ['@openfn/language-common']);
+});
+
+test('metadata: multiple adaptors should be handled', (t) => {
+  const options = parse('metadata -a common -a http');
+  t.deepEqual(options.adaptors, [
+    '@openfn/language-common',
+    '@openfn/language-http',
+  ]);
+});
+
+test('metadata: adaptors expansion can be disabled', (t) => {
+  const options = parse('metadata -a common --no-expand-adaptors');
+  t.deepEqual(options.adaptors, ['common']);
+});

--- a/packages/cli/test/metadata/purge-unsupported.test.ts
+++ b/packages/cli/test/metadata/purge-unsupported.test.ts
@@ -1,0 +1,252 @@
+import { createMockLogger } from '@openfn/logger';
+import test from 'ava';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  isAdaptorUnsupported,
+  markAdaptorAsUnsupported,
+  type UnsupportedAdaptorCache,
+} from '../../src/metadata/cache';
+import { removePackage } from '../../src/repo/handler';
+
+const logger = createMockLogger(undefined, { level: 'debug' });
+const testRepoDir = '/tmp/test-purge-repo';
+
+test.beforeEach(async () => {
+  logger._reset();
+  // Ensure clean test directory
+  try {
+    await rm(testRepoDir, { recursive: true, force: true });
+  } catch (e) {
+    // Directory might not exist, that's fine
+  }
+  await mkdir(testRepoDir, { recursive: true });
+});
+
+test.afterEach(async () => {
+  logger._reset();
+  // Cleanup
+  try {
+    await rm(testRepoDir, { recursive: true, force: true });
+  } catch (e) {
+    // Directory might not exist, that's fine
+  }
+});
+
+test.serial(
+  'isAdaptorUnsupported returns false for non-cached adaptors',
+  async (t) => {
+    const result = await isAdaptorUnsupported(
+      '@openfn/language-common@1.0.0',
+      testRepoDir
+    );
+    t.false(result);
+  }
+);
+
+test.serial('markAdaptorAsUnsupported creates cache entry', async (t) => {
+  await markAdaptorAsUnsupported('@openfn/language-common@1.0.0', testRepoDir);
+
+  const cachePath = path.join(
+    testRepoDir,
+    '.cli-cache',
+    'unsupported-metadata.json'
+  );
+  const content = await readFile(cachePath, 'utf8');
+  const cache: UnsupportedAdaptorCache = JSON.parse(content);
+
+  t.truthy(cache['@openfn/language-common']);
+  t.is(cache['@openfn/language-common'].lastCheckedVersion, '1.0.0');
+  t.is(cache['@openfn/language-common'].majorMinor, '1.0');
+});
+
+test.serial(
+  'isAdaptorUnsupported returns true for cached same/lower versions',
+  async (t) => {
+    // Mark 1.5.0 as unsupported
+    await markAdaptorAsUnsupported(
+      '@openfn/language-common@1.5.0',
+      testRepoDir
+    );
+
+    // Check 1.5.0 - should be unsupported
+    t.true(
+      await isAdaptorUnsupported('@openfn/language-common@1.5.0', testRepoDir)
+    );
+
+    // Check 1.5.1 (patch increase) - should be unsupported
+    t.true(
+      await isAdaptorUnsupported('@openfn/language-common@1.5.1', testRepoDir)
+    );
+
+    // Check 1.4.9 (lower version) - should be unsupported
+    t.true(
+      await isAdaptorUnsupported('@openfn/language-common@1.4.9', testRepoDir)
+    );
+  }
+);
+
+test.serial(
+  'isAdaptorUnsupported returns false for higher major.minor versions',
+  async (t) => {
+    // Mark 1.5.0 as unsupported
+    await markAdaptorAsUnsupported(
+      '@openfn/language-common@1.5.0',
+      testRepoDir
+    );
+
+    // Check 1.6.0 (minor increase) - should NOT be unsupported
+    t.false(
+      await isAdaptorUnsupported('@openfn/language-common@1.6.0', testRepoDir)
+    );
+
+    // Check 2.0.0 (major increase) - should NOT be unsupported
+    t.false(
+      await isAdaptorUnsupported('@openfn/language-common@2.0.0', testRepoDir)
+    );
+  }
+);
+
+test.serial(
+  'markAdaptorAsUnsupported only updates with higher versions',
+  async (t) => {
+    // Mark 1.5.0 as unsupported
+    await markAdaptorAsUnsupported(
+      '@openfn/language-common@1.5.0',
+      testRepoDir
+    );
+
+    // Try to mark 1.4.0 as unsupported (should not update)
+    await markAdaptorAsUnsupported(
+      '@openfn/language-common@1.4.0',
+      testRepoDir
+    );
+
+    const cachePath = path.join(
+      testRepoDir,
+      '.cli-cache',
+      'unsupported-metadata.json'
+    );
+    const content = await readFile(cachePath, 'utf8');
+    const cache: UnsupportedAdaptorCache = JSON.parse(content);
+
+    // Should still be 1.5.0, not 1.4.0
+    t.is(cache['@openfn/language-common'].lastCheckedVersion, '1.5.0');
+
+    // Mark 1.6.0 as unsupported (should update)
+    await markAdaptorAsUnsupported(
+      '@openfn/language-common@1.6.0',
+      testRepoDir
+    );
+
+    const updatedContent = await readFile(cachePath, 'utf8');
+    const updatedCache: UnsupportedAdaptorCache = JSON.parse(updatedContent);
+
+    // Should now be 1.6.0
+    t.is(updatedCache['@openfn/language-common'].lastCheckedVersion, '1.6.0');
+    t.is(updatedCache['@openfn/language-common'].majorMinor, '1.6');
+  }
+);
+
+test.serial('should mark adaptor as unsupported in cache', async (t) => {
+  const adaptor = '@openfn/language-test@1.5.2';
+
+  await markAdaptorAsUnsupported(adaptor, testRepoDir);
+
+  const isUnsupported = await isAdaptorUnsupported(adaptor, testRepoDir);
+  t.true(isUnsupported);
+});
+
+test.serial('should retry on minor version bump', async (t) => {
+  const oldAdaptor = '@openfn/language-test@1.5.2';
+  const newAdaptor = '@openfn/language-test@1.6.0';
+
+  // Mark 1.5.2 as unsupported
+  await markAdaptorAsUnsupported(oldAdaptor, testRepoDir);
+
+  // 1.5.2 should be unsupported
+  t.true(await isAdaptorUnsupported(oldAdaptor, testRepoDir));
+
+  // 1.6.0 should NOT be unsupported (should retry)
+  t.false(await isAdaptorUnsupported(newAdaptor, testRepoDir));
+});
+
+test.serial('should not retry on patch version change', async (t) => {
+  const oldAdaptor = '@openfn/language-test@1.5.2';
+  const patchAdaptor = '@openfn/language-test@1.5.3';
+
+  // Mark 1.5.2 as unsupported
+  await markAdaptorAsUnsupported(oldAdaptor, testRepoDir);
+
+  // 1.5.3 should also be unsupported (same major.minor)
+  t.true(await isAdaptorUnsupported(patchAdaptor, testRepoDir));
+});
+
+test.serial('should not retry on lower version', async (t) => {
+  const higherAdaptor = '@openfn/language-test@1.5.2';
+  const lowerAdaptor = '@openfn/language-test@1.5.1';
+
+  // Mark 1.5.2 as unsupported
+  await markAdaptorAsUnsupported(higherAdaptor, testRepoDir);
+
+  // 1.5.1 should also be unsupported (lower patch)
+  t.true(await isAdaptorUnsupported(lowerAdaptor, testRepoDir));
+});
+
+test.serial('should handle major version bump correctly', async (t) => {
+  const v1Adaptor = '@openfn/language-test@1.5.2';
+  const v2Adaptor = '@openfn/language-test@2.0.0';
+
+  // Mark 1.5.2 as unsupported
+  await markAdaptorAsUnsupported(v1Adaptor, testRepoDir);
+
+  // 2.0.0 should NOT be unsupported (should retry)
+  t.false(await isAdaptorUnsupported(v2Adaptor, testRepoDir));
+});
+
+test.serial('should only cache highest version checked', async (t) => {
+  const lowerAdaptor = '@openfn/language-test@1.5.1';
+  const higherAdaptor = '@openfn/language-test@1.5.2';
+
+  // Mark lower version as unsupported first
+  await markAdaptorAsUnsupported(lowerAdaptor, testRepoDir);
+
+  // Then mark higher version as unsupported
+  await markAdaptorAsUnsupported(higherAdaptor, testRepoDir);
+
+  // Check cache file directly
+  const cachePath = path.join(
+    testRepoDir,
+    '.cli-cache',
+    'unsupported-metadata.json'
+  );
+  const cacheContent = await readFile(cachePath, 'utf8');
+  const cache = JSON.parse(cacheContent);
+
+  // Should have cached the higher version
+  t.is(cache['@openfn/language-test'].lastCheckedVersion, '1.5.2');
+});
+
+test.serial(
+  'removePackage should handle non-existent package gracefully',
+  async (t) => {
+    // Create a minimal package.json
+    const packageJson = {
+      name: 'test-repo',
+      dependencies: {},
+    };
+    await writeFile(
+      path.join(testRepoDir, 'package.json'),
+      JSON.stringify(packageJson, null, 2)
+    );
+
+    // Should not throw when trying to remove non-existent package
+    await t.notThrowsAsync(async () => {
+      await removePackage(
+        '@openfn/language-nonexistent@1.0.0',
+        testRepoDir,
+        logger
+      );
+    });
+  }
+);

--- a/packages/cli/test/metadata/purge-unsupported.test.ts
+++ b/packages/cli/test/metadata/purge-unsupported.test.ts
@@ -1,8 +1,9 @@
 import { createMockLogger } from '@openfn/logger';
 import test from 'ava';
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
+  getUnsupportedCache,
   isAdaptorUnsupported,
   markAdaptorAsUnsupported,
   type UnsupportedAdaptorCache,
@@ -13,24 +14,70 @@ const logger = createMockLogger(undefined, { level: 'debug' });
 const testRepoDir = '/tmp/test-purge-repo';
 
 test.beforeEach(async () => {
-  logger._reset();
-  // Ensure clean test directory
-  try {
-    await rm(testRepoDir, { recursive: true, force: true });
-  } catch (e) {
-    // Directory might not exist, that's fine
-  }
+  await rm(testRepoDir, { recursive: true, force: true });
   await mkdir(testRepoDir, { recursive: true });
 });
 
 test.afterEach(async () => {
   logger._reset();
-  // Cleanup
-  try {
-    await rm(testRepoDir, { recursive: true, force: true });
-  } catch (e) {
-    // Directory might not exist, that's fine
+  await rm(testRepoDir, { recursive: true, force: true });
+});
+
+const getTestCache = async () =>
+  (await getUnsupportedCache(testRepoDir)) as UnsupportedAdaptorCache;
+
+test.serial('markAdaptorAsUnsupported creates cache entry', async (t) => {
+  await markAdaptorAsUnsupported('@openfn/language-common@1.0.0', testRepoDir);
+
+  const cache = await getTestCache();
+
+  t.truthy(cache['@openfn/language-common']);
+  t.is(cache['@openfn/language-common'].lastCheckedVersion, '1.0.0');
+  t.is(cache['@openfn/language-common'].majorMinor, '1.0');
+});
+
+test.serial(
+  'markAdaptorAsUnsupported only updates with higher versions',
+  async (t) => {
+    await markAdaptorAsUnsupported(
+      '@openfn/language-common@1.5.0',
+      testRepoDir
+    );
+
+    let cache = await getTestCache();
+    t.is(cache['@openfn/language-common'].lastCheckedVersion, '1.5.0');
+
+    // Try to mark 1.4.0 as unsupported (should not update)
+    await markAdaptorAsUnsupported(
+      '@openfn/language-common@1.4.0',
+      testRepoDir
+    );
+
+    cache = await getTestCache();
+
+    // Should still be 1.5.0, not 1.4.0
+    t.is(cache['@openfn/language-common'].lastCheckedVersion, '1.5.0');
+
+    // Mark 1.6.0 as unsupported  - this should update
+    await markAdaptorAsUnsupported(
+      '@openfn/language-common@1.6.0',
+      testRepoDir
+    );
+
+    cache = await getTestCache();
+
+    t.is(cache['@openfn/language-common'].lastCheckedVersion, '1.6.0');
+    t.is(cache['@openfn/language-common'].majorMinor, '1.6');
   }
+);
+
+test.serial('should mark adaptor as unsupported in cache', async (t) => {
+  const adaptor = '@openfn/language-test@1.5.2';
+
+  await markAdaptorAsUnsupported(adaptor, testRepoDir);
+
+  const isUnsupported = await isAdaptorUnsupported(adaptor, testRepoDir);
+  t.true(isUnsupported);
 });
 
 test.serial(
@@ -44,42 +91,27 @@ test.serial(
   }
 );
 
-test.serial('markAdaptorAsUnsupported creates cache entry', async (t) => {
-  await markAdaptorAsUnsupported('@openfn/language-common@1.0.0', testRepoDir);
-
-  const cachePath = path.join(
-    testRepoDir,
-    '.cli-cache',
-    'unsupported-metadata.json'
-  );
-  const content = await readFile(cachePath, 'utf8');
-  const cache: UnsupportedAdaptorCache = JSON.parse(content);
-
-  t.truthy(cache['@openfn/language-common']);
-  t.is(cache['@openfn/language-common'].lastCheckedVersion, '1.0.0');
-  t.is(cache['@openfn/language-common'].majorMinor, '1.0');
-});
-
 test.serial(
-  'isAdaptorUnsupported returns true for cached same/lower versions',
+  'isAdaptorUnsupported returns true if the same adaptor version has been marked as unsupported',
   async (t) => {
-    // Mark 1.5.0 as unsupported
     await markAdaptorAsUnsupported(
       '@openfn/language-common@1.5.0',
       testRepoDir
     );
 
-    // Check 1.5.0 - should be unsupported
     t.true(
       await isAdaptorUnsupported('@openfn/language-common@1.5.0', testRepoDir)
     );
+  }
+);
 
-    // Check 1.5.1 (patch increase) - should be unsupported
-    t.true(
-      await isAdaptorUnsupported('@openfn/language-common@1.5.1', testRepoDir)
+test.serial(
+  'isAdaptorUnsupported returns true if a higher version was marked unsupported',
+  async (t) => {
+    await markAdaptorAsUnsupported(
+      '@openfn/language-common@1.5.0',
+      testRepoDir
     );
-
-    // Check 1.4.9 (lower version) - should be unsupported
     t.true(
       await isAdaptorUnsupported('@openfn/language-common@1.4.9', testRepoDir)
     );
@@ -87,122 +119,35 @@ test.serial(
 );
 
 test.serial(
-  'isAdaptorUnsupported returns false for higher major.minor versions',
+  'isAdaptorUnsupported returns true if a lower patch version was marked unsupported',
   async (t) => {
-    // Mark 1.5.0 as unsupported
     await markAdaptorAsUnsupported(
       '@openfn/language-common@1.5.0',
       testRepoDir
     );
-
-    // Check 1.6.0 (minor increase) - should NOT be unsupported
-    t.false(
-      await isAdaptorUnsupported('@openfn/language-common@1.6.0', testRepoDir)
-    );
-
-    // Check 2.0.0 (major increase) - should NOT be unsupported
-    t.false(
-      await isAdaptorUnsupported('@openfn/language-common@2.0.0', testRepoDir)
+    t.true(
+      await isAdaptorUnsupported('@openfn/language-common@1.4.9', testRepoDir)
     );
   }
 );
 
 test.serial(
-  'markAdaptorAsUnsupported only updates with higher versions',
+  'isAdaptorUnsupported returns false if a lower version major & minor was marked unsupported',
   async (t) => {
-    // Mark 1.5.0 as unsupported
     await markAdaptorAsUnsupported(
       '@openfn/language-common@1.5.0',
       testRepoDir
     );
 
-    // Try to mark 1.4.0 as unsupported (should not update)
-    await markAdaptorAsUnsupported(
-      '@openfn/language-common@1.4.0',
-      testRepoDir
+    t.false(
+      await isAdaptorUnsupported('@openfn/language-common@1.6.0', testRepoDir)
     );
 
-    const cachePath = path.join(
-      testRepoDir,
-      '.cli-cache',
-      'unsupported-metadata.json'
+    t.false(
+      await isAdaptorUnsupported('@openfn/language-common@2.0.0', testRepoDir)
     );
-    const content = await readFile(cachePath, 'utf8');
-    const cache: UnsupportedAdaptorCache = JSON.parse(content);
-
-    // Should still be 1.5.0, not 1.4.0
-    t.is(cache['@openfn/language-common'].lastCheckedVersion, '1.5.0');
-
-    // Mark 1.6.0 as unsupported (should update)
-    await markAdaptorAsUnsupported(
-      '@openfn/language-common@1.6.0',
-      testRepoDir
-    );
-
-    const updatedContent = await readFile(cachePath, 'utf8');
-    const updatedCache: UnsupportedAdaptorCache = JSON.parse(updatedContent);
-
-    // Should now be 1.6.0
-    t.is(updatedCache['@openfn/language-common'].lastCheckedVersion, '1.6.0');
-    t.is(updatedCache['@openfn/language-common'].majorMinor, '1.6');
   }
 );
-
-test.serial('should mark adaptor as unsupported in cache', async (t) => {
-  const adaptor = '@openfn/language-test@1.5.2';
-
-  await markAdaptorAsUnsupported(adaptor, testRepoDir);
-
-  const isUnsupported = await isAdaptorUnsupported(adaptor, testRepoDir);
-  t.true(isUnsupported);
-});
-
-test.serial('should retry on minor version bump', async (t) => {
-  const oldAdaptor = '@openfn/language-test@1.5.2';
-  const newAdaptor = '@openfn/language-test@1.6.0';
-
-  // Mark 1.5.2 as unsupported
-  await markAdaptorAsUnsupported(oldAdaptor, testRepoDir);
-
-  // 1.5.2 should be unsupported
-  t.true(await isAdaptorUnsupported(oldAdaptor, testRepoDir));
-
-  // 1.6.0 should NOT be unsupported (should retry)
-  t.false(await isAdaptorUnsupported(newAdaptor, testRepoDir));
-});
-
-test.serial('should not retry on patch version change', async (t) => {
-  const oldAdaptor = '@openfn/language-test@1.5.2';
-  const patchAdaptor = '@openfn/language-test@1.5.3';
-
-  // Mark 1.5.2 as unsupported
-  await markAdaptorAsUnsupported(oldAdaptor, testRepoDir);
-
-  // 1.5.3 should also be unsupported (same major.minor)
-  t.true(await isAdaptorUnsupported(patchAdaptor, testRepoDir));
-});
-
-test.serial('should not retry on lower version', async (t) => {
-  const higherAdaptor = '@openfn/language-test@1.5.2';
-  const lowerAdaptor = '@openfn/language-test@1.5.1';
-
-  // Mark 1.5.2 as unsupported
-  await markAdaptorAsUnsupported(higherAdaptor, testRepoDir);
-
-  // 1.5.1 should also be unsupported (lower patch)
-  t.true(await isAdaptorUnsupported(lowerAdaptor, testRepoDir));
-});
-
-test.serial('should handle major version bump correctly', async (t) => {
-  const v1Adaptor = '@openfn/language-test@1.5.2';
-  const v2Adaptor = '@openfn/language-test@2.0.0';
-
-  // Mark 1.5.2 as unsupported
-  await markAdaptorAsUnsupported(v1Adaptor, testRepoDir);
-
-  // 2.0.0 should NOT be unsupported (should retry)
-  t.false(await isAdaptorUnsupported(v2Adaptor, testRepoDir));
-});
 
 test.serial('should only cache highest version checked', async (t) => {
   const lowerAdaptor = '@openfn/language-test@1.5.1';
@@ -214,14 +159,7 @@ test.serial('should only cache highest version checked', async (t) => {
   // Then mark higher version as unsupported
   await markAdaptorAsUnsupported(higherAdaptor, testRepoDir);
 
-  // Check cache file directly
-  const cachePath = path.join(
-    testRepoDir,
-    '.cli-cache',
-    'unsupported-metadata.json'
-  );
-  const cacheContent = await readFile(cachePath, 'utf8');
-  const cache = JSON.parse(cacheContent);
+  const cache = await getTestCache();
 
   // Should have cached the higher version
   t.is(cache['@openfn/language-test'].lastCheckedVersion, '1.5.2');

--- a/packages/cli/test/metadata/sort-keys.test.ts
+++ b/packages/cli/test/metadata/sort-keys.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import cache from '../../src/metadata/cache';
+import * as cache from '../../src/metadata/cache';
 
 test('sort keys', (t) => {
   const sorted = cache.sortKeys({

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # engine-multi
 
+## 1.6.8
+
+### Patch Changes
+
+- Updated dependencies [f04acef]
+  - @openfn/runtime@1.7.1
+
 ## 1.6.7
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/lightning-mock
 
+## 2.2.2
+
+### Patch Changes
+
+- Updated dependencies [f04acef]
+  - @openfn/runtime@1.7.1
+  - @openfn/engine-multi@1.6.8
+
 ## 2.2.1
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -25,6 +25,7 @@
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",
   "devDependencies": {
+    "@types/mock-fs": "~4.13.4",
     "ava": "5.3.1",
     "mock-fs": "^5.4.1",
     "rimraf": "^3.0.2",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/runtime
 
+## 1.7.1
+
+### Patch Changes
+
+- f04acef: Fix an issue reading package.json on autoinstalled adaptors
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Job processing runtime.",
   "type": "module",
   "exports": {

--- a/packages/runtime/src/modules/repo.ts
+++ b/packages/runtime/src/modules/repo.ts
@@ -193,7 +193,7 @@ const getRepoAlias = async (
     // TODO: fuzzy semver match
     const a = getAliasedName(specifier);
     const pkg = await loadRepoPkg(repoPath);
-    if (pkg && pkg.dependencies[a]) {
+    if (pkg && pkg.dependencies && pkg.dependencies[a]) {
       return a;
     }
   } else {

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ws-worker
 
+## 1.14.2
+
+### Patch Changes
+
+- Updated dependencies [f04acef]
+  - @openfn/runtime@1.7.1
+  - @openfn/engine-multi@1.6.8
+
 ## 1.14.1
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@types/rimraf':
         specifier: ^3.0.2
         version: 3.0.2
+      '@types/semver':
+        specifier: ~7.5.8
+        version: 7.5.8
       '@types/tar-stream':
         specifier: ^2.2.2
         version: 2.2.3
@@ -464,18 +467,6 @@ importers:
         specifier: ^5.1.6
         version: 5.7.2
 
-  packages/engine-multi/tmp/a/b/c:
-    dependencies:
-      ava:
-        specifier: '6'
-        version: 6.4.0
-
-  packages/engine-multi/tmp/repo:
-    dependencies:
-      ava:
-        specifier: '6'
-        version: 6.4.0
-
   packages/lexicon:
     dependencies:
       source-map:
@@ -629,6 +620,9 @@ importers:
         specifier: ^2.2.2
         version: 2.6.1
     devDependencies:
+      '@types/mock-fs':
+        specifier: ~4.13.4
+        version: 4.13.4
       ava:
         specifier: 5.3.1
         version: 5.3.1
@@ -2100,13 +2094,6 @@ packages:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: /wrap-ansi@7.0.0
 
-  /@isaacs/fs-minipass@4.0.1:
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      minipass: 7.1.2
-    dev: false
-
   /@jridgewell/gen-mapping@0.3.8:
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
@@ -2194,23 +2181,6 @@ packages:
       globby: 11.1.0
       read-yaml-file: 1.1.0
     dev: true
-
-  /@mapbox/node-pre-gyp@2.0.0:
-    resolution: {integrity: sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==}
-    engines: {node: '>=18'}
-    hasBin: true
-    dependencies:
-      consola: 3.4.2
-      detect-libc: 2.0.4
-      https-proxy-agent: 7.0.6
-      node-fetch: 2.7.0
-      nopt: 8.1.0
-      semver: 7.6.3
-      tar: 7.4.3
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
 
   /@napi-rs/wasm-runtime@0.2.9:
     resolution: {integrity: sha512-OKRBiajrrxB9ATokgEQoG87Z25c67pCpYcCwmXYX8PBftC9pBfN18gnm/fh1wurSLEKIAt+QRFLFCQISrb66Jg==}
@@ -2815,6 +2785,7 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
     requiresBuild: true
+    dev: true
     optional: true
 
   /@prisma/instrumentation@6.4.1(@opentelemetry/api@1.9.0):
@@ -2826,20 +2797,6 @@ packages:
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@rollup/pluginutils@5.1.4:
-    resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@types/estree': 1.0.6
-      estree-walker: 2.0.2
-      picomatch: 4.0.2
     dev: false
 
   /@rollup/rollup-android-arm-eabi@4.28.1:
@@ -3059,11 +3016,6 @@ packages:
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.30.0
       '@sentry/core': 9.5.0
-    dev: false
-
-  /@sindresorhus/merge-streams@2.3.0:
-    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
-    engines: {node: '>=18'}
     dev: false
 
   /@slack/logger@3.0.0:
@@ -3322,6 +3274,7 @@ packages:
 
   /@types/estree@1.0.6:
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+    dev: true
 
   /@types/express-serve-static-core@5.0.2:
     resolution: {integrity: sha512-vluaspfvWEtE4vcSDlKRNer52DvOGrB2xv6diXy6UKyKW0lqZiWHGNApSyxOv+8DE5Z27IzVvE7hNkxg7EXIcg==}
@@ -3601,34 +3554,6 @@ packages:
       - supports-color
     dev: false
 
-  /@vercel/nft@0.29.4:
-    resolution: {integrity: sha512-6lLqMNX3TuycBPABycx7A9F1bHQR7kiQln6abjFbPrf5C/05qHM9M5E4PeTE59c7z8g6vHnx1Ioihb2AQl7BTA==}
-    engines: {node: '>=18'}
-    hasBin: true
-    dependencies:
-      '@mapbox/node-pre-gyp': 2.0.0
-      '@rollup/pluginutils': 5.1.4
-      acorn: 8.15.0
-      acorn-import-attributes: 1.9.5(acorn@8.15.0)
-      async-sema: 3.1.1
-      bindings: 1.5.0
-      estree-walker: 2.0.2
-      glob: 10.4.5
-      graceful-fs: 4.2.11
-      node-gyp-build: 4.8.4
-      picomatch: 4.0.2
-      resolve-from: 5.0.0
-    transitivePeerDependencies:
-      - encoding
-      - rollup
-      - supports-color
-    dev: false
-
-  /abbrev@3.0.1:
-    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-    dev: false
-
   /accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -3644,14 +3569,6 @@ packages:
       acorn: 8.14.0
     dev: false
 
-  /acorn-import-attributes@1.9.5(acorn@8.15.0):
-    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
-    peerDependencies:
-      acorn: ^8
-    dependencies:
-      acorn: 8.15.0
-    dev: false
-
   /acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
@@ -3663,15 +3580,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  /acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-    dev: false
-
   /agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
+    dev: true
 
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -3794,10 +3706,6 @@ packages:
     dependencies:
       tslib: 2.8.1
 
-  /async-sema@3.1.1:
-    resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
-    dev: false
-
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
     dev: true
@@ -3917,62 +3825,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /ava@6.4.0:
-    resolution: {integrity: sha512-aeFapuBZtaGwVMlFFf074SZJ0bPcdmAdJdsvhHMp+XaOnC2DgeMzopb7yyYAhulNGRJQfUK/SIBYo2PoX7+gtw==}
-    engines: {node: ^18.18 || ^20.8 || ^22 || ^23 || >=24}
-    hasBin: true
-    peerDependencies:
-      '@ava/typescript': '*'
-    peerDependenciesMeta:
-      '@ava/typescript':
-        optional: true
-    dependencies:
-      '@vercel/nft': 0.29.4
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      ansi-styles: 6.2.1
-      arrgv: 1.0.2
-      arrify: 3.0.0
-      callsites: 4.2.0
-      cbor: 10.0.3
-      chalk: 5.4.1
-      chunkd: 2.0.1
-      ci-info: 4.2.0
-      ci-parallel-vars: 1.0.1
-      cli-truncate: 4.0.0
-      code-excerpt: 4.0.0
-      common-path-prefix: 3.0.0
-      concordance: 5.0.4
-      currently-unhandled: 0.4.1
-      debug: 4.4.1
-      emittery: 1.1.0
-      figures: 6.1.0
-      globby: 14.1.0
-      ignore-by-default: 2.1.0
-      indent-string: 5.0.0
-      is-plain-object: 5.0.0
-      is-promise: 4.0.0
-      matcher: 5.0.0
-      memoize: 10.1.0
-      ms: 2.1.3
-      p-map: 7.0.3
-      package-config: 5.0.0
-      picomatch: 4.0.2
-      plur: 5.1.0
-      pretty-ms: 9.2.0
-      resolve-cwd: 3.0.0
-      stack-utils: 2.0.6
-      strip-ansi: 7.1.0
-      supertap: 3.0.1
-      temp-dir: 3.0.0
-      write-file-atomic: 6.0.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - encoding
-      - rollup
-      - supports-color
-    dev: false
-
   /awilix@10.0.2:
     resolution: {integrity: sha512-hFatb7eZFdtiWjjmGRSm/K/uxZpmcBlM+YoeMB3VpOPXk3xa6+7zctg3LRbUzoimom5bwGrePF0jXReO6b4zNQ==}
     engines: {node: '>=14.0.0'}
@@ -4018,12 +3870,6 @@ packages:
   /binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  /bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-    dependencies:
-      file-uri-to-path: 1.0.0
-    dev: false
 
   /bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -4187,13 +4033,6 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /cbor@10.0.3:
-    resolution: {integrity: sha512-72Jnj81xMsqepqdcSdf2+fflz/UDsThOHy5hj2MW5F5xzHL8Oa0KQ6I6V9CwVUPxg5pf+W9xp6W2KilaRXWWtw==}
-    engines: {node: '>=18'}
-    dependencies:
-      nofilter: 3.1.0
-    dev: false
-
   /cbor@8.1.0:
     resolution: {integrity: sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==}
     engines: {node: '>=12.19'}
@@ -4219,11 +4058,6 @@ packages:
   /chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
-  /chalk@5.4.1:
-    resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: false
 
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
@@ -4275,22 +4109,12 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
-    dev: false
-
   /chunkd@2.0.1:
     resolution: {integrity: sha512-7d58XsFmOq0j6el67Ug9mHf9ELUXsQXYJBkyxhH/k+6Ke0qXRnv0kbemx+Twc6fRJ07C49lcbdgm9FL1Ei/6SQ==}
 
   /ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
-
-  /ci-info@4.2.0:
-    resolution: {integrity: sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==}
-    engines: {node: '>=8'}
-    dev: false
 
   /ci-parallel-vars@1.0.1:
     resolution: {integrity: sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==}
@@ -4331,14 +4155,6 @@ packages:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 5.1.2
-
-  /cli-truncate@4.0.0:
-    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
-    engines: {node: '>=18'}
-    dependencies:
-      slice-ansi: 5.0.0
-      string-width: 7.2.0
-    dev: false
 
   /cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -4437,11 +4253,6 @@ packages:
       md5-hex: 3.0.1
       semver: 7.6.3
       well-known-symbols: 2.0.0
-
-  /consola@3.4.2:
-    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
-    engines: {node: ^14.18.0 || >=16.10.0}
-    dev: false
 
   /content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -4607,18 +4418,6 @@ packages:
     dependencies:
       ms: 2.1.3
 
-  /debug@4.4.1:
-    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.3
-    dev: false
-
   /decode-uri-component@0.4.1:
     resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
     engines: {node: '>=14.16'}
@@ -4678,11 +4477,6 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
     dev: true
-
-  /detect-libc@2.0.4:
-    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
-    engines: {node: '>=8'}
-    dev: false
 
   /didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -4763,15 +4557,6 @@ packages:
   /emittery@1.0.3:
     resolution: {integrity: sha512-tJdCJitoy2lrC2ldJcqN4vkqJ00lT+tOWNT1hBJjO/3FDMJa5TTIiYGCKGkn/WfCyOzUMObeohbVTj00fhiLiA==}
     engines: {node: '>=14.16'}
-
-  /emittery@1.1.0:
-    resolution: {integrity: sha512-rsX7ktqARv/6UQDgMaLfIqUWAEzzbCQiVh7V9rhDXp6c37yoJcks12NVD+XPkgl4AEavmNhVfrhGoqYwIsMYYA==}
-    engines: {node: '>=14.16'}
-    dev: false
-
-  /emoji-regex@10.4.0:
-    resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
-    dev: false
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -5247,10 +5032,6 @@ packages:
     engines: {node: '>=4.0'}
     dev: true
 
-  /estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: false
-
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -5354,17 +5135,6 @@ packages:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  /fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-    dev: false
-
   /fast-json-patch@3.1.1:
     resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
     dev: false
@@ -5399,17 +5169,6 @@ packages:
       escape-string-regexp: 5.0.0
       is-unicode-supported: 1.3.0
 
-  /figures@6.1.0:
-    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
-    engines: {node: '>=18'}
-    dependencies:
-      is-unicode-supported: 2.1.0
-    dev: false
-
-  /file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-    dev: false
-
   /fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -5435,11 +5194,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /find-up-simple@1.0.1:
-    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
-    engines: {node: '>=18'}
-    dev: false
 
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -5554,11 +5308,6 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  /get-east-asian-width@1.3.0:
-    resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
-    engines: {node: '>=18'}
-    dev: false
-
   /get-intrinsic@1.2.6:
     resolution: {integrity: sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==}
     engines: {node: '>= 0.4'}
@@ -5608,6 +5357,7 @@ packages:
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
+    dev: true
 
   /glob@11.0.2:
     resolution: {integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==}
@@ -5655,24 +5405,13 @@ packages:
       merge2: 1.4.1
       slash: 4.0.0
 
-  /globby@14.1.0:
-    resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
-    engines: {node: '>=18'}
-    dependencies:
-      '@sindresorhus/merge-streams': 2.3.0
-      fast-glob: 3.3.3
-      ignore: 7.0.5
-      path-type: 6.0.0
-      slash: 5.1.0
-      unicorn-magic: 0.3.0
-    dev: false
-
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    dev: true
 
   /gunzip-maybe@1.4.2:
     resolution: {integrity: sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==}
@@ -5785,6 +5524,7 @@ packages:
       debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /human-id@1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
@@ -5834,11 +5574,6 @@ packages:
   /ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
-
-  /ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
-    engines: {node: '>= 4'}
-    dev: false
 
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -6020,11 +5755,6 @@ packages:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
     engines: {node: '>=12'}
 
-  /is-unicode-supported@2.1.0:
-    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
-    engines: {node: '>=18'}
-    dev: false
-
   /is-utf8@0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
 
@@ -6050,6 +5780,7 @@ packages:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+    dev: true
 
   /jackspeak@4.1.0:
     resolution: {integrity: sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==}
@@ -6321,6 +6052,7 @@ packages:
 
   /lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+    dev: true
 
   /lru-cache@11.1.0:
     resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
@@ -6384,13 +6116,6 @@ packages:
       map-age-cleaner: 0.1.3
       mimic-fn: 4.0.0
 
-  /memoize@10.1.0:
-    resolution: {integrity: sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==}
-    engines: {node: '>=18'}
-    dependencies:
-      mimic-function: 5.0.1
-    dev: false
-
   /merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
     dev: true
@@ -6439,11 +6164,6 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
-  /mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
-    dev: false
-
   /mini-svg-data-uri@1.4.4:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
@@ -6466,6 +6186,7 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
+    dev: true
 
   /minipass-collect@2.0.1:
     resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
@@ -6530,24 +6251,11 @@ packages:
       yallist: 4.0.0
     dev: true
 
-  /minizlib@3.0.2:
-    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
-    engines: {node: '>= 18'}
-    dependencies:
-      minipass: 7.1.2
-    dev: false
-
   /mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
     dev: true
-
-  /mkdirp@3.0.1:
-    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: false
 
   /mock-fs@5.4.1:
     resolution: {integrity: sha512-sz/Q8K1gXXXHR+qr0GZg2ysxCRr323kuN10O7CtQjraJsFDJ4SJ+0I5MzALz7aRp9lHk8Cc/YdsT95h9Ka1aFw==}
@@ -6622,11 +6330,6 @@ packages:
       whatwg-url: 5.0.0
     dev: false
 
-  /node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
-    hasBin: true
-    dev: false
-
   /nodemon@3.0.1:
     resolution: {integrity: sha512-g9AZ7HmkhQkqXkRc20w+ZfQ73cHLbE8hnPbtaFbFtCumZsjyMhKk9LajQ07U5Ux28lvFjZ5X7HvWR1xzU8jHVw==}
     engines: {node: '>=10'}
@@ -6647,14 +6350,6 @@ packages:
   /nofilter@3.1.0:
     resolution: {integrity: sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==}
     engines: {node: '>=12.19'}
-
-  /nopt@8.1.0:
-    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-    hasBin: true
-    dependencies:
-      abbrev: 3.0.1
-    dev: false
 
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -6856,11 +6551,6 @@ packages:
     dependencies:
       aggregate-error: 4.0.1
 
-  /p-map@7.0.3:
-    resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
-    engines: {node: '>=18'}
-    dev: false
-
   /p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
     engines: {node: '>=8'}
@@ -6893,14 +6583,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /package-config@5.0.0:
-    resolution: {integrity: sha512-GYTTew2slBcYdvRHqjhwaaydVMvn/qrGC323+nKclYioNSLTDUM/lGgtGTgyHVtYcozb+XkE8CNhwcraOmZ9Mg==}
-    engines: {node: '>=18'}
-    dependencies:
-      find-up-simple: 1.0.1
-      load-json-file: 7.0.1
-    dev: false
-
   /package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -6932,11 +6614,6 @@ packages:
   /parse-ms@3.0.0:
     resolution: {integrity: sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==}
     engines: {node: '>=12'}
-
-  /parse-ms@4.0.0:
-    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
-    engines: {node: '>=18'}
-    dev: false
 
   /parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
@@ -6992,6 +6669,7 @@ packages:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+    dev: true
 
   /path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
@@ -7018,11 +6696,6 @@ packages:
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-
-  /path-type@6.0.0:
-    resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
-    engines: {node: '>=18'}
-    dev: false
 
   /peek-stream@1.1.3:
     resolution: {integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==}
@@ -7063,11 +6736,6 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-
-  /picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
-    dev: false
 
   /pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -7239,13 +6907,6 @@ packages:
     engines: {node: '>=14.16'}
     dependencies:
       parse-ms: 3.0.0
-
-  /pretty-ms@9.2.0:
-    resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
-    engines: {node: '>=18'}
-    dependencies:
-      parse-ms: 4.0.0
-    dev: false
 
   /proc-log@4.2.0:
     resolution: {integrity: sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==}
@@ -7693,11 +7354,6 @@ packages:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
 
-  /slash@5.1.0:
-    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
-    engines: {node: '>=14.16'}
-    dev: false
-
   /slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
@@ -7844,15 +7500,6 @@ packages:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
 
-  /string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-    dependencies:
-      emoji-regex: 10.4.0
-      get-east-asian-width: 1.3.0
-      strip-ansi: 7.1.0
-    dev: false
-
   /string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
     dependencies:
@@ -7982,18 +7629,6 @@ packages:
       mkdirp: 1.0.4
       yallist: 4.0.0
     dev: true
-
-  /tar@7.4.3:
-    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
-    engines: {node: '>=18'}
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.2
-      minizlib: 3.0.2
-      mkdirp: 3.0.1
-      yallist: 5.0.0
-    dev: false
 
   /temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
@@ -8318,11 +7953,6 @@ packages:
     engines: {node: '>=20.18.1'}
     dev: false
 
-  /unicorn-magic@0.3.0:
-    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
-    engines: {node: '>=18'}
-    dev: false
-
   /unique-filename@3.0.0:
     resolution: {integrity: sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -8457,14 +8087,6 @@ packages:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  /write-file-atomic@6.0.0:
-    resolution: {integrity: sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-    dependencies:
-      imurmurhash: 0.1.4
-      signal-exit: 4.1.0
-    dev: false
-
   /ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
@@ -8488,11 +8110,6 @@ packages:
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
-
-  /yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
-    dev: false
 
   /yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}


### PR DESCRIPTION
## Short Description

When Lightning requests metadata via the CLI, adaptors that don't support metadata are downloaded but never removed, wasting space and causing issues in container environments.

Fixes #952
Re: OpenFn/lightning#3351

## Implementation Details

- Removes adaptors that don't support metadata after download
- Remembers unsupported adaptors per major.minor version to avoid unnecessary future downloads
- `--keep-unsupported` flag allows opting out of automatic removal
- Uses `npm uninstall` instead of manual file deletion

## QA Notes

Still needs to be hand tested!

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset version` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
