### PR TITLE
Workflow Class

### DIFF
--- a/packages/project/src/Project.ts
+++ b/packages/project/src/Project.ts
@@ -2,6 +2,7 @@ import * as l from '@openfn/lexicon';
 // but what is this ?
 // is it just types?
 
+import Workflow from './Workflow';
 import * as serializers from './serialize';
 import fromAppState from './parse/from-app-state';
 
@@ -62,7 +63,7 @@ export class Project {
   // array of version shas
   history: string[] = [];
 
-  workflows: l.Workflow[];
+  workflows: Workflow[];
 
   // option strings saved by the app
   // these are all (?) unused clientside
@@ -120,8 +121,7 @@ export class Project {
     this.description = data.description;
     this.openfn = data.openfn;
     this.options = data.options;
-    this.workflows = data.workflows;
-    // this.workflows = data.workflows.map((w) => new Workflow(w));
+    this.workflows = data.workflows?.map((w) => new Workflow(w)) ?? [];
     this.collections = data.collections;
     this.credentials = data.credentials;
     this.meta = data.meta;

--- a/packages/project/src/Project.ts
+++ b/packages/project/src/Project.ts
@@ -172,29 +172,3 @@ export class Project {
     return getUuidForStep(this, workflow, stepId);
   }
 }
-
-class Workflow {
-  constructor(workflow: l.Workflow) {
-    this.steps = {}; // TODO extract from workflow
-    this.edges = {}; // TODO extract from workflow
-
-    // maybe the raw model
-    this.model = workflow;
-  }
-
-  getStep(id) {}
-  setStep(id, props) {
-    // replace the step with id with the properties attached
-    // create a new step if doesn't exist?
-  }
-  mergeStep(id, props) {
-    // overwrite each key of props on the step
-    // throw if the step doesn't exist?
-  }
-  getEdge(from, to) {}
-  setEdge(from, to, props) {}
-  mergeEdge(from, to, props) {}
-
-  // TODO same for triggers?
-  // Or is a trigger just a step?
-}

--- a/packages/project/src/Project.ts
+++ b/packages/project/src/Project.ts
@@ -1,12 +1,8 @@
 import * as l from '@openfn/lexicon';
-// but what is this ?
-// is it just types?
-
 import Workflow from './Workflow';
 import * as serializers from './serialize';
 import fromAppState from './parse/from-app-state';
 
-// TODO this naming clearly isn't right
 import { parseProject as fromFs } from './parse/from-fs';
 import getIdentifier from './util/get-identifier';
 import slugify from './util/slugify';
@@ -31,7 +27,7 @@ type RepoOptions = {
   };
 };
 
-// // A local collection of openfn projects
+// A local collection of openfn projects?
 // class Repo {
 
 //   projects: {}

--- a/packages/project/src/Workflow.ts
+++ b/packages/project/src/Workflow.ts
@@ -3,7 +3,7 @@ import * as l from '@openfn/lexicon';
 const clone = (obj) => JSON.parse(JSON.stringify(obj));
 
 class Workflow {
-  workflow;
+  workflow; // this is the raw workflow JSON representation
   index;
 
   constructor(workflow: l.Workflow) {
@@ -86,16 +86,9 @@ class Workflow {
     return edge;
   }
 
-  // setStep(id, props) {
-  //   // replace the step with id with the properties attached
-  //   // create a new step if doesn't exist?
-  // }
-  // mergeStep(id, props) {
-  //   // overwrite each key of props on the step
-  //   // throw if the step doesn't exist?
-  // }
-  // setEdge(from, to, props) {}
-  // mergeEdge(from, to, props) {}
+  getUUID(id) {
+    return this.index.uuid[id];
+  }
 
   toJSON() {
     return this.workflow;

--- a/packages/project/src/Workflow.ts
+++ b/packages/project/src/Workflow.ts
@@ -15,8 +15,12 @@ class Workflow {
     };
 
     this.#workflow = clone(workflow);
-    this.id = workflow.id;
-    this.name = workflow.name;
+
+    const { id, name, openfn, steps, ...options } = workflow;
+    this.id = id;
+    this.name = name;
+    this.openfn = openfn;
+    this.options = options;
 
     this.#buildIndex();
   }
@@ -40,13 +44,15 @@ class Workflow {
         const edgeId = `${s.id}-${next}`;
         const edge = edges[next];
         this.index.edges[edgeId] = edge;
-        this.index.uuid[edgeId] = edge.openfn.id;
+        this.index.uuid[edgeId] = edge.openfn?.id;
         if (edge.openfn?.id) {
           this.index.id[edge.openfn.id] = edgeId;
         }
       }
     }
   }
+
+  set(id, props) {}
 
   getStep(id) {}
   setStep(id, props) {

--- a/packages/project/src/Workflow.ts
+++ b/packages/project/src/Workflow.ts
@@ -52,23 +52,50 @@ class Workflow {
     }
   }
 
-  set(id, props) {}
+  // Set properties on any step or edge by id
+  set(id, props) {
+    const item = this.index.edges[id] || this.index.steps[id];
+    if (!item) {
+      throw new Error(`step/edge with id "${id}" does not exist in workflow`);
+    }
 
-  getStep(id) {}
-  setStep(id, props) {
-    // replace the step with id with the properties attached
-    // create a new step if doesn't exist?
-  }
-  mergeStep(id, props) {
-    // overwrite each key of props on the step
-    // throw if the step doesn't exist?
-  }
-  getEdge(from, to) {}
-  setEdge(from, to, props) {}
-  mergeEdge(from, to, props) {}
+    Object.assign(item, props);
 
-  // TODO same for triggers?
-  // Or is a trigger just a step?
+    return this;
+  }
+
+  // Get properties on any step or edge by id
+  get(id) {
+    const item = this.index.edges[id] || this.index.steps[id];
+    if (!item) {
+      throw new Error(`step/edge with id "${id}" does not exist in workflow`);
+    }
+
+    return item;
+  }
+
+  // Get an edge based on its source and target
+  getEdge(from, to) {
+    const edgeId = [from, to].join('-');
+
+    const edge = this.index.edges[edgeId];
+    if (!edge) {
+      throw new Error(`edge with id "${edgeId}" does not exist in workflow`);
+    }
+
+    return edge;
+  }
+
+  // setStep(id, props) {
+  //   // replace the step with id with the properties attached
+  //   // create a new step if doesn't exist?
+  // }
+  // mergeStep(id, props) {
+  //   // overwrite each key of props on the step
+  //   // throw if the step doesn't exist?
+  // }
+  // setEdge(from, to, props) {}
+  // mergeEdge(from, to, props) {}
 
   // TODO make sure this stays up to date after edits
   toJSON() {

--- a/packages/project/src/Workflow.ts
+++ b/packages/project/src/Workflow.ts
@@ -1,0 +1,73 @@
+import * as l from '@openfn/lexicon';
+
+const clone = (obj) => JSON.parse(JSON.stringify(obj));
+
+class Workflow {
+  #workflow;
+  index;
+
+  constructor(workflow: l.Workflow) {
+    this.index = {
+      steps: {}, // steps by id
+      edges: {}, // edges by from-id id
+      uuid: {}, // id to uuid
+      id: {}, // uuid to ids
+    };
+
+    this.#workflow = clone(workflow);
+    this.id = workflow.id;
+    this.name = workflow.name;
+
+    this.#buildIndex();
+  }
+
+  get steps() {
+    return this.#workflow.steps;
+  }
+
+  #buildIndex() {
+    for (const s of this.#workflow.steps) {
+      // index this step
+      this.index.steps[s.id] = s;
+      this.index.uuid[s.id] = s.openfn.id;
+      if (s.openfn?.id) {
+        this.index.id[s.openfn.id] = s.id;
+      }
+
+      const edges = s.next ?? {};
+      // Now index each edge
+      for (const next in edges) {
+        const edgeId = `${s.id}-${next}`;
+        const edge = edges[next];
+        this.index.edges[edgeId] = edge;
+        this.index.uuid[edgeId] = edge.openfn.id;
+        if (edge.openfn?.id) {
+          this.index.id[edge.openfn.id] = edgeId;
+        }
+      }
+    }
+  }
+
+  getStep(id) {}
+  setStep(id, props) {
+    // replace the step with id with the properties attached
+    // create a new step if doesn't exist?
+  }
+  mergeStep(id, props) {
+    // overwrite each key of props on the step
+    // throw if the step doesn't exist?
+  }
+  getEdge(from, to) {}
+  setEdge(from, to, props) {}
+  mergeEdge(from, to, props) {}
+
+  // TODO same for triggers?
+  // Or is a trigger just a step?
+
+  // TODO make sure this stays up to date after edits
+  toJSON() {
+    return this.#workflow;
+  }
+}
+
+export default Workflow;

--- a/packages/project/src/Workflow.ts
+++ b/packages/project/src/Workflow.ts
@@ -3,7 +3,7 @@ import * as l from '@openfn/lexicon';
 const clone = (obj) => JSON.parse(JSON.stringify(obj));
 
 class Workflow {
-  #workflow;
+  workflow;
   index;
 
   constructor(workflow: l.Workflow) {
@@ -14,7 +14,7 @@ class Workflow {
       id: {}, // uuid to ids
     };
 
-    this.#workflow = clone(workflow);
+    this.workflow = clone(workflow);
 
     const { id, name, openfn, steps, ...options } = workflow;
     this.id = id;
@@ -26,11 +26,11 @@ class Workflow {
   }
 
   get steps() {
-    return this.#workflow.steps;
+    return this.workflow.steps;
   }
 
   #buildIndex() {
-    for (const s of this.#workflow.steps) {
+    for (const s of this.workflow.steps) {
       // index this step
       this.index.steps[s.id] = s;
       this.index.uuid[s.id] = s.openfn.id;
@@ -97,9 +97,8 @@ class Workflow {
   // setEdge(from, to, props) {}
   // mergeEdge(from, to, props) {}
 
-  // TODO make sure this stays up to date after edits
   toJSON() {
-    return this.#workflow;
+    return this.workflow;
   }
 }
 

--- a/packages/project/src/serialize/to-app-state.ts
+++ b/packages/project/src/serialize/to-app-state.ts
@@ -2,6 +2,7 @@
 
 import { Project } from '../Project';
 import { jsonToYaml } from '../util/yaml';
+import Workflow from '../Workflow';
 
 import { randomUUID } from 'node:crypto';
 type Options = { format?: 'json' | 'yaml' };
@@ -34,6 +35,10 @@ export default function (project: Project, options: Options = {}) {
 }
 
 const mapWorkflow = (workflow) => {
+  // TODO this is always a Workflow now, no?
+  if (workflow instanceof Workflow) {
+    workflow = workflow.toJSON();
+  }
   const wfState = {
     name: workflow.name,
     ...workflow.openfn,

--- a/packages/project/src/serialize/to-fs.ts
+++ b/packages/project/src/serialize/to-fs.ts
@@ -29,7 +29,7 @@ export default function (project: Project) {
 }
 
 // extracts a workflow.json|yaml from a project
-export const extractWorkflow = (project, workflowId) => {
+export const extractWorkflow = (project: Project, workflowId: string) => {
   const format = project.repo.formats.workflow;
 
   const workflow = project.getWorkflow(workflowId);
@@ -44,6 +44,8 @@ export const extractWorkflow = (project, workflowId) => {
   const wf = {
     id: workflow.id,
     name: workflow.name,
+    // Note: if no options are defined, options will serialize to an empty object
+    // Not crazy about this - maybe we should do something better? Or do we like the consistency?
     options: workflow.options,
     steps: workflow.steps.map((step) => {
       const { openfn, expression, ...mapped } = step;
@@ -57,7 +59,7 @@ export const extractWorkflow = (project, workflowId) => {
 };
 
 // extracts an expression.js from a workflow in project
-export const extractStep = (project, workflowId, stepId) => {
+export const extractStep = (project: Projec, workflowId, stepId) => {
   const workflow = project.getWorkflow(workflowId);
   if (!workflow) {
     throw new Error(`workflow not found: ${workflowId}`);

--- a/packages/project/test/merge/map-uuids.test.ts
+++ b/packages/project/test/merge/map-uuids.test.ts
@@ -3,22 +3,22 @@ import * as l from '@openfn/lexicon';
 import test from 'ava';
 import mapUUIDs from '../../src/merge/map-uuids';
 import { createWorkflow } from '../util';
-import generateWorkflow from './workflow-generator';
+import generateWorkflow from '../workflow-generator';
 
 test('map triggers with the same name', (t) => {
-  const source = generateWorkflow(['trigger']).setProp('trigger', {
+  const source = generateWorkflow(['trigger']).set('trigger', {
     type: 'webhook',
   });
-  const target = generateWorkflow(['trigger']).setProp('trigger', {
+  const target = generateWorkflow(['trigger']).set('trigger', {
     type: 'webhook',
   });
 
   const result = mapUUIDs(source.workflow, target.workflow);
   t.deepEqual(result.nodes, {
-    ['trigger']: target.getId('trigger'),
+    ['trigger']: target.getUUID('trigger'),
   });
   // no edges here
-  t.deepEqual(result.edges, {})
+  t.deepEqual(result.edges, {});
 });
 
 // map steps with the same name
@@ -35,8 +35,8 @@ test('node name changes but no positional change', (t) => {
   const result = mapUUIDs(source.workflow, target.workflow);
 
   t.deepEqual(result.nodes, {
-    ['trigger']: target.getId('trigger'),
-    ['b']: target.getId('b'),
+    ['trigger']: target.getUUID('trigger'),
+    ['b']: target.getUUID('b'),
     ['c']: null,
     ['a']: true,
   });
@@ -55,17 +55,17 @@ test('one connecting node missing', (t) => {
 
   const result = mapUUIDs(source.workflow, target.workflow);
   t.deepEqual(result.nodes, {
-    ['a']: target.getId('a'),
-    ['b']: target.getId('b'),
-    ['c']: target.getId('c'),
-    ['d']: target.getId('d'),
+    ['a']: target.getUUID('a'),
+    ['b']: target.getUUID('b'),
+    ['c']: target.getUUID('c'),
+    ['d']: target.getUUID('d'),
     ['z']: null,
   });
 
   // retained b-c and b-d
   t.deepEqual(result.edges, {
-    ['b-c']: target.getId('b-c'),
-    ['b-d']: target.getId('b-d'),
+    ['b-c']: target.getUUID('b-c'),
+    ['b-d']: target.getUUID('b-d'),
     ['a-b']: true,
     ['a-z']: null,
     ['z-b']: null,

--- a/packages/project/test/merge/workflow-generator.test.ts
+++ b/packages/project/test/merge/workflow-generator.test.ts
@@ -1,0 +1,147 @@
+import test from 'ava';
+
+import generateWorkflow from './workflow-generator';
+
+test('should generate a simple workflow with uuids', (t) => {
+  const wf = generateWorkflow(['a-b'], { uuidSeed: 0 });
+
+  t.deepEqual(wf.workflow, {
+    name: 'workflow',
+    steps: [
+      {
+        id: 'a',
+        next: {
+          b: {
+            openfn: {
+              id: 1,
+            },
+          },
+        },
+        openfn: {
+          id: 2,
+        },
+      },
+      {
+        id: 'b',
+        next: {},
+        openfn: {
+          id: 3,
+        },
+      },
+    ],
+  });
+});
+
+test('should generate two children for one node', (t) => {
+  const wf = generateWorkflow(['a-b', 'a-c'], { uuidSeed: 0 });
+
+  t.log(JSON.stringify(wf.workflow, null, 2));
+
+  t.deepEqual(wf.workflow, {
+    name: 'workflow',
+    steps: [
+      {
+        id: 'a',
+        next: {
+          b: {
+            openfn: {
+              id: 1,
+            },
+          },
+          c: {
+            openfn: {
+              id: 4,
+            },
+          },
+        },
+        openfn: {
+          id: 2,
+        },
+      },
+      {
+        id: 'b',
+        next: {},
+        openfn: {
+          id: 3,
+        },
+      },
+      {
+        id: 'c',
+        next: {},
+        openfn: {
+          id: 5,
+        },
+      },
+    ],
+  });
+});
+
+test("should generate circular references even though that's illegal", (t) => {
+  const wf = generateWorkflow(['a-b', 'b-a'], { uuidSeed: 0 });
+
+  t.log(JSON.stringify(wf.workflow, null, 2));
+
+  t.deepEqual(wf.workflow, {
+    name: 'workflow',
+    steps: [
+      {
+        id: 'a',
+        next: {
+          b: {
+            openfn: {
+              id: 1,
+            },
+          },
+        },
+        openfn: {
+          id: 2,
+        },
+      },
+      {
+        id: 'b',
+        next: {
+          a: {
+            openfn: {
+              id: 4,
+            },
+          },
+        },
+        openfn: {
+          id: 3,
+        },
+      },
+    ],
+  });
+});
+
+test('should ignore duplicates', (t) => {
+  const wf = generateWorkflow(['a-b', 'a-b'], { uuidSeed: 0 });
+
+  t.log(JSON.stringify(wf.workflow, null, 2));
+
+  t.deepEqual(wf.workflow, {
+    name: 'workflow',
+    steps: [
+      {
+        id: 'a',
+        next: {
+          b: {
+            openfn: {
+              id: 1,
+            },
+          },
+        },
+        openfn: {
+          id: 2,
+        },
+      },
+      {
+        id: 'b',
+        next: {},
+        openfn: {
+          id: 3,
+        },
+      },
+    ],
+  });
+});

--- a/packages/project/test/merge/workflow-generator.test.ts
+++ b/packages/project/test/merge/workflow-generator.test.ts
@@ -4,7 +4,6 @@ import generateWorkflow from './workflow-generator';
 
 test('should generate a simple workflow with uuids', (t) => {
   const wf = generateWorkflow(['a-b'], { uuidSeed: 0 });
-
   t.deepEqual(wf.workflow, {
     name: 'workflow',
     steps: [
@@ -23,7 +22,6 @@ test('should generate a simple workflow with uuids', (t) => {
       },
       {
         id: 'b',
-        next: {},
         openfn: {
           id: 3,
         },
@@ -53,7 +51,6 @@ test('should support long node ids', (t) => {
       },
       {
         id: 'child',
-        next: {},
         openfn: {
           id: 3,
         },
@@ -88,14 +85,12 @@ test('should generate two children for one node', (t) => {
       },
       {
         id: 'b',
-        next: {},
         openfn: {
           id: 3,
         },
       },
       {
         id: 'c',
-        next: {},
         openfn: {
           id: 5,
         },
@@ -161,7 +156,6 @@ test('should ignore duplicates', (t) => {
       },
       {
         id: 'b',
-        next: {},
         openfn: {
           id: 3,
         },
@@ -175,8 +169,6 @@ test('should generate a complex workflow', (t) => {
     ['a-b', 'a-c', 'c-d', 'c-e', 'c-f', 'a-f', 'e-a', 'e-f'],
     { uuidSeed: 0 }
   );
-
-  t.log(JSON.stringify(wf.workflow, null, 2));
 
   t.deepEqual(wf.workflow, {
     name: 'workflow',
@@ -206,7 +198,6 @@ test('should generate a complex workflow', (t) => {
       },
       {
         id: 'b',
-        next: {},
         openfn: {
           id: 3,
         },
@@ -236,7 +227,6 @@ test('should generate a complex workflow', (t) => {
       },
       {
         id: 'd',
-        next: {},
         openfn: {
           id: 7,
         },
@@ -261,7 +251,6 @@ test('should generate a complex workflow', (t) => {
       },
       {
         id: 'f',
-        next: {},
         openfn: {
           id: 11,
         },

--- a/packages/project/test/merge/workflow-generator.test.ts
+++ b/packages/project/test/merge/workflow-generator.test.ts
@@ -32,10 +32,38 @@ test('should generate a simple workflow with uuids', (t) => {
   });
 });
 
+test('should support long node ids', (t) => {
+  const wf = generateWorkflow(['parent-child'], { uuidSeed: 0 });
+
+  t.deepEqual(wf.workflow, {
+    name: 'workflow',
+    steps: [
+      {
+        id: 'parent',
+        next: {
+          child: {
+            openfn: {
+              id: 1,
+            },
+          },
+        },
+        openfn: {
+          id: 2,
+        },
+      },
+      {
+        id: 'child',
+        next: {},
+        openfn: {
+          id: 3,
+        },
+      },
+    ],
+  });
+});
+
 test('should generate two children for one node', (t) => {
   const wf = generateWorkflow(['a-b', 'a-c'], { uuidSeed: 0 });
-
-  t.log(JSON.stringify(wf.workflow, null, 2));
 
   t.deepEqual(wf.workflow, {
     name: 'workflow',
@@ -79,8 +107,6 @@ test('should generate two children for one node', (t) => {
 test("should generate circular references even though that's illegal", (t) => {
   const wf = generateWorkflow(['a-b', 'b-a'], { uuidSeed: 0 });
 
-  t.log(JSON.stringify(wf.workflow, null, 2));
-
   t.deepEqual(wf.workflow, {
     name: 'workflow',
     steps: [
@@ -117,8 +143,6 @@ test("should generate circular references even though that's illegal", (t) => {
 test('should ignore duplicates', (t) => {
   const wf = generateWorkflow(['a-b', 'a-b'], { uuidSeed: 0 });
 
-  t.log(JSON.stringify(wf.workflow, null, 2));
-
   t.deepEqual(wf.workflow, {
     name: 'workflow',
     steps: [
@@ -140,6 +164,106 @@ test('should ignore duplicates', (t) => {
         next: {},
         openfn: {
           id: 3,
+        },
+      },
+    ],
+  });
+});
+
+test('should generate a complex workflow', (t) => {
+  const wf = generateWorkflow(
+    ['a-b', 'a-c', 'c-d', 'c-e', 'c-f', 'a-f', 'e-a', 'e-f'],
+    { uuidSeed: 0 }
+  );
+
+  t.log(JSON.stringify(wf.workflow, null, 2));
+
+  t.deepEqual(wf.workflow, {
+    name: 'workflow',
+    steps: [
+      {
+        id: 'a',
+        next: {
+          b: {
+            openfn: {
+              id: 1,
+            },
+          },
+          c: {
+            openfn: {
+              id: 4,
+            },
+          },
+          f: {
+            openfn: {
+              id: 12,
+            },
+          },
+        },
+        openfn: {
+          id: 2,
+        },
+      },
+      {
+        id: 'b',
+        next: {},
+        openfn: {
+          id: 3,
+        },
+      },
+      {
+        id: 'c',
+        next: {
+          d: {
+            openfn: {
+              id: 6,
+            },
+          },
+          e: {
+            openfn: {
+              id: 8,
+            },
+          },
+          f: {
+            openfn: {
+              id: 10,
+            },
+          },
+        },
+        openfn: {
+          id: 5,
+        },
+      },
+      {
+        id: 'd',
+        next: {},
+        openfn: {
+          id: 7,
+        },
+      },
+      {
+        id: 'e',
+        next: {
+          a: {
+            openfn: {
+              id: 13,
+            },
+          },
+          f: {
+            openfn: {
+              id: 14,
+            },
+          },
+        },
+        openfn: {
+          id: 9,
+        },
+      },
+      {
+        id: 'f',
+        next: {},
+        openfn: {
+          id: 11,
         },
       },
     ],

--- a/packages/project/test/merge/workflow-generator.ts
+++ b/packages/project/test/merge/workflow-generator.ts
@@ -3,7 +3,16 @@ import { randomUUID } from 'node:crypto';
 class WorkflowGenerator {
   ids = new Map<string, string>();
   nodes: Record<string, any> = {};
-  constructor(def: string[], private name: string = 'workflow') {
+
+  uuidSeed;
+
+  constructor(
+    def: string[],
+    private name: string = 'workflow',
+    private uuidSeed
+  ) {
+    this.uuidSeed = uuidSeed;
+
     for (const conn of def) {
       const [from, to] = conn.split('-');
       // create node for from and to
@@ -15,24 +24,24 @@ class WorkflowGenerator {
       } else {
         this.nodes[from] = {
           id: from,
-          openfn: { id: this.uuid(from) },
           next: to
             ? { [to]: { openfn: { id: this.uuid(`${from}-${to}`) } } }
             : {},
+          openfn: { id: this.uuid(from) },
         };
       }
       if (to && !this.nodes[to]) {
         this.nodes[to] = {
           id: to,
-          openfn: { id: this.uuid(to) },
           next: {},
+          openfn: { id: this.uuid(to) },
         };
       }
     }
   }
 
   private uuid(id: string) {
-    const muuid = randomUUID();
+    const muuid = !isNaN(this.uuidSeed) ? ++this.uuidSeed : randomUUID();
     this.ids.set(id, muuid);
     return muuid;
   }
@@ -62,6 +71,8 @@ class WorkflowGenerator {
   }
 }
 
-export default function generateWorkflow(def: string, name?: string) {
-  return new WorkflowGenerator(def, name);
+export default function generateWorkflow(def: string, options = {}) {
+  const { name, uuidSeed } = options;
+
+  return new WorkflowGenerator(def, name, uuidSeed);
 }

--- a/packages/project/test/parse/from-app-state.test.ts
+++ b/packages/project/test/parse/from-app-state.test.ts
@@ -111,7 +111,7 @@ test('should create a Project from prov state with a workflow', (t) => {
   const project = fromAppState(state, config);
 
   t.is(project.workflows.length, 1);
-  t.deepEqual(project.workflows[0], {
+  t.deepEqual(project.workflows[0].toJSON(), {
     id: 'wf1',
     name: 'wf1',
     steps: [

--- a/packages/project/test/serialize/to-fs.test.ts
+++ b/packages/project/test/serialize/to-fs.test.ts
@@ -38,10 +38,13 @@ test('extractWorkflow: single simple workflow (yaml by default)', (t) => {
 
   const { path, content } = extractWorkflow(project, 'my-workflow');
   t.is(path, 'workflows/my-workflow/my-workflow.yaml');
+
+  // TODO is the empty options object correct here??
   t.deepEqual(
     content,
     `id: my-workflow
 name: My Workflow
+options: {}
 steps:
   - id: step
     adaptor: "@openfn/language-common@latest"
@@ -91,6 +94,7 @@ test('extractWorkflow: single simple workflow with an edge', (t) => {
   t.deepEqual(JSON.parse(content), {
     id: 'my-workflow',
     name: 'My Workflow',
+    options: {},
     steps: [
       {
         id: 'step1',
@@ -144,6 +148,7 @@ test('extractWorkflow: single simple workflow with random edge property', (t) =>
   t.deepEqual(JSON.parse(content), {
     id: 'my-workflow',
     name: 'My Workflow',
+    options: {},
     steps: [
       {
         id: 'step',

--- a/packages/project/test/workflow-generator.test.ts
+++ b/packages/project/test/workflow-generator.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import generateWorkflow from './workflow-generator';
+import generateWorkflow from '../workflow-generator';
 
 test('should generate a simple workflow with uuids', (t) => {
   const wf = generateWorkflow(['a-b'], { uuidSeed: 0 });

--- a/packages/project/test/workflow-generator.ts
+++ b/packages/project/test/workflow-generator.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import Workflow from '../../src/Workflow';
+import Workflow from '../src/Workflow';
 
 function gen(def: string[], name: string = 'workflow', uuidSeed?: number) {
   const ids = new Map<string, string>();

--- a/packages/project/test/workflow.test.ts
+++ b/packages/project/test/workflow.test.ts
@@ -53,7 +53,7 @@ test('create a Workflow from json', (t) => {
   const w = new Workflow(simpleWorkflow);
 
   t.is(w.steps.length, 3);
-  t.falsy(w.workflow);
+  t.truthy(w.workflow.steps);
 });
 
 test('a Workflow class behaves just like regular json', (t) => {

--- a/packages/project/test/workflow.test.ts
+++ b/packages/project/test/workflow.test.ts
@@ -1,0 +1,126 @@
+import { randomUUID } from 'node:crypto';
+import test from 'ava';
+import Workflow from '../src/Workflow';
+
+const simpleWorkflow = {
+  id: 'wf1',
+  name: 'My Workflow',
+  steps: [
+    {
+      id: 'a',
+      expression: 'fn(s => s)',
+      next: {
+        c: {
+          condition: true,
+          openfn: {
+            id: randomUUID(),
+          },
+        },
+      },
+      openfn: {
+        id: randomUUID(),
+      },
+    },
+    {
+      id: 'b',
+      expression: 'fn(s => s)',
+      next: {
+        c: {
+          condition: false,
+          openfn: {
+            id: randomUUID(),
+          },
+        },
+      },
+      openfn: {
+        id: randomUUID(),
+      },
+    },
+    {
+      id: 'c',
+      expression: 'fn(s => s)',
+      openfn: {
+        id: randomUUID(),
+      },
+    },
+  ],
+  openfn: {
+    id: randomUUID(),
+  },
+};
+
+test('create a Workflow from json', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.is(w.steps.length, 3);
+  t.falsy(w.workflow);
+});
+
+test('a Workflow class behaves just like regular json', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.is(w.id, 'wf1');
+  t.is(w.name, 'My Workflow');
+  t.is(w.steps.length, 3);
+
+  t.is(w.steps[0].id, 'a');
+  t.is(w.steps[1].id, 'b');
+  t.is(w.steps[2].id, 'c');
+});
+
+test('a Workflow class can serialize to JSON', (t) => {
+  const w = new Workflow(simpleWorkflow);
+  const json = w.toJSON();
+
+  t.deepEqual(json, simpleWorkflow);
+});
+
+test.skip("Editing a workflow internally doesn't affect the input", (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  // set a property on w
+  // simple workflow should not reflect the change
+
+  t.deepEqual(json, simpleWorkflow);
+});
+
+test('map steps by id', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.deepEqual(w.index.steps['a'], simpleWorkflow.steps[0]);
+  t.deepEqual(w.index.steps['b'], simpleWorkflow.steps[1]);
+  t.deepEqual(w.index.steps['c'], simpleWorkflow.steps[2]);
+});
+
+test('map edges by name', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.deepEqual(w.index.edges['a-c'], simpleWorkflow.steps[0].next.c);
+  t.deepEqual(w.index.edges['b-c'], simpleWorkflow.steps[1].next.c);
+});
+
+test('map ids to uuids', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.deepEqual(w.index.uuid['a'], simpleWorkflow.steps[0].openfn.id);
+  t.deepEqual(w.index.uuid['b'], simpleWorkflow.steps[1].openfn.id);
+  t.deepEqual(w.index.uuid['c'], simpleWorkflow.steps[2].openfn.id);
+  t.deepEqual(w.index.uuid['a-c'], simpleWorkflow.steps[0].next.c.openfn.id);
+  t.deepEqual(w.index.uuid['b-c'], simpleWorkflow.steps[1].next.c.openfn.id);
+});
+
+test('map uuids to ids', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  const uuid_a = simpleWorkflow.steps[0].openfn.id;
+  const uuid_b = simpleWorkflow.steps[1].openfn.id;
+  const uuid_c = simpleWorkflow.steps[2].openfn.id;
+  const uuid_ac = simpleWorkflow.steps[0].next.c.openfn.id;
+  const uuid_bc = simpleWorkflow.steps[1].next.c.openfn.id;
+
+  t.deepEqual(w.index.id[uuid_a], 'a');
+  t.deepEqual(w.index.id[uuid_b], 'b');
+  t.deepEqual(w.index.id[uuid_c], 'c');
+  t.deepEqual(w.index.id[uuid_ac], 'a-c');
+  t.deepEqual(w.index.id[uuid_bc], 'b-c');
+});

--- a/packages/project/test/workflow.test.ts
+++ b/packages/project/test/workflow.test.ts
@@ -75,13 +75,74 @@ test('a Workflow class can serialize to JSON', (t) => {
   t.deepEqual(json, simpleWorkflow);
 });
 
-test.skip("Editing a workflow internally doesn't affect the input", (t) => {
+test('get - get a step', (t) => {
   const w = new Workflow(simpleWorkflow);
 
-  // set a property on w
-  // simple workflow should not reflect the change
+  const step = w.get('a');
 
-  t.deepEqual(json, simpleWorkflow);
+  t.deepEqual(step, simpleWorkflow.steps[0]);
+});
+
+test('get - get an edge', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  const edge = w.get('a-c');
+
+  t.deepEqual(edge, simpleWorkflow.steps[0].next.c);
+});
+
+test('get - throw if not found', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.throws(() => w.get('x'), {
+    message: 'step/edge with id "x" does not exist in workflow',
+  });
+});
+
+test('getEdge - get an edge', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  const edge = w.getEdge('a', 'c');
+
+  t.deepEqual(edge, simpleWorkflow.steps[0].next.c);
+});
+
+test('set properties on a step', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.set('a', { adaptor: 'salesforce' });
+
+  const step = w.get('a');
+  t.is(step.adaptor, 'salesforce');
+});
+
+test('set properties on a step, with a chain', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.set('a', { adaptor: 'salesforce' }).set('b', { adaptor: 'dhis2' });
+
+  const a = w.get('a');
+  t.is(a.adaptor, 'salesforce');
+
+  const b = w.get('b');
+  t.is(b.adaptor, 'dhis2');
+});
+
+test('set properties on an edge', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.set('a-c', { condition: '!state.error' });
+
+  const edge = w.get('a-c');
+  t.is(edge.condition, '!state.error');
+});
+
+test("Editing a workflow internally doesn't affect the input", (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.set('a', { adaptor: 'salesforce' });
+
+  t.falsy(simpleWorkflow.steps[0].adaptor);
 });
 
 test('map steps by id', (t) => {


### PR DESCRIPTION
This PR adds a Workflow class which makes it a bit easier to manage workflow structures. It's easier to look up nodes and edges and map their UUIDs and stuff.

A Workflow class behaves just like a workflow object, but also has a `.workflow` property which is useful for deep equality tests.

The new workflow generator, the project, and the unit tests have all been updated to use the new class