### PR TITLE
Worker: force a super long timeout on claims

### DIFF
--- a/.changeset/mean-poets-sip.md
+++ b/.changeset/mean-poets-sip.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Increase timeout on claim events

--- a/packages/ws-worker/src/channels/worker-queue.ts
+++ b/packages/ws-worker/src/channels/worker-queue.ts
@@ -65,7 +65,7 @@ const connectToWorkerQueue = (
       };
 
       channel
-        .join()
+        .join(1000 * 60 * 60 * 24) // force a really long 24hr timeout
         .receive('ok', () => {
           logger.debug('Connected to worker queue socket');
           events.emit('connect', { socket, channel });

--- a/packages/ws-worker/src/start.ts
+++ b/packages/ws-worker/src/start.ts
@@ -46,8 +46,16 @@ function engineReady(engine: any) {
     collectionsUrl: args.collectionsUrl,
     monorepoDir: args.monorepoDir,
     messageTimeoutSeconds: args.messageTimeoutSeconds,
+    claimTimeoutSeconds: args.claimTimeoutSeconds,
+    // deprecated!
     socketTimeoutSeconds: args.socketTimeoutSeconds,
   };
+
+  if ('socketTimeoutSeconds' in args) {
+    logger.warn(
+      'WARNING: deprecated socketTimeoutSeconds value passed.\n\nThis will be respected as the default socket timeout value, but will be removed from future versions of the worker.'
+    );
+  }
 
   if (args.lightningPublicKey) {
     logger.info(

--- a/packages/ws-worker/test/channels/worker-queue.test.ts
+++ b/packages/ws-worker/test/channels/worker-queue.test.ts
@@ -11,14 +11,9 @@ const logger = createMockLogger();
 
 test('should connect', (t) => {
   return new Promise((done) => {
-    connectToWorkerQueue(
-      'www',
-      'a',
-      'secret',
-      undefined,
-      logger,
-      MockSocket as any
-    ).on('connect', ({ socket, channel }) => {
+    connectToWorkerQueue('www', 'a', 'secret', logger, {
+      SocketConstructor: MockSocket as any,
+    }).on('connect', ({ socket, channel }) => {
       t.truthy(socket);
       t.truthy(socket.connect);
       t.truthy(channel);
@@ -45,14 +40,9 @@ test('should connect with an auth token', async (t) => {
 
       return socket;
     }
-    connectToWorkerQueue(
-      'www',
-      workerId,
-      secret,
-      undefined,
-      logger,
-      createSocket as any
-    ).on('connect', ({ socket, channel }) => {
+    connectToWorkerQueue('www', workerId, secret, logger, {
+      SocketConstructor: createSocket,
+    }).on('connect', ({ socket, channel }) => {
       t.truthy(socket);
       t.truthy(socket.connect);
       t.truthy(channel);
@@ -80,14 +70,9 @@ test('should connect with api and worker versions', async (t) => {
       return socket;
     }
 
-    connectToWorkerQueue(
-      'www',
-      'a',
-      'secret',
-      undefined,
-      logger,
-      createSocket as any
-    ).on('connect', done);
+    connectToWorkerQueue('www', 'a', 'secret', logger, {
+      SocketConstructor: createSocket as any,
+    }).on('connect', done);
   });
 });
 
@@ -111,14 +96,9 @@ test('should fail to connect with an invalid auth token', async (t) => {
       return socket;
     }
 
-    connectToWorkerQueue(
-      'www',
-      workerId,
-      'wrong-secret!',
-      undefined,
-      logger,
-      createSocket as any
-    ).on('error', (e) => {
+    connectToWorkerQueue('www', workerId, 'wrong-secret!', logger, {
+      SocketConstructor: createSocket,
+    }).on('error', (e) => {
       t.is(e, 'auth_fail');
       t.pass('error thrown');
       done();


### PR DESCRIPTION
The point between a Worker _claiming_ a Run and _starting_ it is super delicate.

Right now, if the claim event takes too long, it'll timeout. The run will be removed from the queue but won't get started by the worker.

This PR forces the timeout on claim to be super long to give it the maximum chance to download the run id to the worker.

It's a crude solution but it feels necessary at this point.

Closes #981 (at least for now)
