### PR TITLE
CLI: support streamed events from Apollo

### DIFF
--- a/.changeset/short-eyes-clean.md
+++ b/.changeset/short-eyes-clean.md
@@ -1,5 +1,0 @@
----
-'@openfn/cli': patch
----
-
-apollo: add support for events while streaming from apollo

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/cli
 
+## 1.13.3
+
+### Patch Changes
+
+- 284b889: apollo: add support for events while streaming from apollo
+
 ## 1.13.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "CLI devtools for the OpenFn toolchain",
   "engines": {
     "node": ">=18",


### PR DESCRIPTION
This PR adds a little bit of special support for events streamed out of Apollo.

This is just for debugging really: events are logged to a special logger and so appear under the EVT namespace in the CLI output:

<img width="337" height="62" alt="image" src="https://github.com/user-attachments/assets/bbb756e0-5692-4452-810d-2c24069d4d7c" />


Events are just rendered with the event type (status, token, whatever) and the payload (string or JSON) dumped into stdout.

This works against the new streaming API. Output can be quite noisy but you can disable most logs by doing:
```
 openfn apollo job_chat -s tmp/payload.json --log none
```
## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
