### PR TITLE
Reduce compiler memory overhead

### DIFF
--- a/.changeset/tender-parrots-agree.md
+++ b/.changeset/tender-parrots-agree.md
@@ -1,0 +1,6 @@
+---
+'@openfn/compiler': patch
+---
+
+- Exit transformers a little earlier. This reduces the memory overhead of parsing large files
+- Add memory diagnostic outputs

--- a/packages/cli/src/compile/command.ts
+++ b/packages/cli/src/compile/command.ts
@@ -18,6 +18,7 @@ export type CompileOptions = Pick<
   | 'path'
   | 'useAdaptorsMonorepo'
   | 'globals'
+  | 'trace'
 > & {
   workflow?: Opts['workflow'];
   repoDir?: string;
@@ -35,6 +36,7 @@ const options = [
   }),
   o.outputPath,
   o.repoDir,
+  o.trace,
   o.useAdaptorsMonorepo,
   o.workflow,
 ];

--- a/packages/cli/src/compile/compile.ts
+++ b/packages/cli/src/compile/compile.ts
@@ -84,6 +84,7 @@ const compileWorkflow = async (
       ...opts,
       adaptors: job.adaptors ?? opts.adaptors,
       ignoreImports: globalsIgnoreList,
+      trace: opts.trace,
     };
     if (job.expression) {
       const { code, map } = await compileJob(
@@ -138,6 +139,7 @@ export const loadTransformOptions = async (
 ) => {
   const options: Options = {
     logger: log || createLogger(COMPILER, opts as any),
+    trace: opts.trace,
   };
   // If an adaptor is passed in, we need to look up its declared exports
   // and pass them along to the compiler

--- a/packages/cli/src/execute/command.ts
+++ b/packages/cli/src/execute/command.ts
@@ -31,6 +31,7 @@ export type ExecuteOptions = Required<
     | 'stateStdin'
     | 'sanitize'
     | 'timeout'
+    | 'trace'
     | 'useAdaptorsMonorepo'
     | 'workflowPath'
     | 'globals'
@@ -61,6 +62,7 @@ const options = [
   o.statePath,
   o.stateStdin,
   o.timeout,
+  o.trace,
   o.useAdaptorsMonorepo,
 ];
 

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -60,6 +60,7 @@ export type Opts = {
   statePath?: string;
   stateStdin?: string;
   timeout?: number; // ms
+  trace?: boolean;
   useAdaptorsMonorepo?: boolean;
   workflow: string;
 
@@ -510,6 +511,17 @@ export const timeout: CLIOption = {
     number: true,
     description: 'Set the timeout duration (ms). Defaults to 5 minutes.',
     default: 5 * 60 * 1000,
+  },
+};
+
+// undocumented secret API
+export const trace: CLIOption = {
+  name: 'trace',
+  yargs: {
+    boolean: true,
+    hidden: true,
+    description: 'Show trace debugger output in the compiler',
+    default: false,
   },
 };
 

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -39,7 +39,8 @@ export default function compile(
   }
 
   const name = options.name ?? 'src';
-  const ast = parse(source, { name });
+  const trace = options.trace;
+  const ast = parse(source, { logger, name, trace });
   const transformedAst = transform(ast, undefined, options);
 
   const { code, map } = print(transformedAst, {

--- a/packages/compiler/src/parse.ts
+++ b/packages/compiler/src/parse.ts
@@ -11,10 +11,12 @@
 import recast from 'recast';
 import * as acorn from 'acorn';
 import { namedTypes } from 'ast-types';
+import { heap } from './util';
 
 type Options = {
   /** Name of the source job (no file extension). This triggers source map generation */
   name?: string;
+  trace?: boolean;
 };
 
 export default function parse(
@@ -23,6 +25,10 @@ export default function parse(
 ): namedTypes.File {
   // This is copied from v1 but I am unsure the use-case
   const escaped = source.replace(/\ $/, '');
+
+  if (options.trace) {
+    heap('pre acorn parse');
+  }
 
   const ast = recast.parse(escaped, {
     sourceFileName: options.name && `${options.name}.js`,
@@ -38,6 +44,10 @@ export default function parse(
         }),
     },
   });
+
+  if (options.trace) {
+    heap('post acorn parse');
+  }
 
   // Recast with Acorn doesn't have an initial errors array
   if (!ast.program.errors) {

--- a/packages/compiler/src/parse.ts
+++ b/packages/compiler/src/parse.ts
@@ -11,12 +11,16 @@
 import recast from 'recast';
 import * as acorn from 'acorn';
 import { namedTypes } from 'ast-types';
+
 import { heap } from './util';
+
+import type { Logger } from '@openfn/logger';
 
 type Options = {
   /** Name of the source job (no file extension). This triggers source map generation */
   name?: string;
   trace?: boolean;
+  logger?: Logger;
 };
 
 export default function parse(
@@ -27,7 +31,7 @@ export default function parse(
   const escaped = source.replace(/\ $/, '');
 
   if (options.trace) {
-    heap('pre acorn parse');
+    heap('pre acorn parse', options.logger);
   }
 
   const ast = recast.parse(escaped, {
@@ -46,7 +50,7 @@ export default function parse(
   });
 
   if (options.trace) {
-    heap('post acorn parse');
+    heap('post acorn parse', options.logger);
   }
 
   // Recast with Acorn doesn't have an initial errors array

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -10,6 +10,7 @@ import promises from './transforms/promises';
 import topLevelOps, {
   TopLevelOpsOptions,
 } from './transforms/top-level-operations';
+import { heap } from './util';
 
 export type TransformerName =
   | 'add-imports'
@@ -33,6 +34,7 @@ export type Transformer = {
 
 export type TransformOptions = {
   logger?: Logger; //  TODO maybe in the wrong place?
+  trace?: boolean; // print debug information
 
   ['add-imports']?: AddImportsOptions | boolean;
   ['ensure-exports']?: boolean;
@@ -49,8 +51,24 @@ export default function transform(
   transformers?: Transformer[],
   options: TransformOptions = {}
 ) {
+  const printHeap = (reason: string) => {
+    if (options.trace) {
+      heap(reason);
+    }
+  };
+  const start = Date.now();
+
   if (!transformers) {
     transformers = [
+      lazyState,
+      promises,
+      ensureExports,
+      topLevelOps,
+      addImports,
+    ] as Transformer[];
+
+    // @ts-ignore
+    const _transformers = [
       lazyState,
       promises,
       ensureExports,
@@ -77,6 +95,7 @@ export default function transform(
       for (const type of types) {
         const name = `visit${type}` as keyof Visitor;
         astTypes[name] = function (path: NodePath) {
+          printHeap(`visit: ${path.name}`);
           const opts = options[id] || {};
           const abort = visitor!(path, logger, opts);
           if (abort) {
@@ -89,6 +108,10 @@ export default function transform(
       // @ts-ignore
       visit(ast, astTypes);
     });
+
+  printHeap(`finished`);
+  const duration = (Date.now() - start) / 1000;
+  logger.debug(`Finished in ${duration}s`);
 
   return ast;
 }

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -53,7 +53,7 @@ export default function transform(
 ) {
   const printHeap = (reason: string) => {
     if (options.trace) {
-      heap(reason);
+      heap(reason, options.logger);
     }
   };
   const start = Date.now();

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -66,15 +66,6 @@ export default function transform(
       topLevelOps,
       addImports,
     ] as Transformer[];
-
-    // @ts-ignore
-    const _transformers = [
-      lazyState,
-      promises,
-      ensureExports,
-      topLevelOps,
-      addImports,
-    ] as Transformer[];
   }
   const logger = options.logger || defaultLogger;
 

--- a/packages/compiler/src/transforms/add-imports.ts
+++ b/packages/compiler/src/transforms/add-imports.ts
@@ -189,6 +189,7 @@ function visitor(path: NodePath, logger: Logger, options: AddImportsOptions) {
       }
     }
   }
+  return true;
 }
 
 // Add an import statement to pull in the named values from an adaptor

--- a/packages/compiler/src/transforms/ensure-exports.ts
+++ b/packages/compiler/src/transforms/ensure-exports.ts
@@ -14,12 +14,14 @@ function visitor(path: NodePath<namedTypes.Program>) {
   // if we find any, we do nothing
   const currentExport = path.node.body.find(({ type }) => type.match(/Export/));
   if (currentExport) {
-    return;
+    return true;
   }
 
   // Add an empty export default statement as the final statement
   const newExport = buildExports();
   path.node.body.push(newExport);
+
+  return true;
 }
 
 // This will basically create `default export [];`

--- a/packages/compiler/src/transforms/lazy-state.ts
+++ b/packages/compiler/src/transforms/lazy-state.ts
@@ -102,9 +102,6 @@ function visitor(path: NodePath<n.MemberExpression>) {
     // from the parenting member expression, ensure the parent arrow is nicely wrapped
     ensureParentArrow(path);
   }
-
-  // Stop parsing this member expression
-  return true;
 }
 
 export default {

--- a/packages/compiler/src/transforms/lazy-state.ts
+++ b/packages/compiler/src/transforms/lazy-state.ts
@@ -104,7 +104,7 @@ function visitor(path: NodePath<n.MemberExpression>) {
   }
 
   // Stop parsing this member expression
-  return false;
+  return true;
 }
 
 export default {

--- a/packages/compiler/src/transforms/top-level-operations.ts
+++ b/packages/compiler/src/transforms/top-level-operations.ts
@@ -48,7 +48,7 @@ function visitor(path: NodePath<namedTypes.CallExpression>) {
   }
 
   // if not (for now) we should cancel traversal
-  // (should we only cancel traversal for this visitor?)
+  return true;
 }
 
 // Add metadata to each operation for:

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -5,10 +5,10 @@ import path from 'node:path';
 import { Project, describeDts } from '@openfn/describe-package';
 import type { Logger } from '@openfn/logger';
 
-export function heap(reason: string) {
+export function heap(reason: string, logger?: Logger) {
   const { used_heap_size } = getHeapStatistics();
   const mb = used_heap_size / 1024 / 1024;
-  console.log(`>> [${reason}] Used heap at ${mb.toFixed(2)}mb`);
+  logger?.debug(`[${reason}] Used heap at ${mb.toFixed(2)}mb`);
 }
 
 export const loadFile = (filePath: string) =>

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -1,8 +1,15 @@
 import { readFileSync } from 'node:fs';
+import { getHeapStatistics } from 'v8';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { Project, describeDts } from '@openfn/describe-package';
 import type { Logger } from '@openfn/logger';
+
+export function heap(reason: string) {
+  const { used_heap_size } = getHeapStatistics();
+  const mb = used_heap_size / 1024 / 1024;
+  console.log(`>> [${reason}] Used heap at ${mb.toFixed(2)}mb`);
+}
 
 export const loadFile = (filePath: string) =>
   readFileSync(path.resolve(filePath), 'utf8');


### PR DESCRIPTION
This PR reduces the memory overhead of compilation by making some visitors exit early

I'm parsing 1.6mb Javascript file here which, in production takes around 350mb to parse.

This PR brings that down to around 270mb.

Note that I've added a little `trace` option to the compiler, although I haven't added it to the CLI yet. Should really add it as an undocumented option.

This is just a quick win really. I think we need to figure out how to do #1011 properly, which will take some thinking (I sure hope our unit tests are good enough to catch regressions, that'll be a risky job)

Closes #744

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
