### PR TITLE
only run CI against a single node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
     # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
     docker:
-      - image: cimg/node:22.12
+      - image: cimg/node:22.20
     resource_class: medium
     # Add steps to the job
     # See: https://circleci.com/docs/2.0/configuration-reference/#steps
@@ -35,7 +35,7 @@ jobs:
 
   build:
     docker:
-      - image: cimg/node:22.12
+      - image: cimg/node:22.20
     resource_class: medium
     steps:
       - attach_workspace:
@@ -50,7 +50,7 @@ jobs:
 
   unit_test:
     docker:
-      - image: cimg/node:22.12
+      - image: cimg/node:22.20
     resource_class: medium
     parallelism: 1
     steps:
@@ -62,7 +62,7 @@ jobs:
 
   format:
     docker:
-      - image: cimg/node:22.12
+      - image: cimg/node:22.20
     resource_class: medium
     steps:
       - attach_workspace:
@@ -73,7 +73,7 @@ jobs:
 
   type_check:
     docker:
-      - image: cimg/node:22.12
+      - image: cimg/node:22.20
     resource_class: medium
     steps:
       - attach_workspace:
@@ -131,8 +131,6 @@ workflows:
       - integration_test:
           matrix:
             parameters:
-              # temporarily test against a range of versions while we get over teh 18x hump
-              # We can reduce this later
-              node_version: ['18.12.1', '18.18', '20.18.1', '22.12']
+              node_version: ['22.20']
           requires:
             - build


### PR DESCRIPTION
It's time to stop running CI tests against 4 versions of node. Node 18 is old enough now - we haven't officially deprecated it but we really need to.

Unofficially, I'm done with it.

We're getting a lot of flaky test fails in the integration suite lately. Running fewer tests might result in fewer fails.