### PR TITLE
fix: yaml execution error

### DIFF
--- a/.changeset/wild-trees-wink.md
+++ b/.changeset/wild-trees-wink.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Fix CLI execution errors when passed a workflow yaml file.

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -312,7 +312,7 @@ export const ignoreImports: CLIOption = {
 
 const getBaseDir = (opts: { path?: string }) => {
   const basePath = opts.path ?? '.';
-  if (/\.(jso?n?)$/.test(basePath)) {
+  if (/\.(jso?n?|ya?ml)$/.test(basePath)) {
     return nodePath.dirname(basePath);
   }
   return basePath;
@@ -343,6 +343,8 @@ export const inputPath: CLIOption = {
     } else if (basePath?.endsWith('.js')) {
       opts.expressionPath = basePath;
     } else {
+      // why couldn't this be path.basename?
+      // currently it only returns path.basename when .json is matched. added support for .ya?ml
       const base = getBaseDir(opts);
       setDefaultValue(opts, 'expressionPath', nodePath.join(base, 'job.js'));
     }

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -343,8 +343,6 @@ export const inputPath: CLIOption = {
     } else if (basePath?.endsWith('.js')) {
       opts.expressionPath = basePath;
     } else {
-      // why couldn't this be path.basename?
-      // currently it only returns path.basename when .json is matched. added support for .ya?ml
       const base = getBaseDir(opts);
       setDefaultValue(opts, 'expressionPath', nodePath.join(base, 'job.js'));
     }

--- a/packages/cli/src/util/validate-plan.ts
+++ b/packages/cli/src/util/validate-plan.ts
@@ -29,6 +29,7 @@ const assertWorkflowStructure = (plan: ExecutionPlan, logger: Logger) => {
 const assertStepStructure = (step: Job | Trigger, index: number) => {
   const allowedKeys = [
     'id',
+    'type',
     'name',
     'next',
     'previous',


### PR DESCRIPTION
## Short Description

The issue is that
1. Our step validation code doesn't allow `type` as a key.
2. We weren't getting the base directory well when the path passed to the command line was a `.yaml` or `.yml` file. we were considering just `.json` well.

## Implementation Details

A more detailed breakdown of the changes, including motivations (if not provided in the issue).

## QA Notes

List any considerations/cases/advice for testing/QA here.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset version` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
