### PR TITLE
worker: don't destroy until all outstanding claims have come home

### DIFF
--- a/.changeset/cuddly-apples-buy.md
+++ b/.changeset/cuddly-apples-buy.md
@@ -1,5 +1,0 @@
----
-'@openfn/ws-worker': patch
----
-
-Allow the worker to shutdown gracefully while claims are still in-flight. Runs will be completed before the server closes

--- a/.changeset/cuddly-apples-buy.md
+++ b/.changeset/cuddly-apples-buy.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Allow the worker to shutdown gracefully while claims are still in-flight. Runs will be completed before the server closes

--- a/packages/lightning-mock/src/server.ts
+++ b/packages/lightning-mock/src/server.ts
@@ -117,10 +117,13 @@ const createLightningServer = (options: LightningOptions = {}) => {
 
   app.use(createRestAPI(app as any, state, logger, api));
 
-  app.destroy = () => {
-    server.close();
-    api.close();
-  };
+  app.destroy = () =>
+    new Promise<void>(async (resolve) => {
+      api.close();
+      server.close(() => {
+        resolve();
+      });
+    });
   return app;
 };
 

--- a/packages/lightning-mock/src/types.ts
+++ b/packages/lightning-mock/src/types.ts
@@ -14,7 +14,7 @@ export type DevServer = Koa & {
   addCredential(id: string, cred: Credential): void;
   addDataclip(id: string, data: DataClip): void;
   enqueueRun(run: LightningPlan): void;
-  destroy: () => void;
+  destroy: () => Promise<void>;
   getRun(id: string): LightningPlan;
   getCredential(id: string): Credential;
   getDataclip(id: string): DataClip;

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ws-worker
 
+## 1.15.3
+
+### Patch Changes
+
+- 5688813: Allow the worker to shutdown gracefully while claims are still in-flight. Runs will be completed before the server closes
+
 ## 1.15.2
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/ws-worker/src/events.ts
+++ b/packages/ws-worker/src/events.ts
@@ -14,6 +14,9 @@ export const RUN_LOG = 'run:log';
 export const STEP_START = 'step:start';
 export const STEP_COMPLETE = 'step:complete';
 export const INTERNAL_RUN_COMPLETE = 'server:run-complete';
+export const INTERNAL_CLAIM_START = 'server:claim-start';
+export const INTERNAL_CLAIM_COMPLETE = 'server:claim-complete';
+export const INTERNAL_SOCKET_READY = 'server:socket-ready';
 
 export type QueueEvents = {
   [CLAIM]: l.ClaimPayload;

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -11,7 +11,11 @@ import Router from '@koa/router';
 import { humanId } from 'human-id';
 import { createMockLogger, Logger } from '@openfn/logger';
 import { ClaimRun } from '@openfn/lexicon/lightning';
-import { INTERNAL_RUN_COMPLETE, WORK_AVAILABLE } from './events';
+import {
+  INTERNAL_RUN_COMPLETE,
+  INTERNAL_SOCKET_READY,
+  WORK_AVAILABLE,
+} from './events';
 import destroy from './api/destroy';
 import startWorkloop, { Workloop } from './api/workloop';
 import claim from './api/claim';
@@ -71,6 +75,9 @@ export interface ServerApp extends Koa {
   execute: ({ id, token }: ClaimRun) => Promise<void>;
   destroy: () => void;
   resumeWorkloop: () => void;
+
+  // debug API
+  claim: () => Promise<any>;
 }
 
 type SocketAndChannel = {
@@ -112,6 +119,7 @@ function connect(app: ServerApp, logger: Logger, options: ServerOptions = {}) {
       logger.break();
     }
 
+    app.events.emit(INTERNAL_SOCKET_READY);
     app.resumeWorkloop();
   };
 
@@ -147,9 +155,12 @@ function connect(app: ServerApp, logger: Logger, options: ServerOptions = {}) {
   // handles messages for the worker:queue
   const onMessage = (event: string) => {
     if (event === WORK_AVAILABLE) {
-      claim(app, logger, { maxWorkers: options.maxWorkflows }).catch(() => {
-        // do nothing - it's fine if  claim throws here
-      });
+      // TODO ought to have a unit test against this
+      if (!app.destroyed) {
+        claim(app, logger, { maxWorkers: options.maxWorkflows }).catch(() => {
+          // do nothing - it's fine if  claim throws here
+        });
+      }
     }
   };
 
@@ -350,6 +361,12 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
         ctx.status = 204;
       });
   });
+
+  app.claim = () => {
+    return claim(app, logger, {
+      maxWorkers: options.maxWorkflows,
+    });
+  };
 
   app.destroy = () => destroy(app, logger);
 

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -155,7 +155,6 @@ function connect(app: ServerApp, logger: Logger, options: ServerOptions = {}) {
   // handles messages for the worker:queue
   const onMessage = (event: string) => {
     if (event === WORK_AVAILABLE) {
-      // TODO ought to have a unit test against this
       if (!app.destroyed) {
         claim(app, logger, { maxWorkers: options.maxWorkflows }).catch(() => {
           // do nothing - it's fine if  claim throws here

--- a/packages/ws-worker/test/api/claim.test.ts
+++ b/packages/ws-worker/test/api/claim.test.ts
@@ -145,7 +145,7 @@ const createMockApp = (opts: any) => {
     openClaims: {},
     workflows,
     queueChannel: channel,
-    execute: (...args) => {
+    execute: (...args: any) => {
       onExecute(...args);
     },
     events: new EventEmitter(),

--- a/packages/ws-worker/test/api/claim.test.ts
+++ b/packages/ws-worker/test/api/claim.test.ts
@@ -8,6 +8,7 @@ import { createMockLogger } from '@openfn/logger';
 import { ServerApp } from '../../src/server';
 import { mockChannel } from '../../src/mock/sockets';
 import { CLAIM } from '../../src';
+import EventEmitter from 'node:events';
 
 let keys = { public: '.', private: '.' };
 
@@ -147,7 +148,8 @@ const createMockApp = (opts: any) => {
     execute: (...args) => {
       onExecute(...args);
     },
-  } as ServerApp;
+    events: new EventEmitter(),
+  } as unknown as ServerApp;
 };
 const logger = createMockLogger();
 


### PR DESCRIPTION
## Short Description

No issue: I learned this afternoon that some lost runs are caused by the worker receiving a SIGTERM while claims are still outstanding.

If lightning happens to have released these claims, the worker will shut down and renege on its promise to complete the work.

As a result of this PR, the worker will now wait for all outstanding claims, and their associated runs, before shutting down.

Most of the effort was in getting the test to work - took a bunch of refactoring :sweat_smile: 


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
