### PR TITLE
Runtime: experiment with custom promise class

### DIFF
--- a/packages/runtime/src/execute/context.ts
+++ b/packages/runtime/src/execute/context.ts
@@ -34,6 +34,24 @@ export default (
     }
   }
 
+  // TODO naming
+  class FancyPromise extends Promise {
+    constructor(resolve, reject) {
+      super(resolve, reject);
+    }
+    reject(e: any) {
+      console.log(' >>> custom reject!!');
+      if (!e || !(e instanceof Error)) {
+        // Force all promise objects to be errors
+        // This allows us to track positions
+        const error = new Error();
+        Object.assign(error, e);
+        return super.reject(error);
+      }
+      return super.reject(e);
+    }
+  }
+
   const context = vm.createContext(
     freezeAll(
       {
@@ -48,6 +66,7 @@ export default (
         setTimeout,
         state, // TODO will be dropped as a global one day, see https://github.com/OpenFn/kit/issues/17
         Buffer: SafeBuffer,
+        Promise: FancyPromise,
       },
       { state: true }
     ),

--- a/packages/runtime/test/errors.test.ts
+++ b/packages/runtime/test/errors.test.ts
@@ -313,6 +313,28 @@ test('fail on runtime TypeError', async (t) => {
   });
 });
 
+test.only('fail with position on rejected promise', async (t) => {
+  const expression = `export default [(s) => {
+  return Promise.reject({});
+}]`;
+
+  const result: any = await run(expression);
+  const error = result.errors['job-1'];
+  t.log(error);
+
+  // t.deepEqual(error, {
+  //   message: "TypeError: Cannot read properties of undefined (reading 'y')",
+  //   name: 'RuntimeError',
+  //   subtype: 'TypeError',
+  //   severity: 'fail',
+  //   source: 'runtime',
+  //   pos: {
+  //     column: 28,
+  //     line: 1,
+  //   },
+  // });
+});
+
 test('fail on runtime error with RangeError', async (t) => {
   const expression =
     'export default [(s) => Number.parseFloat("1").toFixed(-1)]';


### PR DESCRIPTION
Found a case where a rejected promise has no error information attached.

The fix is to force an error object to be generated in these cases. Not sure if I'm committed to this yet - just trying it out.

Fixes #1174 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
