### PR TITLE
Validate API key and endpoint before making requests

### DIFF
--- a/packages/cli/src/projects/util.ts
+++ b/packages/cli/src/projects/util.ts
@@ -37,13 +37,6 @@ export const loadAppAuthConfig = (
       'OPENFN_API_KEY is required. Set it in .env, pass --api-key, or set the environment variable.'
     );
   }
-  if (!config.endpoint) {
-    throw new CLIError(
-      'OPENFN_ENDPOINT is required. Set it in .env, pass --endpoint, or set the environment variable.\n' +
-        'Example: OPENFN_ENDPOINT=https://app.openfn.org'
-    );
-  }
-
   return config as Required<AuthOptions>;
 };
 
@@ -103,6 +96,12 @@ export const getLightningUrl = (
   path: string = '',
   snapshots?: string[]
 ) => {
+  if (!endpoint) {
+    throw new CLIError(
+      'OPENFN_ENDPOINT is required. Set it in .env, pass --endpoint, or set the environment variable.\n' +
+        'Example: OPENFN_ENDPOINT=https://app.openfn.org'
+    );
+  }
   const params = new URLSearchParams();
   snapshots?.forEach((snapshot) => params.append('snapshots[]', snapshot));
   return new URL(`/api/provision/${path}?${params.toString()}`, endpoint);


### PR DESCRIPTION
## Short Description

Throw a clear error when `OPENFN_API_KEY` or `OPENFN_ENDPOINT` is missing instead of letting it fall through to a cryptic `TypeError: Invalid URL`.

See #1249

## Implementation Details

In `loadAppAuthConfig` (`projects/util.ts`), when `OPENFN_ENDPOINT` is not set, `config.endpoint` stays `undefined`. This later causes `new URL('/api/provision/...', undefined)` in `getLightningUrl` to throw `TypeError: Invalid URL`, which is not helpful to the user.

There was already a `// TODO probably need to throw` on line 35 anticipating this. This PR fills in that TODO with early validation for both `apiKey` and `endpoint`, with actionable error messages.

## QA Notes

1. Create a `.env` with only `OPENFN_API_KEY` (no `OPENFN_ENDPOINT`)
2. Run `openfn project pull <uuid> -c .env`
3. Verify you get `OPENFN_ENDPOINT is required...` instead of `TypeError: Invalid URL`
4. Remove `OPENFN_API_KEY` too and verify you get `OPENFN_API_KEY is required...`

## AI Usage

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI