### PR TITLE
Align AI Usage section in PR template with Lightning

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,17 +14,15 @@ List any considerations/cases/advice for testing/QA here.
 
 ## AI Usage
 
-Please disclose how you've used AI in this work (it's cool, we just want to know!):
+Please disclose whether you've used AI anywhere in this PR (it's cool, we just
+want to know!):
 
-- [ ] Code generation (copilot but not intellisense)
-- [ ] Learning or fact checking
-- [ ] Strategy / design
-- [ ] Optimisation / refactoring
-- [ ] Translation / spellchecking / doc gen
-- [ ] Other
+- [ ] I have used Claude Code
+- [ ] I have used another model
 - [ ] I have not used AI
 
-You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
+You can read more details in our
+[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
 
 ## Release branch checklist
 


### PR DESCRIPTION
## Short Description

Align the AI Usage section of the PR template with Lightning's updated format. The old granular checkboxes (code generation, learning, strategy, etc.) are replaced with the simplified disclosure used in Lightning: Claude Code / other model / not used.

## Implementation Details

## QA Notes

## AI Usage

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)