### PR TITLE
update the worker to node 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable

--- a/packages/ws-worker/README.md
+++ b/packages/ws-worker/README.md
@@ -11,6 +11,15 @@ This package contains:
 
 The mock services allow lightweight and controlled testing of the interfaces between them.
 
+## Docker
+
+To build and run the worker as a Docker image locally:
+
+```bash
+docker build -t openfn-worker .
+docker run --network host -e WORKER_SECRET=$WORKER_SECRET -e WORKER_LIGHTNING_SERVICE_URL="ws://localhost:4000/worker"  openfn-worker
+```
+
 ## Getting started
 
 To use this server:
@@ -98,12 +107,12 @@ remaining capacity serve general work.
 
 ### Syntax
 
-| Element | Meaning |
-|---------|---------|
-| `>` | Queue preference separator (left = highest priority) |
-| `*` | Wildcard: accept runs from any queue (must be last) |
-| `:N` | Number of slots for this group |
-| ` ` (space) | Group separator |
+| Element     | Meaning                                              |
+| ----------- | ---------------------------------------------------- |
+| `>`         | Queue preference separator (left = highest priority) |
+| `*`         | Wildcard: accept runs from any queue (must be last)  |
+| `:N`        | Number of slots for this group                       |
+| ` ` (space) | Group separator                                      |
 
 ### Examples
 


### PR DESCRIPTION
Didn't do this on the prior release - update the worker image to use node 24

We've tested the worker with the new loader on node 22 and it works great

This updates the worker to node 24

I need to test the image locally before putting onto staging because of permissions changes in node 24. It's probably fine - I don't think anything affects us? - but needs a sanity test before we do the update