### PR TITLE
fix(project): include trigger reply fields in version hash

### DIFF
--- a/.changeset/quiet-seals-battle.md
+++ b/.changeset/quiet-seals-battle.md
@@ -1,0 +1,6 @@
+---
+'@openfn/project': patch
+'@openfn/cli': patch
+---
+
+Include `webhook_reply` and `cron_cursor_job_id` in workflow version hashes.

--- a/packages/project/src/util/version.ts
+++ b/packages/project/src/util/version.ts
@@ -54,7 +54,13 @@ export const generateHash = (
     'body',
   ].sort();
 
-  const triggerKeys = ['type', 'cron_expression', 'enabled'].sort();
+  const triggerKeys = [
+    'type',
+    'cron_expression',
+    'enabled',
+    'webhook_reply',
+    'cron_cursor_job_id',
+  ].sort();
 
   const edgeKeys = [
     'name', // generated

--- a/packages/project/test/util/version-workflow.test.ts
+++ b/packages/project/test/util/version-workflow.test.ts
@@ -384,6 +384,40 @@ test('hash a trigger', (t) => {
   t.not(generateHash(webhook), generateHash(cronExpression));
 });
 
+test('hash changes when webhook_reply changes', (t) => {
+  const wf1 = generateWorkflow(
+    `@name wf-1
+    @id workflow-id
+    t(type=webhook,webhook_reply=x)-x
+    `
+  );
+  const wf2 = generateWorkflow(
+    `@name wf-1
+    @id workflow-id
+    t(type=webhook,webhook_reply=y)-x
+    `
+  );
+
+  t.not(generateHash(wf1), generateHash(wf2));
+});
+
+test('hash changes when cron_cursor_job_id changes', (t) => {
+  const wf1 = generateWorkflow(
+    `@name wf-1
+    @id workflow-id
+    t(type=cron,cron_expression="1",cron_cursor_job_id=x)-x
+    `
+  );
+  const wf2 = generateWorkflow(
+    `@name wf-1
+    @id workflow-id
+    t(type=cron,cron_expression="1",cron_cursor_job_id=y)-x
+    `
+  );
+
+  t.not(generateHash(wf1), generateHash(wf2));
+});
+
 test('hash changes across an edge', (t) => {
   const basicEdge = generateWorkflow(
     `


### PR DESCRIPTION
## Description

This keeps the project-side workflow version hash aligned with Lightning by including `webhook_reply` and `cron_cursor_job_id` in the trigger field list used by `generateHash()`.

Without this, the CLI can compute a different hash from Lightning for the same workflow after those trigger fields change.

## Changes

- include `webhook_reply` and `cron_cursor_job_id` in `packages/project/src/util/version.ts`
- add regression tests covering both trigger fields in `packages/project/test/util/version-workflow.test.ts`
- add a changeset so the fix is released through the monorepo flow


Companion to OpenFn/lightning#4599.

## AI Usage

Used only for research.
