### PR TITLE
Possible k8s OOM kill prevention pill 1 (--max-old-space-size)

### DIFF
--- a/.changeset/five-months-dance.md
+++ b/.changeset/five-months-dance.md
@@ -1,0 +1,6 @@
+---
+'@openfn/engine-multi': patch
+'@openfn/ws-worker': patch
+---
+
+Enforce run memory limits at the child_process level

--- a/packages/engine-multi/src/api/call-worker.ts
+++ b/packages/engine-multi/src/api/call-worker.ts
@@ -12,6 +12,7 @@ type WorkerOptions = {
   maxWorkers?: number;
   env?: any;
   timeout?: number; // ms
+  memoryLimitMb?: number;
   proxyStdout?: boolean; // print internal stdout to console
 };
 
@@ -22,13 +23,19 @@ export default function initWorkers(
   options: WorkerOptions = {},
   logger: Logger
 ) {
-  const { env = {}, maxWorkers = 5, proxyStdout = false } = options;
+  const {
+    env = {},
+    maxWorkers = 5,
+    memoryLimitMb,
+    proxyStdout = false,
+  } = options;
 
   const workers = createPool(
     workerPath,
     {
       maxWorkers,
       env,
+      memoryLimitMb,
       proxyStdout,
     },
     logger

--- a/packages/engine-multi/src/engine.ts
+++ b/packages/engine-multi/src/engine.ts
@@ -139,6 +139,7 @@ const createEngine = async (
     resolvedWorkerPath,
     {
       maxWorkers: options.maxWorkers,
+      memoryLimitMb: defaultMemoryLimit,
       proxyStdout: options.proxyStdout,
     },
     options.logger

--- a/packages/engine-multi/src/test/worker-functions.ts
+++ b/packages/engine-multi/src/test/worker-functions.ts
@@ -24,6 +24,7 @@ const tasks = {
   },
   threadId: async () => threadId,
   processId: async () => process.pid,
+  getExecArgv: async () => process.execArgv,
   // very very simple intepretation of a run function
   // Most tests should use the mock-worker instead
   run: async (plan: ExecutionPlan, _input: any, _adaptorPaths: any) => {

--- a/packages/engine-multi/src/worker/pool.ts
+++ b/packages/engine-multi/src/worker/pool.ts
@@ -18,6 +18,7 @@ export type PoolOptions = {
   capacity?: number; // defaults to 5
   maxWorkers?: number; // alias for capacity. Which is best?
   env?: Record<string, string>; // default environment for workers
+  memoryLimitMb?: number; // --max-old-space-size for child processes
 
   proxyStdout?: boolean; // print internal stdout to console
 };
@@ -83,8 +84,13 @@ function createPool(script: string, options: PoolOptions = {}, logger: Logger) {
     let child: ChildProcess;
     if (!maybeChild) {
       // create a new child process and load the module script into it
+      const execArgv = ['--experimental-vm-modules', '--no-warnings'];
+      if (options.memoryLimitMb) {
+        execArgv.push(`--max-old-space-size=${options.memoryLimitMb}`);
+      }
+
       child = fork(envPath, [script], {
-        execArgv: ['--experimental-vm-modules', '--no-warnings'],
+        execArgv,
 
         env: options.env || {},
 

--- a/packages/engine-multi/test/worker/pool.test.ts
+++ b/packages/engine-multi/test/worker/pool.test.ts
@@ -185,6 +185,30 @@ test('throw if memory limit is exceeded', async (t) => {
   }
 });
 
+test('child process should have --max-old-space-size when memoryLimitMb is set', async (t) => {
+  const pool = createPool(workerPath, { memoryLimitMb: 200 }, logger);
+  const execArgv = await pool.exec('getExecArgv', []);
+  t.true(execArgv.some((a: string) => a === '--max-old-space-size=200'));
+});
+
+test('child process should not have --max-old-space-size when memoryLimitMb is not set', async (t) => {
+  const pool = createPool(workerPath, {}, logger);
+  const execArgv = await pool.exec('getExecArgv', []);
+  t.false(execArgv.some((a: string) => a.includes('--max-old-space-size')));
+});
+
+test('pool recovers after process-level OOM', async (t) => {
+  const pool = createPool(workerPath, { memoryLimitMb: 50 }, logger);
+
+  await t.throwsAsync(() => pool.exec('blowMemory', [], { memoryLimitMb: 20 }), {
+    name: 'OOMError',
+  });
+
+  // Pool should still be functional after the OOM
+  const result = await pool.exec('test', [42]);
+  t.is(result, 42);
+});
+
 test('handle weird exit', async (t) => {
   const pool = createPool(workerPath, {}, logger);
 


### PR DESCRIPTION
Adds `--max-old-space-size` to child processes forked by the worker pool.

Currently, memory limits only apply at the Worker Thread level via V8's `resourceLimits`. The child process itself runs with V8's default heap limit (~1.5-4GB). During rapid allocation spikes (e.g., infinite loop pushing to an array), this means the child process can grow far beyond the intended run memory limit before V8 kills the thread.

This change passes `--max-old-space-size` to the child process, reducing the ceiling from V8's default down to `WORKER_MAX_RUN_MEMORY_MB` (default 500MB). This makes V8 GC more aggressively at the process level and trigger OOM earlier.

This does **not** guarantee protection against k8s OOM kills — RSS can still transiently exceed the V8 heap limit during rapid allocation. But it significantly reduces the headroom from gigabytes to something much closer to the configured limit. A hard guarantee would require kernel-level enforcement via cgroups (future work).

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset version` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
