### PR TITLE
Fix state growing exponentially on empty cron tasks

### DIFF
--- a/.changeset/tender-cases-write.md
+++ b/.changeset/tender-cases-write.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+When processing final state for a run with multiple leaf nodes, don't send empty leaf results. This prevents state recursively growing in cron tasks

--- a/packages/ws-worker/src/events/run-complete.ts
+++ b/packages/ws-worker/src/events/run-complete.ts
@@ -8,20 +8,44 @@ import logFinalReason from '../util/log-final-reason';
 import { timeInMicroseconds } from '../util';
 import { sendEvent } from '../util/send-event';
 
+const isEmptyState = (obj: any) => {
+  if (Object.keys(obj).length == 0) {
+    return true;
+  }
+  if (
+    Object.keys(obj).length == 1 &&
+    'data' in obj &&
+    !Object.keys(obj.data).length
+  ) {
+    return true;
+  }
+  return false;
+};
+
 export default async function onWorkflowComplete(
   context: Context,
   event: WorkflowCompletePayload
 ) {
   const { state, onFinish, logger } = context;
 
-  const result = event.state;
-
-  const reason = calculateRunExitReason(state);
-  await logFinalReason(context, reason);
-
   const isSingleLeaf =
     state.leafDataclipIds.length === 1 &&
     !state.withheldDataclips[state.leafDataclipIds[0]];
+
+  const result = event.state;
+
+  // remove any empty leaf nodes from state
+  // This fixes recursive state growth in cron jobs https://github.com/OpenFn/kit/issues/1367
+  if (!isSingleLeaf) {
+    for (const key in result) {
+      if (isEmptyState(result[key])) {
+        delete result[key];
+      }
+    }
+  }
+
+  const reason = calculateRunExitReason(state);
+  await logFinalReason(context, reason);
 
   const payload: RunCompletePayload = {
     timestamp: timeInMicroseconds(event.time),

--- a/packages/ws-worker/test/events/run-complete.test.ts
+++ b/packages/ws-worker/test/events/run-complete.test.ts
@@ -38,12 +38,38 @@ test('should send final_state when there are multiple leaves', async (t) => {
   const plan = createPlan();
 
   const state = createRunState(plan);
-  state.leafDataclipIds = ['clip-1', 'clip-2'];
+  state.leafDataclipIds = ['a', 'b'];
 
   const channel = mockChannel({
     [RUN_LOG]: () => true,
     [RUN_COMPLETE]: (evt) => {
       t.deepEqual(evt.final_state, result);
+      t.falsy(evt.final_dataclip_id);
+    },
+  });
+
+  const event: any = { state: result };
+
+  const context: any = { channel, state, onFinish: () => {} };
+  await handleRunComplete(context, event);
+});
+
+test('should ignore empty leaf state in final_state', async (t) => {
+  const result = {};
+  const plan = createPlan();
+
+  const state = createRunState(plan);
+  state.leafDataclipIds = ['clip-1', 'clip-2'];
+  state.dataclips = {
+    // two different structures of empty
+    a: {},
+    b: { data: {} },
+  };
+
+  const channel = mockChannel({
+    [RUN_LOG]: () => true,
+    [RUN_COMPLETE]: (evt) => {
+      t.deepEqual(evt.final_state, {});
       t.falsy(evt.final_dataclip_id);
     },
   });
@@ -438,7 +464,10 @@ test('should properly serialize final_state as JSON', async (t) => {
   await handleRunComplete(context, event);
 
   t.deepEqual(completeEvent.final_state, complexState);
-  t.deepEqual(completeEvent.final_state.data.users[0], { id: 1, name: 'Alice' });
+  t.deepEqual(completeEvent.final_state.data.users[0], {
+    id: 1,
+    name: 'Alice',
+  });
   t.is(completeEvent.final_state.data.metadata.nested.deeply.value, 42);
 
   const jsonString = JSON.stringify(completeEvent.final_state);
@@ -473,5 +502,8 @@ test('should handle Uint8Array in final_state', async (t) => {
 
   await handleRunComplete(context, event);
 
-  t.deepEqual(completeEvent.final_state.data.buffer, new Uint8Array([1, 2, 3, 4, 5]));
+  t.deepEqual(
+    completeEvent.final_state.data.buffer,
+    new Uint8Array([1, 2, 3, 4, 5])
+  );
 });


### PR DESCRIPTION
A simple fix: ignore empty state objects on final state

This prevents empty workflows with mutliple leaves on a cron from getting into an infinite  growth state.

Cron jobs with multiple leaves will need to do manual state reconcilation anyway, and users can fix this on their own terms.

This is about ensuring that empty workflows, particularly those  generated by AI, are stable.

closes half of #1367


## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
