### PR TITLE
Rollback min release age

### DIFF
--- a/.changeset/chubby-moments-start.md
+++ b/.changeset/chubby-moments-start.md
@@ -1,7 +1,0 @@
----
-'@openfn/runtime': patch
-'@openfn/cli': patch
-'@openfn/ws-worker': patch
----
-
-Revert min-release-age constraint on adaptor installation

--- a/.changeset/chubby-moments-start.md
+++ b/.changeset/chubby-moments-start.md
@@ -1,0 +1,7 @@
+---
+'@openfn/runtime': patch
+'@openfn/cli': patch
+'@openfn/ws-worker': patch
+---
+
+Revert min-release-age constraint on adaptor installation

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/cli
 
+## 1.34.1
+
+### Patch Changes
+
+- 9f65093: Revert min-release-age constraint on adaptor installation
+- Updated dependencies [9f65093]
+  - @openfn/runtime@1.9.1
+
 ## 1.34.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "description": "CLI devtools for the OpenFn toolchain",
   "engines": {
     "node": ">=18",

--- a/packages/engine-multi/CHANGELOG.md
+++ b/packages/engine-multi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # engine-multi
 
+## 1.11.2
+
+### Patch Changes
+
+- Updated dependencies [9f65093]
+  - @openfn/runtime@1.9.1
+
 ## 1.11.1
 
 ### Patch Changes

--- a/packages/engine-multi/package.json
+++ b/packages/engine-multi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/engine-multi",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Multi-process runtime engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/lightning-mock/CHANGELOG.md
+++ b/packages/lightning-mock/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openfn/lightning-mock
 
+## 2.4.14
+
+### Patch Changes
+
+- Updated dependencies [9f65093]
+  - @openfn/runtime@1.9.1
+  - @openfn/engine-multi@1.11.2
+
 ## 2.4.13
 
 ### Patch Changes

--- a/packages/lightning-mock/package.json
+++ b/packages/lightning-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lightning-mock",
-  "version": "2.4.13",
+  "version": "2.4.14",
   "private": true,
   "description": "A mock Lightning server",
   "main": "dist/index.js",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfn/runtime
 
+## 1.9.1
+
+### Patch Changes
+
+- 9f65093: Revert min-release-age constraint on adaptor installation
+
 ## 1.9.0
 
 ### Minor Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/runtime",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Job processing runtime.",
   "type": "module",
   "exports": {

--- a/packages/runtime/src/modules/repo.ts
+++ b/packages/runtime/src/modules/repo.ts
@@ -15,12 +15,7 @@ const defaultPkg = {
 };
 
 export const defaultRepoPath = path.join(homeDir, './openfn/repo/cli');
-const npmInstallFlags = [
-  '--no-audit',
-  '--no-fund',
-  '--no-package-lock',
-  `--min-release-age=1`,
-];
+const npmInstallFlags = ['--no-audit', '--no-fund', '--no-package-lock'];
 
 type InstallList = Array<{ name: string; version: string }>;
 

--- a/packages/runtime/test/repo/install.test.ts
+++ b/packages/runtime/test/repo/install.test.ts
@@ -119,7 +119,7 @@ test.serial('installing should use the correct flags', async (t) => {
   const flags = cmd
     .split(' ')
     .filter((token: string) => token.startsWith('--'));
-  t.assert(flags.length === 4);
+  t.assert(flags.length === 3);
   t.assert(flags.includes('--no-audit'));
   t.assert(flags.includes('--no-fund'));
   t.assert(flags.includes('--no-package-lock'));

--- a/packages/runtime/test/repo/install.test.ts
+++ b/packages/runtime/test/repo/install.test.ts
@@ -123,7 +123,6 @@ test.serial('installing should use the correct flags', async (t) => {
   t.assert(flags.includes('--no-audit'));
   t.assert(flags.includes('--no-fund'));
   t.assert(flags.includes('--no-package-lock'));
-  t.assert(flags.includes('--min-release-age=1'));
 });
 
 test.serial('install with the correct alias', async (t) => {

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # ws-worker
 
+## 1.23.8
+
+### Patch Changes
+
+- 9f65093: Revert min-release-age constraint on adaptor installation
+- Updated dependencies [9f65093]
+  - @openfn/runtime@1.9.1
+  - @openfn/engine-multi@1.11.2
+
 ## 1.23.7
 
 ### Patch Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.23.7",
+  "version": "1.23.8",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Turns out that when you set `min-release-age` on npm install, you can't install an adaptor directly until N hours after its release.

I thought it only affected dependencies - but it literally won't install a package even if you ask for that specific version.

I also realise now that it'll give us problems with common. Even if you could install a fresh http, it wouldn't install the correct common dep for 24 hours.

So back to the drawing board on this