### PR TITLE
Runtime: wait for notify events to send

### DIFF
--- a/.changeset/hungry-bees-call.md
+++ b/.changeset/hungry-bees-call.md
@@ -1,0 +1,5 @@
+---
+'@openfn/runtime': patch
+---
+
+make sure that notify are properly awaited

--- a/.changeset/strict-windows-think.md
+++ b/.changeset/strict-windows-think.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': patch
+---
+
+Make publish() async

--- a/packages/engine-multi/src/worker/thread/run.ts
+++ b/packages/engine-multi/src/worker/thread/run.ts
@@ -81,7 +81,7 @@ register({
         notify: (name: NotifyEvents, payload: any) => {
           // @ts-ignore
           const mappedPayload = eventMap[name]?.(payload) ?? payload;
-          publish(`worker:${name}`, {
+          return publish(`worker:${name}`, {
             workflowId: plan.id,
             ...mappedPayload,
           });

--- a/packages/runtime/src/execute/step.ts
+++ b/packages/runtime/src/execute/step.ts
@@ -147,7 +147,7 @@ const executeStep = async (
     const jobName = job.name || job.id;
 
     // The notify events only apply to jobs - not steps - so names don't need to be changed here
-    notify(NOTIFY_INIT_START, { jobId });
+    await notify(NOTIFY_INIT_START, { jobId });
 
     // lazy load config and state
     const configuration = await loadCredentials(
@@ -166,7 +166,7 @@ const executeStep = async (
       plan.workflow?.credentials
     );
 
-    notify(NOTIFY_INIT_COMPLETE, {
+    await notify(NOTIFY_INIT_COMPLETE, {
       jobId,
       duration: Date.now() - duration,
     });
@@ -182,7 +182,7 @@ const executeStep = async (
     const startTime = Date.now();
     try {
       // TODO include the upstream job?
-      notify(NOTIFY_JOB_START, { jobId });
+      await notify(NOTIFY_JOB_START, { jobId });
       result = await executeExpression(
         ctx,
         job.expression!,
@@ -212,7 +212,7 @@ const executeStep = async (
         report(state, jobId, error);
 
         next = calculateNext(step, result, logger);
-        notify(NOTIFY_JOB_ERROR, {
+        await notify(NOTIFY_JOB_ERROR, {
           duration: Date.now() - startTime,
           error,
           state,
@@ -267,7 +267,7 @@ const executeStep = async (
       }
 
       next = calculateNext(step, result, logger);
-      notify(NOTIFY_JOB_COMPLETE, {
+      await notify(NOTIFY_JOB_COMPLETE, {
         duration: Date.now() - duration,
         state: result,
         jobId,


### PR DESCRIPTION
## Short Description

This PR ensures that when the runtime publishes an event, like run:start, it awaits the publication before carrying on.

This might address #1072 but I'm not sure, I don't have a local repro

I can't really line it up in my head. If `run:start` is published and processed async, then the runtime might complete a step quickly and publish `run:complete` before the `run:start` processed. But the start event still went on the stack before the publish event. I suppose it might yield and let the complete event through  first.

But in the case I'm looking at, the start event has  tiny payload, the step takes a few SECONDS to actually run, and then the complete payload was very large and got redacted. So I can;'t believe that step complete just won the race. Also it looks from the logs like  the start event doesn't get published AT ALL.

So this might help some cases. Certainly feels like the right thing to do. Not sure it'll close the issue.


## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
