### PR TITLE
feat(ws-worker): support multi-root @local adaptor resolution

### DIFF
--- a/.changeset/multi-root-local-adaptors.md
+++ b/.changeset/multi-root-local-adaptors.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': minor
+---
+
+Support colon-separated `OPENFN_ADAPTORS_REPO` so a private adaptor monorepo can be loaded alongside the canonical OpenFn adaptors monorepo. When a job pins an adaptor to `@local`, the worker now walks the configured roots in order and resolves to the first root that contains `packages/<shortName>/package.json`. Single-path values continue to work unchanged. Earlier paths win on collision, mirroring Lightning's `AdaptorRegistry` precedence rules so the registry view and the worker's execution path stay consistent.

--- a/.changeset/multi-root-local-adaptors.md
+++ b/.changeset/multi-root-local-adaptors.md
@@ -2,4 +2,4 @@
 '@openfn/ws-worker': minor
 ---
 
-Support colon-separated `OPENFN_ADAPTORS_REPO` so a private adaptor monorepo can be loaded alongside the canonical OpenFn adaptors monorepo. When a job pins an adaptor to `@local`, the worker now walks the configured roots in order and resolves to the first root that contains `packages/<shortName>/package.json`. Single-path values continue to work unchanged. Earlier paths win on collision, mirroring Lightning's `AdaptorRegistry` precedence rules so the registry view and the worker's execution path stay consistent.
+Support comma-separated `OPENFN_ADAPTORS_REPO` so a private adaptor monorepo can be loaded alongside the canonical OpenFn adaptors monorepo. When a job pins an adaptor to `@local`, the worker now walks the configured roots in order and resolves to the first root that contains `packages/<shortName>/package.json`. Single-path values continue to work unchanged. Earlier paths win on collision, mirroring Lightning's `AdaptorRegistry` precedence rules so the registry view and the worker's execution path stay consistent.

--- a/packages/ws-worker/src/util/cli.ts
+++ b/packages/ws-worker/src/util/cli.ts
@@ -132,7 +132,7 @@ export default function parseArgs(argv: string[]): Args {
     .option('monorepo-dir', {
       alias: 'm',
       description:
-        'Path to the adaptors monorepo, from where @local adaptors will be loaded. Env: OPENFN_ADAPTORS_REPO',
+        'Path to the adaptors monorepo, from where @local adaptors will be loaded. Accepts a colon-separated list to merge multiple monorepos; the first path containing a given adaptor wins. Env: OPENFN_ADAPTORS_REPO',
     })
     .option('secret', {
       alias: 's',

--- a/packages/ws-worker/src/util/cli.ts
+++ b/packages/ws-worker/src/util/cli.ts
@@ -132,7 +132,7 @@ export default function parseArgs(argv: string[]): Args {
     .option('monorepo-dir', {
       alias: 'm',
       description:
-        'Path to the adaptors monorepo, from where @local adaptors will be loaded. Accepts a colon-separated list to merge multiple monorepos; the first path containing a given adaptor wins. Env: OPENFN_ADAPTORS_REPO',
+        'Path to the adaptors monorepo, from where @local adaptors will be loaded. Accepts a comma-separated list to merge multiple monorepos; the first path containing a given adaptor wins. Env: OPENFN_ADAPTORS_REPO',
     })
     .option('secret', {
       alias: 's',

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import fs from 'node:fs';
 import path from 'node:path';
 import type {
   Step,
@@ -50,18 +51,49 @@ export default (
 ): { plan: ExecutionPlan; options: WorkerRunOptions; input: Lazy<State> } => {
   const { collectionsVersion, monorepoPath } = options;
 
+  // monorepoPath is a colon-separated list of monorepo roots, mirroring how
+  // Lightning's AdaptorRegistry parses OPENFN_ADAPTORS_REPO. A single path
+  // (the common case) just becomes a one-element list. Order is precedence:
+  // when a `packages/<shortName>` directory exists in more than one root, the
+  // earlier entry wins, so a private adaptor repo can be listed before the
+  // canonical OpenFn monorepo to override individual adaptors locally.
+  const monorepoRoots = (monorepoPath ?? '')
+    .split(':')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+
+  const resolveLocalAdaptorPath = (shortName: string): string | undefined => {
+    if (monorepoRoots.length === 0) return undefined;
+
+    for (const root of monorepoRoots) {
+      const candidate = path.resolve(root, 'packages', shortName);
+      if (fs.existsSync(path.join(candidate, 'package.json'))) {
+        return candidate;
+      }
+    }
+    // Fall back to the first root's resolved candidate path. The directory
+    // does not exist, but this surfaces a recognisable "missing local
+    // adaptor" path to the runtime instead of an unresolved colon-joined
+    // string. It also preserves the single-path behaviour from before
+    // multi-root support was added (the path was returned without an
+    // existence check).
+    return path.resolve(monorepoRoots[0], 'packages', shortName);
+  };
+
   const appendLocalVersions = (job: Job) => {
-    if (monorepoPath && job.adaptors!) {
+    if (monorepoRoots.length && job.adaptors!) {
       for (const adaptor of job.adaptors) {
         const { name, version } = getNameAndVersion(adaptor);
-        if (monorepoPath && version === 'local') {
+        if (version === 'local') {
           const shortName = name.replace('@openfn/language-', '');
-          const localPath = path.resolve(monorepoPath, 'packages', shortName);
-          job.linker ??= {};
-          job.linker[name] = {
-            path: localPath,
-            version: 'local',
-          };
+          const localPath = resolveLocalAdaptorPath(shortName);
+          if (localPath) {
+            job.linker ??= {};
+            job.linker[name] = {
+              path: localPath,
+              version: 'local',
+            };
+          }
         }
       }
     }

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -51,14 +51,15 @@ export default (
 ): { plan: ExecutionPlan; options: WorkerRunOptions; input: Lazy<State> } => {
   const { collectionsVersion, monorepoPath } = options;
 
-  // monorepoPath is a colon-separated list of monorepo roots, mirroring how
+  // monorepoPath is a comma-separated list of monorepo roots, mirroring how
   // Lightning's AdaptorRegistry parses OPENFN_ADAPTORS_REPO. A single path
   // (the common case) just becomes a one-element list. Order is precedence:
   // when a `packages/<shortName>` directory exists in more than one root, the
   // earlier entry wins, so a private adaptor repo can be listed before the
-  // canonical OpenFn monorepo to override individual adaptors locally.
+  // canonical OpenFn monorepo to override individual adaptors locally. Comma
+  // (rather than ':') keeps Windows drive-letter paths like `c:/repo` usable.
   const monorepoRoots = (monorepoPath ?? '')
-    .split(':')
+    .split(',')
     .map((p) => p.trim())
     .filter((p) => p.length > 0);
 
@@ -73,10 +74,9 @@ export default (
     }
     // Fall back to the first root's resolved candidate path. The directory
     // does not exist, but this surfaces a recognisable "missing local
-    // adaptor" path to the runtime instead of an unresolved colon-joined
-    // string. It also preserves the single-path behaviour from before
-    // multi-root support was added (the path was returned without an
-    // existence check).
+    // adaptor" path to the runtime instead of an unresolved joined string.
+    // It also preserves the single-path behaviour from before multi-root
+    // support was added (the path was returned without an existence check).
     return path.resolve(monorepoRoots[0], 'packages', shortName);
   };
 

--- a/packages/ws-worker/test/util/convert-lightning-plan.test.ts
+++ b/packages/ws-worker/test/util/convert-lightning-plan.test.ts
@@ -1,4 +1,7 @@
 import test from 'ava';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import type {
   LightningPlan,
   LightningJob,
@@ -6,6 +9,17 @@ import type {
 } from '@openfn/lexicon/lightning';
 import convertPlan from '../../src/util/convert-lightning-plan';
 import { Job } from '@openfn/lexicon';
+
+// Builds a temporary monorepo root with package.json files in each named adaptor.
+const makeMonorepo = (adaptors: string[]) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'multi-root-'));
+  for (const adaptor of adaptors) {
+    const pkgDir = path.join(root, 'packages', adaptor);
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), '{}');
+  }
+  return root;
+};
 
 // Creates a lightning node (job or trigger)
 const createNode = (props = {}) =>
@@ -583,6 +597,112 @@ test('Use local paths', (t) => {
       version: 'local',
     },
   });
+});
+
+test('Use local paths: resolves @local against a single existing root', (t) => {
+  const root = makeMonorepo(['common']);
+
+  const run: Partial<LightningPlan> = {
+    id: 'w',
+    jobs: [createNode({ id: 'a', adaptor: 'common@local' })],
+    triggers: [{ id: 't', type: 'cron' }],
+    edges: [createEdge('t', 'a')],
+  };
+
+  const { plan } = convertPlan(run as LightningPlan, { monorepoPath: root });
+  const [, a] = plan.workflow.steps as any[];
+
+  t.deepEqual(a.linker.common, {
+    path: path.resolve(root, 'packages', 'common'),
+    version: 'local',
+  });
+});
+
+test('Use local paths: walks colon-separated roots in order, first match wins', (t) => {
+  const privateRoot = makeMonorepo(['publicschema']);
+  const canonicalRoot = makeMonorepo(['common', 'publicschema']);
+
+  const run: Partial<LightningPlan> = {
+    id: 'w',
+    jobs: [
+      createNode({ id: 'a', adaptor: 'common@local' }),
+      createNode({ id: 'b', adaptor: 'publicschema@local' }),
+    ],
+    triggers: [{ id: 't', type: 'cron' }],
+    edges: [createEdge('t', 'a'), createEdge('a', 'b')],
+  };
+
+  const { plan } = convertPlan(run as LightningPlan, {
+    monorepoPath: `${privateRoot}:${canonicalRoot}`,
+  });
+  const [, a, b] = plan.workflow.steps as any[];
+
+  // common only exists in the canonical root, so it falls through.
+  t.is(a.linker.common.path, path.resolve(canonicalRoot, 'packages', 'common'));
+  // publicschema exists in both; the private (earlier) root wins.
+  t.is(
+    b.linker.publicschema.path,
+    path.resolve(privateRoot, 'packages', 'publicschema')
+  );
+});
+
+test('Use local paths: ignores roots that do not contain the adaptor', (t) => {
+  const emptyRoot = makeMonorepo([]);
+  const realRoot = makeMonorepo(['http']);
+
+  const run: Partial<LightningPlan> = {
+    id: 'w',
+    jobs: [createNode({ id: 'a', adaptor: 'http@local' })],
+    triggers: [{ id: 't', type: 'cron' }],
+    edges: [createEdge('t', 'a')],
+  };
+
+  const { plan } = convertPlan(run as LightningPlan, {
+    monorepoPath: `${emptyRoot}:${realRoot}`,
+  });
+  const [, a] = plan.workflow.steps as any[];
+
+  t.is(a.linker.http.path, path.resolve(realRoot, 'packages', 'http'));
+});
+
+test('Use local paths: trims whitespace and drops empty segments', (t) => {
+  const root = makeMonorepo(['common']);
+
+  const run: Partial<LightningPlan> = {
+    id: 'w',
+    jobs: [createNode({ id: 'a', adaptor: 'common@local' })],
+    triggers: [{ id: 't', type: 'cron' }],
+    edges: [createEdge('t', 'a')],
+  };
+
+  const { plan } = convertPlan(run as LightningPlan, {
+    monorepoPath: `  :  ${root}  : `,
+  });
+  const [, a] = plan.workflow.steps as any[];
+
+  t.is(a.linker.common.path, path.resolve(root, 'packages', 'common'));
+});
+
+test('Use local paths: falls back to the first root when no root has the adaptor', (t) => {
+  const rootA = makeMonorepo([]);
+  const rootB = makeMonorepo([]);
+
+  const run: Partial<LightningPlan> = {
+    id: 'w',
+    jobs: [createNode({ id: 'a', adaptor: 'mystery@local' })],
+    triggers: [{ id: 't', type: 'cron' }],
+    edges: [createEdge('t', 'a')],
+  };
+
+  const { plan } = convertPlan(run as LightningPlan, {
+    monorepoPath: `${rootA}:${rootB}`,
+  });
+  const [, a] = plan.workflow.steps as any[];
+
+  // The candidate path under the first root is surfaced even though the
+  // adaptor is missing, so the runtime emits a clean "missing adaptor"
+  // error instead of crashing on a malformed colon-joined path.
+  t.is(a.linker.mystery.path, path.resolve(rootA, 'packages', 'mystery'));
 });
 
 test('pass globals from lightning run to plan', (t) => {

--- a/packages/ws-worker/test/util/convert-lightning-plan.test.ts
+++ b/packages/ws-worker/test/util/convert-lightning-plan.test.ts
@@ -618,7 +618,7 @@ test('Use local paths: resolves @local against a single existing root', (t) => {
   });
 });
 
-test('Use local paths: walks colon-separated roots in order, first match wins', (t) => {
+test('Use local paths: walks comma-separated roots in order, first match wins', (t) => {
   const privateRoot = makeMonorepo(['publicschema']);
   const canonicalRoot = makeMonorepo(['common', 'publicschema']);
 
@@ -633,7 +633,7 @@ test('Use local paths: walks colon-separated roots in order, first match wins', 
   };
 
   const { plan } = convertPlan(run as LightningPlan, {
-    monorepoPath: `${privateRoot}:${canonicalRoot}`,
+    monorepoPath: `${privateRoot},${canonicalRoot}`,
   });
   const [, a, b] = plan.workflow.steps as any[];
 
@@ -658,7 +658,7 @@ test('Use local paths: ignores roots that do not contain the adaptor', (t) => {
   };
 
   const { plan } = convertPlan(run as LightningPlan, {
-    monorepoPath: `${emptyRoot}:${realRoot}`,
+    monorepoPath: `${emptyRoot},${realRoot}`,
   });
   const [, a] = plan.workflow.steps as any[];
 
@@ -676,7 +676,7 @@ test('Use local paths: trims whitespace and drops empty segments', (t) => {
   };
 
   const { plan } = convertPlan(run as LightningPlan, {
-    monorepoPath: `  :  ${root}  : `,
+    monorepoPath: `  ,  ${root}  , `,
   });
   const [, a] = plan.workflow.steps as any[];
 
@@ -695,13 +695,13 @@ test('Use local paths: falls back to the first root when no root has the adaptor
   };
 
   const { plan } = convertPlan(run as LightningPlan, {
-    monorepoPath: `${rootA}:${rootB}`,
+    monorepoPath: `${rootA},${rootB}`,
   });
   const [, a] = plan.workflow.steps as any[];
 
   // The candidate path under the first root is surfaced even though the
   // adaptor is missing, so the runtime emits a clean "missing adaptor"
-  // error instead of crashing on a malformed colon-joined path.
+  // error instead of crashing on a malformed joined path.
   t.is(a.linker.mystery.path, path.resolve(rootA, 'packages', 'mystery'));
 });
 


### PR DESCRIPTION
## Summary

Lets `@openfn/ws-worker` resolve `@local` adaptors against a colon-separated `OPENFN_ADAPTORS_REPO`, so a private adaptor monorepo can be loaded alongside the canonical OpenFn adaptors monorepo without forking.

- Single-path values keep working unchanged (a one-element root list).
- Order is precedence: when more than one root contains `packages/<shortName>/package.json`, the earlier root wins.
- Whitespace and empty segments in the colon list are trimmed.
- When no root contains the adaptor, the worker falls back to the first root's resolved candidate path. The directory does not exist, so the runtime still surfaces a recognisable "missing local adaptor" path, and single-path callers see the same behaviour as before this PR (the path was returned without an existence check).

## Companion to Lightning PR

This is the executor-side half of OpenFn/lightning#4714. Without this patch, colon-separated `OPENFN_ADAPTORS_REPO` only widens what Lightning's `AdaptorRegistry` exposes (picker UI, metadata, version validation); the worker still tries to load the literal joined path and dies with `ENOENT`. The two PRs ship together so multi-root @local execution works end-to-end.

The first-wins semantics here mirror Lightning's `AdaptorRegistry`: a private adaptor repo listed before the canonical OpenFn monorepo will override individual adaptors locally, and the registry view and the worker's execution path stay consistent.

## Test plan

- [x] `pnpm --filter @openfn/ws-worker test` — 30/30 `convert-lightning-plan` tests green, including 5 new cases:
  - resolves `@local` against a single existing root
  - walks colon-separated roots in order, first match wins
  - ignores roots that do not contain the adaptor
  - trims whitespace and drops empty segments
  - falls back to the first root when no root has the adaptor
- [x] `pnpm --filter @openfn/ws-worker test:types` clean
- [x] `pnpm prettier --check` clean for the touched files
- [x] Live verification inside a Lightning dev container with the companion Lightning PR applied: a workflow with `@openfn/language-publicschema@local` was resolved by the patched worker to `/private-adaptors/packages/publicschema/dist/index.js` (the first root in the colon list), and the runtime logged `Resolved adaptor @openfn/language-publicschema to version 0.0.1`.

## Changeset

`minor` bump for `@openfn/ws-worker`.
