### PR TITLE
CLI: add --workflows flag to merge and deploy

### DIFF
--- a/.changeset/few-cobras-pick.md
+++ b/.changeset/few-cobras-pick.md
@@ -1,0 +1,7 @@
+---
+'@openfn/cli': minor
+---
+
+Allow users to specifiy which workflows to deploy or merge by passing `-w`.
+
+NOTE: the `-w` alias has been repurposed from `--workspace` to `--workflow`. This may affect your local development environment. If so, just expand `-w` to `--workspace`.

--- a/.changeset/some-squids-follow.md
+++ b/.changeset/some-squids-follow.md
@@ -1,0 +1,5 @@
+---
+'@openfn/lightning-mock': patch
+---
+
+Ensure that projects added as JSON are deeply cloned, preventing scribbles

--- a/integration-tests/cli/test/project-v1.test.ts
+++ b/integration-tests/cli/test/project-v1.test.ts
@@ -108,7 +108,9 @@ workflows:
 const projectsPath = path.resolve(TMP_DIR);
 
 test.before(async () => {
-  // await rm(TMP_DIR, { recursive: true });
+  try {
+    await rm(TMP_DIR, { recursive: true });
+  } catch (e) {}
   await mkdir(`${TMP_DIR}/.projects`, { recursive: true });
 
   await writeFile(`${TMP_DIR}/openfn.yaml`, '');
@@ -120,7 +122,7 @@ test.before(async () => {
 });
 
 test.serial('list available projects', async (t) => {
-  const { stdout } = await run(`openfn projects -w ${projectsPath}`);
+  const { stdout } = await run(`openfn projects --workspace ${projectsPath}`);
 
   t.regex(stdout, /hello-world/);
   t.regex(stdout, /8dbc4349-52b4-4bf2-be10-fdf06da52c46/);
@@ -130,7 +132,7 @@ test.serial('list available projects', async (t) => {
 
 // checkout a project from a yaml file
 test.serial('Checkout a project', async (t) => {
-  await run(`openfn checkout hello-world -w ${projectsPath}`);
+  await run(`openfn checkout hello-world --workspace ${projectsPath}`);
 
   // check workflow.yaml
   const workflowYaml = await readFile(
@@ -167,7 +169,7 @@ steps:
 // note: order of tests is important here
 test.serial('execute a workflow from the checked out project', async (t) => {
   // cheeky bonus test of checkout by alias
-  await run(`openfn checkout main -w ${projectsPath}`);
+  await run(`openfn checkout main --workspace ${projectsPath}`);
 
   // execute a workflow
   const { stdout } = await run(
@@ -191,7 +193,9 @@ test.serial('merge a project', async (t) => {
   t.is(initial, 'fn(() => ({ x: 1}))');
 
   // Run the merge
-  await run(`openfn merge hello-world-staging -w ${projectsPath} --force`);
+  await run(
+    `openfn merge hello-world-staging --workspace ${projectsPath} --force`
+  );
 
   // Check the step is updated
   const merged = await readStep();

--- a/integration-tests/cli/test/project-v2.test.ts
+++ b/integration-tests/cli/test/project-v2.test.ts
@@ -131,7 +131,7 @@ test.before(async () => {
 });
 
 test.serial('list available projects', async (t) => {
-  const { stdout } = await run(`openfn projects -w ${TMP_DIR}`);
+  const { stdout } = await run(`openfn projects --workspace ${TMP_DIR}`);
   t.regex(stdout, /sandboxing-simple/);
   t.regex(stdout, /a272a529-716a-4de7-a01c-a082916c6d23/);
   t.regex(stdout, /staging/);
@@ -139,7 +139,7 @@ test.serial('list available projects', async (t) => {
 });
 
 test.serial('Checkout a project', async (t) => {
-  await run(`openfn checkout staging -w ${TMP_DIR}`);
+  await run(`openfn checkout staging --workspace ${TMP_DIR}`);
 
   // check workflow.yaml
   const workflowYaml = await readFile(
@@ -174,7 +174,7 @@ steps:
 
 test.serial('execute a workflow from the checked out project', async (t) => {
   // cheeky bonus test of checkout by alias
-  await run(`openfn checkout main -w ${TMP_DIR}`);
+  await run(`openfn checkout main --workspace ${TMP_DIR}`);
 
   // execute a workflow
   await run(
@@ -189,7 +189,7 @@ test.serial('execute a workflow from the checked out project', async (t) => {
 test.serial(
   'execute a workflow from the checked out project with a credential map',
   async (t) => {
-    await run(`openfn checkout main --log debug -w ${TMP_DIR}`);
+    await run(`openfn checkout main --log debug --workspace ${TMP_DIR}`);
 
     // Modify the checked out workflow code
     await writeFile(
@@ -248,7 +248,7 @@ test.serial(
     // Important: the collection value MUST be as string
     server.collections.upsert('stuff', 'x', JSON.stringify({ id: 'x' }));
 
-    await run(`openfn checkout main --log debug -w ${TMP_DIR}`);
+    await run(`openfn checkout main --log debug --workspace ${TMP_DIR}`);
 
     // Modify the checked out workflow code
     await writeFile(
@@ -313,7 +313,7 @@ workspace:
 );
 
 test.serial('merge a project', async (t) => {
-  await run(`openfn checkout main -w ${TMP_DIR}`);
+  await run(`openfn checkout main --workspace ${TMP_DIR}`);
 
   const readStep = () =>
     readFile(
@@ -326,7 +326,9 @@ test.serial('merge a project', async (t) => {
   t.is(initial, 'fn(() => ({ x: 1}))');
 
   // Run the merge
-  const { stdout } = await run(`openfn merge staging -w ${TMP_DIR} --force`);
+  const { stdout } = await run(
+    `openfn merge staging --workspace ${TMP_DIR} --force`
+  );
 
   // Check the step is updated
   const merged = await readStep();

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -1,5 +1,9 @@
 import yargs from 'yargs';
-import Project, { versionsEqual, Workspace } from '@openfn/project';
+import Project, {
+  MergeProjectOptions,
+  versionsEqual,
+  Workspace,
+} from '@openfn/project';
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -42,6 +46,7 @@ export type DeployOptions = Pick<
   name?: string;
   alias?: string;
   jsonDiff?: boolean;
+  workflows?: string[];
 };
 
 const options = [
@@ -53,6 +58,7 @@ const options = [
   o2.name,
   o2.alias,
   o2.jsonDiff,
+  o2.workflows,
 
   // general options
   o.apiKey,
@@ -170,14 +176,29 @@ const syncProjects = async (
     // this will actually happen later
   }
 
-  const locallyChangedWorkflows = await findLocallyChangedWorkflows(
-    ws,
-    localProject
-  );
+  let mergeCandidates: string[];
+  if (options.workflows?.length) {
+    const missing = options.workflows.filter(
+      (id) => !localProject.workflows.some((w) => w.id === id)
+    );
+    if (missing.length) {
+      throw new Error(
+        `The following workflows were not found in local project ${
+          localProject.id
+        }: ${missing.join(', ')}`
+      );
+    }
+    logger.info(
+      `--workflows passed: forcing deploy of ${options.workflows.join(', ')}`
+    );
+    mergeCandidates = options.workflows;
+  } else {
+    mergeCandidates = await findLocallyChangedWorkflows(ws, localProject);
+  }
 
   // TODO: what if remote diff and the version checked disagree for some reason?
-  const diffs = locallyChangedWorkflows.length
-    ? remoteProject.diff(localProject, locallyChangedWorkflows)
+  const diffs = mergeCandidates.length
+    ? remoteProject.diff(localProject, mergeCandidates)
     : [];
 
   if (!diffs.length) {
@@ -203,7 +224,7 @@ const syncProjects = async (
     const divergentWorkflows = hasRemoteDiverged(
       localProject,
       remoteProject!,
-      locallyChangedWorkflows
+      mergeCandidates
     );
     if (divergentWorkflows) {
       logger.warn(
@@ -231,16 +252,24 @@ const syncProjects = async (
   }
 
   logger.info('Merging changes into remote project');
-  // TODO I would like to log which workflows are being updated
-  const merged = Project.merge(localProject, remoteProject!, {
+  const mergeOptions: MergeProjectOptions = {
     // If pushing the same project, we use a replace strategy
     // Otherwise, use the sandbox strategy to preserve UUIDs
     mode: localProject.uuid === remoteProject.uuid ? 'replace' : 'sandbox',
     force: true,
-    onlyUpdated: true,
-  });
+  };
+  if (options.workflows?.length) {
+    // If workflows is passed, force-include exactly the listed workflows via workflowMappings
+    mergeOptions.workflowMappings = Object.fromEntries(
+      options.workflows.map((id) => [id, id])
+    );
+  } else {
+    // Otherwise only merge locally updated workflows
+    mergeOptions.onlyUpdated = true;
+  }
+  const merged = Project.merge(localProject, remoteProject!, mergeOptions);
 
-  return { merged, remoteProject, locallyChangedWorkflows };
+  return { merged, remoteProject, locallyChangedWorkflows: mergeCandidates };
 };
 
 export async function handler(options: DeployOptions, logger: Logger) {

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -188,9 +188,6 @@ const syncProjects = async (
         }: ${missing.join(', ')}`
       );
     }
-    logger.info(
-      `--workflow passed: forcing deploy of ${options.workflow.join(', ')}`
-    );
     mergeCandidates = options.workflow;
   } else {
     mergeCandidates = await findLocallyChangedWorkflows(ws, localProject);

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -46,7 +46,7 @@ export type DeployOptions = Pick<
   name?: string;
   alias?: string;
   jsonDiff?: boolean;
-  workflows?: string[];
+  workflow?: string[];
 };
 
 const options = [
@@ -58,7 +58,7 @@ const options = [
   o2.name,
   o2.alias,
   o2.jsonDiff,
-  o2.workflows,
+  o2.workflow,
 
   // general options
   o.apiKey,
@@ -177,8 +177,8 @@ const syncProjects = async (
   }
 
   let mergeCandidates: string[];
-  if (options.workflows?.length) {
-    const missing = options.workflows.filter(
+  if (options.workflow?.length) {
+    const missing = options.workflow.filter(
       (id) => !localProject.workflows.some((w) => w.id === id)
     );
     if (missing.length) {
@@ -189,9 +189,9 @@ const syncProjects = async (
       );
     }
     logger.info(
-      `--workflows passed: forcing deploy of ${options.workflows.join(', ')}`
+      `--workflow passed: forcing deploy of ${options.workflow.join(', ')}`
     );
-    mergeCandidates = options.workflows;
+    mergeCandidates = options.workflow;
   } else {
     mergeCandidates = await findLocallyChangedWorkflows(ws, localProject);
   }
@@ -258,10 +258,10 @@ const syncProjects = async (
     mode: localProject.uuid === remoteProject.uuid ? 'replace' : 'sandbox',
     force: true,
   };
-  if (options.workflows?.length) {
-    // If workflows is passed, force-include exactly the listed workflows via workflowMappings
+  if (options.workflow?.length) {
+    // If --workflow is passed, force-include exactly the listed workflows via workflowMappings
     mergeOptions.workflowMappings = Object.fromEntries(
-      options.workflows.map((id) => [id, id])
+      options.workflow.map((id) => [id, id])
     );
   } else {
     // Otherwise only merge locally updated workflows

--- a/packages/cli/src/projects/merge.ts
+++ b/packages/cli/src/projects/merge.ts
@@ -17,12 +17,12 @@ export type MergeOptions = Required<
     'command' | 'project' | 'workspace' | 'removeUnmapped' | 'workflowMappings'
   >
 > &
-  Pick<Opts, 'log' | 'force' | 'outputPath' | 'workflows'> & { base?: string };
+  Pick<Opts, 'log' | 'force' | 'outputPath' | 'workflow'> & { base?: string };
 
 const options = [
   po.removeUnmapped,
   po.workflowMappings,
-  po.workflows,
+  po.workflow,
   po.workspace,
   o.log,
   // custom output because we don't want defaults or anything
@@ -112,14 +112,14 @@ export const handler = async (options: MergeOptions, logger: Logger) => {
   }
 
   let workflowMappings = options.workflowMappings;
-  if (options.workflows?.length) {
+  if (options.workflow?.length) {
     if (workflowMappings && Object.keys(workflowMappings).length) {
       logger.error(
-        '--workflows and --workflow-mappings are mutually exclusive'
+        '--workflow and --workflow-mappings are mutually exclusive'
       );
       return;
     }
-    const missing = options.workflows.filter(
+    const missing = options.workflow.filter(
       (id) => !sourceProject.workflows.some((w) => w.id === id)
     );
     if (missing.length) {
@@ -129,7 +129,7 @@ export const handler = async (options: MergeOptions, logger: Logger) => {
       return;
     }
     workflowMappings = Object.fromEntries(
-      options.workflows.map((id) => [id, id])
+      options.workflow.map((id) => [id, id])
     );
   }
 

--- a/packages/cli/src/projects/merge.ts
+++ b/packages/cli/src/projects/merge.ts
@@ -17,11 +17,12 @@ export type MergeOptions = Required<
     'command' | 'project' | 'workspace' | 'removeUnmapped' | 'workflowMappings'
   >
 > &
-  Pick<Opts, 'log' | 'force' | 'outputPath'> & { base?: string };
+  Pick<Opts, 'log' | 'force' | 'outputPath' | 'workflows'> & { base?: string };
 
 const options = [
   po.removeUnmapped,
   po.workflowMappings,
+  po.workflows,
   po.workspace,
   o.log,
   // custom output because we don't want defaults or anything
@@ -109,6 +110,29 @@ export const handler = async (options: MergeOptions, logger: Logger) => {
     logger.error('The checked out project has no id');
     return;
   }
+
+  let workflowMappings = options.workflowMappings;
+  if (options.workflows?.length) {
+    if (workflowMappings && Object.keys(workflowMappings).length) {
+      logger.error(
+        '--workflows and --workflow-mappings are mutually exclusive'
+      );
+      return;
+    }
+    const missing = options.workflows.filter(
+      (id) => !sourceProject.workflows.some((w) => w.id === id)
+    );
+    if (missing.length) {
+      logger.error(
+        `The following workflows were not found in source project ${sourceProject.id}: ${missing.join(', ')}`
+      );
+      return;
+    }
+    workflowMappings = Object.fromEntries(
+      options.workflows.map((id) => [id, id])
+    );
+  }
+
   const finalPath =
     options.outputPath ?? workspace.getProjectPath(targetProject.id);
   if (!finalPath) {
@@ -117,7 +141,7 @@ export const handler = async (options: MergeOptions, logger: Logger) => {
   }
   const final = Project.merge(sourceProject, targetProject, {
     removeUnmapped: options.removeUnmapped,
-    workflowMappings: options.workflowMappings,
+    workflowMappings,
     force: options.force,
   });
 

--- a/packages/cli/src/projects/merge.ts
+++ b/packages/cli/src/projects/merge.ts
@@ -114,9 +114,7 @@ export const handler = async (options: MergeOptions, logger: Logger) => {
   let workflowMappings = options.workflowMappings;
   if (options.workflow?.length) {
     if (workflowMappings && Object.keys(workflowMappings).length) {
-      logger.error(
-        '--workflow and --workflow-mappings are mutually exclusive'
-      );
+      logger.error('--workflow and --workflow-mappings are mutually exclusive');
       return;
     }
     const missing = options.workflow.filter(
@@ -124,7 +122,9 @@ export const handler = async (options: MergeOptions, logger: Logger) => {
     );
     if (missing.length) {
       logger.error(
-        `The following workflows were not found in source project ${sourceProject.id}: ${missing.join(', ')}`
+        `The following workflows were not found in source project ${
+          sourceProject.id
+        }: ${missing.join(', ')}`
       );
       return;
     }

--- a/packages/cli/src/projects/options.ts
+++ b/packages/cli/src/projects/options.ts
@@ -8,7 +8,7 @@ export type Opts = BaseOpts & {
   workspace?: string;
   removeUnmapped?: boolean | undefined;
   workflowMappings?: Record<string, string> | undefined;
-  workflows?: string[];
+  workflow?: string[];
   project?: string;
   format?: 'yaml' | 'json' | 'state';
   clean?: boolean;
@@ -87,17 +87,19 @@ export const workflowMappings: CLIOption = {
   },
 };
 
-export const workflows: CLIOption = {
-  name: 'workflows',
+export const workflow: CLIOption = {
+  name: 'workflow',
   yargs: {
+    alias: ['w'],
     array: true,
     description:
-      'Restrict merge/deploy to the given workflow ids. Listed workflows are force-included from the source and will overwrite the target/remote even if unchanged locally. Mutually exclusive with --workflow-mappings.',
+      'Restrict merge/deploy to the given workflow ids. Pass multiple times to include multiple workflows. Listed workflows are force-included from the source and will overwrite the target/remote even if unchanged locally. Mutually exclusive with --workflow-mappings.',
   },
   ensure: (opts: any) => {
-    if (opts.workflows?.length) {
-      opts.workflows = Array.from(new Set(opts.workflows));
+    if (opts.workflow?.length) {
+      opts.workflow = Array.from(new Set(opts.workflow));
     }
+    delete opts.w;
   },
 };
 
@@ -115,7 +117,6 @@ export const outputPath: CLIOption = {
 export const workspace: CLIOption = {
   name: 'workspace',
   yargs: {
-    alias: ['w'],
     description: 'Path to the project workspace (ie, path to openfn.yaml)',
   },
   ensure: (opts: any) => {

--- a/packages/cli/src/projects/options.ts
+++ b/packages/cli/src/projects/options.ts
@@ -8,6 +8,7 @@ export type Opts = BaseOpts & {
   workspace?: string;
   removeUnmapped?: boolean | undefined;
   workflowMappings?: Record<string, string> | undefined;
+  workflows?: string[];
   project?: string;
   format?: 'yaml' | 'json' | 'state';
   clean?: boolean;
@@ -83,6 +84,20 @@ export const workflowMappings: CLIOption = {
     coerce: getCLIOptionObject,
     description:
       'A manual object mapping of which workflows in source and target should be matched for a merge.',
+  },
+};
+
+export const workflows: CLIOption = {
+  name: 'workflows',
+  yargs: {
+    array: true,
+    description:
+      'Restrict merge/deploy to the given workflow ids. Listed workflows are force-included from the source and will overwrite the target/remote even if unchanged locally. Mutually exclusive with --workflow-mappings.',
+  },
+  ensure: (opts: any) => {
+    if (opts.workflows?.length) {
+      opts.workflows = Array.from(new Set(opts.workflows));
+    }
   },
 };
 

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -194,6 +194,94 @@ test.serial(
   }
 );
 
+test.serial(
+  '--workflows errors when an id is not in the local project',
+  async (t) => {
+    await setup(projectYaml);
+
+    await t.throwsAsync(
+      () =>
+        deploy(
+          {
+            endpoint: ENDPOINT,
+            apiKey: 'test-api-key',
+            workspace: '/ws',
+            confirm: false,
+            workflows: ['nope-not-a-real-workflow'],
+          } as any,
+          logger
+        ),
+      { message: /nope-not-a-real-workflow/ }
+    );
+  }
+);
+
+test.serial(
+  '--workflows force-pushes a locally-unchanged workflow over a diverged remote when --force is set',
+  async (t) => {
+    t.truthy(server.state.projects[UUID]);
+    await setup(projectYaml);
+
+    // Local is unchanged. Modify remote so it diverges.
+    const modified = JSON.parse(
+      JSON.stringify(server.state.projects[UUID].workflows['my-workflow'])
+    );
+    modified.jobs['transform-data'].body = 'each()';
+    server.updateWorkflow(UUID, modified);
+
+    // Without --workflows, change-detection would say "nothing to deploy".
+    // With --workflows + --force, we should revert the remote to local.
+    await deploy(
+      {
+        endpoint: ENDPOINT,
+        apiKey: 'test-api-key',
+        workspace: '/ws',
+        confirm: false,
+        workflows: ['my-workflow'],
+        force: true,
+      } as any,
+      logger
+    );
+
+    t.truthy(logger._find('success', /Updated project at/));
+
+    // The remote should have been overwritten with the local body
+    const transformData =
+      server.state.projects[UUID].workflows['my-workflow'].jobs[
+        'transform-data'
+      ];
+    t.is(transformData.body, 'fn()');
+  }
+);
+
+test.serial(
+  '--workflows still errors on divergence without --force',
+  async (t) => {
+    await setup(projectYaml);
+
+    const modified = JSON.parse(
+      JSON.stringify(server.state.projects[UUID].workflows['my-workflow'])
+    );
+    modified.jobs['transform-data'].body = 'each()';
+    server.updateWorkflow(UUID, modified);
+
+    await t.throwsAsync(
+      () =>
+        deploy(
+          {
+            endpoint: ENDPOINT,
+            apiKey: 'test-api-key',
+            workspace: '/ws',
+            confirm: false,
+            workflows: ['my-workflow'],
+          } as any,
+          logger
+        ),
+      { message: /PROJECTS_DIVERGED/ }
+    );
+  }
+);
+
 test('printRichDiff: should report no changes for identical projects', (t) => {
   const wf = generateWorkflow('@id a trigger-x');
 

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -19,6 +19,7 @@ import {
   TWO_WORKFLOWS_UUID,
 } from './fixtures';
 import { checkout } from '../../src/projects';
+import { readFileSync } from 'node:fs';
 
 let server: any;
 const logger = createMockLogger(undefined, { level: 'debug' });
@@ -30,9 +31,14 @@ const projectYaml = myProject_yaml.replace('https://app.openfn.org', ENDPOINT);
 const two_workflows_yaml = twowfs.replace('https://app.openfn.org', ENDPOINT);
 
 const mockFs = (paths: Record<string, string>) => {
-  const pnpm = path.resolve('../../node_modules/.pnpm');
+  // ensure this path is available to pnpm (needed by deps for some reason??)
+  // Note: loading all of pnpm takes ~7 seconds per test
+  // this workaround cuts out that delay entirely
+  const iconv = path.resolve(
+    '../../node_modules/.pnpm/iconv-lite@0.4.24/node_modules/iconv-lite/encodings'
+  );
   mock({
-    [pnpm]: mock.load(pnpm, {}),
+    [iconv]: mock.load(iconv, {}),
     ...paths,
   });
 };
@@ -283,7 +289,9 @@ test.serial(
 
     // Assert that the original remote code is fn()
     const ogTransformData =
-      server.state.projects[UUID].workflows['my-workflow'].jobs['fn()-data'];
+      server.state.projects[UUID].workflows['my-workflow'].jobs[
+        'transform-data'
+      ];
     t.is(ogTransformData.body, 'fn()');
 
     // Modify the remote
@@ -294,7 +302,9 @@ test.serial(
     server.updateWorkflow(UUID, modified);
 
     const changedTransformData =
-      server.state.projects[UUID].workflows['my-workflow'].jobs['fn()-data'];
+      server.state.projects[UUID].workflows['my-workflow'].jobs[
+        'transform-data'
+      ];
     t.is(changedTransformData.body, 'each()');
 
     // Force push local (which will revert the remote changed)

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -11,7 +11,13 @@ import {
   hasRemoteDiverged,
 } from '../../src/projects/deploy';
 import { printRichDiff } from '../../src/projects/diff';
-import { myProject_yaml, myProject_v1, UUID } from './fixtures';
+import {
+  myProject_yaml,
+  myProject_v1,
+  UUID,
+  two_workflows_yaml as twowfs,
+  TWO_WORKFLOWS_UUID,
+} from './fixtures';
 import { checkout } from '../../src/projects';
 
 let server: any;
@@ -21,6 +27,7 @@ const ENDPOINT = `http://localhost:${port}`;
 
 // quick fix to the fixture yaml, otherwise the deploy code kicks off
 const projectYaml = myProject_yaml.replace('https://app.openfn.org', ENDPOINT);
+const two_workflows_yaml = twowfs.replace('https://app.openfn.org', ENDPOINT);
 
 const mockFs = (paths: Record<string, string>) => {
   const pnpm = path.resolve('../../node_modules/.pnpm');
@@ -195,7 +202,37 @@ test.serial(
 );
 
 test.serial(
-  '--workflows errors when an id is not in the local project',
+  'Passing --workflow only updates the requested workflows',
+  async (t) => {
+    await server.addProject(two_workflows_yaml);
+    await setup(two_workflows_yaml);
+
+    // Change both workflows locally
+    await writeFile('/ws/workflows/workflow-a/job-a.js', 'modifiedA()');
+    await writeFile('/ws/workflows/workflow-b/job-b.js', 'modifiedB()');
+
+    await deploy(
+      {
+        endpoint: ENDPOINT,
+        apiKey: 'test-api-key',
+        workspace: '/ws',
+        confirm: false,
+        workflow: ['workflow-a'],
+      } as any,
+      logger
+    );
+
+    const remoteProject = server.state.projects[TWO_WORKFLOWS_UUID];
+    t.is(
+      remoteProject.workflows['workflow-a'].jobs['job-a'].body,
+      'modifiedA()'
+    );
+    t.is(remoteProject.workflows['workflow-b'].jobs['job-b'].body, 'fn()');
+  }
+);
+
+test.serial(
+  '--workflow errors when an id is not in the local project',
   async (t) => {
     await setup(projectYaml);
 
@@ -207,7 +244,7 @@ test.serial(
             apiKey: 'test-api-key',
             workspace: '/ws',
             confirm: false,
-            workflows: ['nope-not-a-real-workflow'],
+            workflow: ['nope-not-a-real-workflow'],
           } as any,
           logger
         ),
@@ -216,8 +253,9 @@ test.serial(
   }
 );
 
+// TODO check this langauge and behaviour
 test.serial(
-  '--workflows force-pushes a locally-unchanged workflow over a diverged remote when --force is set',
+  '--workflow force-pushes a locally-unchanged workflow over a diverged remote when --force is set',
   async (t) => {
     t.truthy(server.state.projects[UUID]);
     await setup(projectYaml);
@@ -229,15 +267,15 @@ test.serial(
     modified.jobs['transform-data'].body = 'each()';
     server.updateWorkflow(UUID, modified);
 
-    // Without --workflows, change-detection would say "nothing to deploy".
-    // With --workflows + --force, we should revert the remote to local.
+    // Without --workflow, change-detection would say "nothing to deploy"
+    // With --workflow + --force, we should revert the remote to local
     await deploy(
       {
         endpoint: ENDPOINT,
         apiKey: 'test-api-key',
         workspace: '/ws',
         confirm: false,
-        workflows: ['my-workflow'],
+        workflow: ['my-workflow'],
         force: true,
       } as any,
       logger
@@ -255,7 +293,7 @@ test.serial(
 );
 
 test.serial(
-  '--workflows still errors on divergence without --force',
+  '--workflow still errors on divergence without --force',
   async (t) => {
     await setup(projectYaml);
 
@@ -273,7 +311,7 @@ test.serial(
             apiKey: 'test-api-key',
             workspace: '/ws',
             confirm: false,
-            workflows: ['my-workflow'],
+            workflow: ['my-workflow'],
           } as any,
           logger
         ),

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -253,22 +253,51 @@ test.serial(
   }
 );
 
-// TODO check this langauge and behaviour
 test.serial(
-  '--workflow force-pushes a locally-unchanged workflow over a diverged remote when --force is set',
+  '--workflow only actually updates a workflow if it has changed',
   async (t) => {
     t.truthy(server.state.projects[UUID]);
     await setup(projectYaml);
 
-    // Local is unchanged. Modify remote so it diverges.
+    await deploy(
+      {
+        endpoint: ENDPOINT,
+        apiKey: 'test-api-key',
+        workspace: '/ws',
+        confirm: false,
+        workflow: ['my-workflow'],
+      } as any,
+      logger
+    );
+
+    // TODO better to check that there is no post request tbh
+    t.truthy(logger._find('success', /Nothing to deploy/));
+  }
+);
+
+test.serial(
+  '--workflow will overwrite a newer version on the target if --force is included',
+  async (t) => {
+    t.truthy(server.state.projects[UUID]);
+    await setup(projectYaml);
+
+    // Assert that the original remote code is fn()
+    const ogTransformData =
+      server.state.projects[UUID].workflows['my-workflow'].jobs['fn()-data'];
+    t.is(ogTransformData.body, 'fn()');
+
+    // Modify the remote
     const modified = JSON.parse(
       JSON.stringify(server.state.projects[UUID].workflows['my-workflow'])
     );
     modified.jobs['transform-data'].body = 'each()';
     server.updateWorkflow(UUID, modified);
 
-    // Without --workflow, change-detection would say "nothing to deploy"
-    // With --workflow + --force, we should revert the remote to local
+    const changedTransformData =
+      server.state.projects[UUID].workflows['my-workflow'].jobs['fn()-data'];
+    t.is(changedTransformData.body, 'each()');
+
+    // Force push local (which will revert the remote changed)
     await deploy(
       {
         endpoint: ENDPOINT,
@@ -284,11 +313,11 @@ test.serial(
     t.truthy(logger._find('success', /Updated project at/));
 
     // The remote should have been overwritten with the local body
-    const transformData =
+    const mergedTransformData =
       server.state.projects[UUID].workflows['my-workflow'].jobs[
         'transform-data'
       ];
-    t.is(transformData.body, 'fn()');
+    t.is(mergedTransformData.body, 'fn()');
   }
 );
 

--- a/packages/cli/test/projects/fixtures.ts
+++ b/packages/cli/test/projects/fixtures.ts
@@ -103,3 +103,72 @@ workflows:
       lock_version: 1
     id: my-workflow
     start: webhook`;
+
+export const TWO_WORKFLOWS_UUID = '4b09ddf1-35f4-4e40-9aa9-0d80c086dd9e';
+
+export const two_workflows_yaml = `id: my-project
+name: My Project
+schema_version: '4.0'
+description: ''
+collections: []
+credentials: []
+openfn:
+  uuid: ${TWO_WORKFLOWS_UUID}
+  endpoint: https://app.openfn.org
+  inserted_at: 2025-04-23T11:15:59Z
+  updated_at: 2025-04-23T11:15:59Z
+options:
+  allow_support_access: false
+  requires_mfa: false
+  retention_policy: retain_all
+workflows:
+  - id: workflow-a
+    name: Workflow A
+    steps:
+      - id: job-a
+        name: Job A
+        expression: fn()
+        adaptor: '@openfn/language-common@latest'
+        openfn:
+          uuid: 3d4727b6-4052-4f58-a834-3a03e433ff1d
+      - id: trigger-a
+        type: webhook
+        enabled: true
+        openfn:
+          uuid: 1b1c1dd5-e8d9-432f-aeaf-4e09397cac98
+        next:
+          job-a:
+            condition: always
+            openfn:
+              uuid: 1118353a-6015-40f9-8e57-51801a65bcfc
+    openfn:
+      uuid: 4584df01-cab4-4182-974d-6a75b13c7b97
+      inserted_at: 2025-04-23T11:19:32Z
+      updated_at: 2025-04-23T11:19:32Z
+      lock_version: 1
+    start: trigger-a
+  - id: workflow-b
+    name: Workflow B
+    steps:
+      - id: job-b
+        name: Job B
+        expression: fn()
+        adaptor: '@openfn/language-common@latest'
+        openfn:
+          uuid: 37e6e616-3840-4d71-b63c-a736ebc208b7
+      - id: trigger-b
+        type: webhook
+        enabled: true
+        openfn:
+          uuid: d65ed915-7f39-428b-af57-57ed2ecf507e
+        next:
+          job-b:
+            condition: always
+            openfn:
+              uuid: 4b291d27-c055-40cd-b82d-210644338715
+    openfn:
+      uuid: fc5eeff6-537b-4667-841b-4d17c70dfab9
+      inserted_at: 2025-04-23T11:19:32Z
+      updated_at: 2025-04-23T11:19:32Z
+      lock_version: 1
+    start: trigger-b`;

--- a/packages/cli/test/projects/merge.test.ts
+++ b/packages/cli/test/projects/merge.test.ts
@@ -373,7 +373,7 @@ const mockMultiWorkflowWorkspace = () => {
 };
 
 test.serial(
-  '--workflows merges only the listed workflow, leaving other target workflows untouched',
+  '--workflow merges only the listed workflow, leaving other target workflows untouched',
   async (t) => {
     mockMultiWorkflowWorkspace();
 
@@ -384,7 +384,7 @@ test.serial(
         project: 'my-sandbox',
         removeUnmapped: false,
         workflowMappings: {},
-        workflows: ['workflow-1'],
+        workflow: ['workflow-1'],
       },
       logger
     );
@@ -406,7 +406,7 @@ test.serial(
 );
 
 test.serial(
-  '--workflows errors when an id is not in the source project',
+  '--workflow errors when an id is not in the source project',
   async (t) => {
     mockMultiWorkflowWorkspace();
 
@@ -417,7 +417,7 @@ test.serial(
         project: 'my-sandbox',
         removeUnmapped: false,
         workflowMappings: {},
-        workflows: ['workflow-1', 'does-not-exist'],
+        workflow: ['workflow-1', 'does-not-exist'],
       },
       logger
     );
@@ -429,7 +429,7 @@ test.serial(
 );
 
 test.serial(
-  '--workflows and --workflow-mappings are mutually exclusive',
+  '--workflow and --workflow-mappings are mutually exclusive',
   async (t) => {
     mockMultiWorkflowWorkspace();
 
@@ -440,7 +440,7 @@ test.serial(
         project: 'my-sandbox',
         removeUnmapped: false,
         workflowMappings: { 'workflow-1': 'workflow-1' },
-        workflows: ['workflow-1'],
+        workflow: ['workflow-1'],
       },
       logger
     );

--- a/packages/cli/test/projects/merge.test.ts
+++ b/packages/cli/test/projects/merge.test.ts
@@ -321,3 +321,132 @@ test.serial('merge with custom base', async (t) => {
   t.is(merged.workflows[0].steps[1].name, 'Job X');
   t.is(merged.workflows[0].steps[1].openfn?.uuid, 'job-a'); // id got retained
 });
+
+// Multi-workflow fixtures used by --workflows tests
+const buildWorkflow = (id: string, jobId: string, jobName: string) => ({
+  name: id,
+  id,
+  jobs: [{ id: jobId, name: jobName }],
+  triggers: [{ type: 'cron', enabled: true, id: `${id}-trigger` }],
+  edges: [
+    {
+      id: `${id}-edge`,
+      target_job_id: jobId,
+      enabled: true,
+      source_trigger_id: `${id}-trigger`,
+      condition_type: 'always',
+    },
+  ],
+});
+
+const multiSandbox = {
+  id: '<uuid:sandbox>',
+  name: 'My Sandbox',
+  workflows: [
+    buildWorkflow('workflow-1', 'job-x', 'Job X (from sandbox)'),
+    buildWorkflow('workflow-2', 'job-y', 'Job Y (from sandbox)'),
+  ],
+};
+
+const multiMain = {
+  id: '<uuid:main>',
+  name: 'My Project',
+  workflows: [
+    buildWorkflow('workflow-1', 'job-a', 'Job A (from main)'),
+    buildWorkflow('workflow-2', 'job-b', 'Job B (from main)'),
+  ],
+};
+
+const mockMultiWorkflowWorkspace = () => {
+  mock({
+    '/ws/workflows': {},
+    '/ws/openfn.yaml': jsonToYaml({
+      project: { id: 'my-project', name: 'My Project' },
+      workspace: {
+        dirs: { workflows: 'workflows' },
+        formats: { openfn: 'yaml', project: 'yaml', workflow: 'yaml' },
+      },
+    }),
+    '/ws/.projects/staging@app.openfn.org.yaml': jsonToYaml(multiSandbox),
+    '/ws/.projects/project@app.openfn.org.yaml': jsonToYaml(multiMain),
+  });
+};
+
+test.serial(
+  '--workflows merges only the listed workflow, leaving other target workflows untouched',
+  async (t) => {
+    mockMultiWorkflowWorkspace();
+
+    await mergeHandler(
+      {
+        command: 'project-merge',
+        workspace: '/ws',
+        project: 'my-sandbox',
+        removeUnmapped: false,
+        workflowMappings: {},
+        workflows: ['workflow-1'],
+      },
+      logger
+    );
+
+    const merged = await Project.from(
+      'path',
+      '/ws/.projects/project@app.openfn.org.yaml'
+    );
+
+    const wf1 = merged.workflows.find((w) => w.id === 'workflow-1')!;
+    const wf2 = merged.workflows.find((w) => w.id === 'workflow-2')!;
+
+    // workflow-1 was merged from sandbox (Job X overlaid)
+    t.truthy(wf1.steps.find((s) => s.name === 'Job X (from sandbox)'));
+    // workflow-2 was NOT touched - still has Job B from main, not Job Y from sandbox
+    t.truthy(wf2.steps.find((s) => s.name === 'Job B (from main)'));
+    t.falsy(wf2.steps.find((s) => s.name === 'Job Y (from sandbox)'));
+  }
+);
+
+test.serial(
+  '--workflows errors when an id is not in the source project',
+  async (t) => {
+    mockMultiWorkflowWorkspace();
+
+    await mergeHandler(
+      {
+        command: 'project-merge',
+        workspace: '/ws',
+        project: 'my-sandbox',
+        removeUnmapped: false,
+        workflowMappings: {},
+        workflows: ['workflow-1', 'does-not-exist'],
+      },
+      logger
+    );
+
+    const { message, level } = logger._parse(logger._last);
+    t.is(level, 'error');
+    t.regex(message as string, /does-not-exist/);
+  }
+);
+
+test.serial(
+  '--workflows and --workflow-mappings are mutually exclusive',
+  async (t) => {
+    mockMultiWorkflowWorkspace();
+
+    await mergeHandler(
+      {
+        command: 'project-merge',
+        workspace: '/ws',
+        project: 'my-sandbox',
+        removeUnmapped: false,
+        workflowMappings: { 'workflow-1': 'workflow-1' },
+        workflows: ['workflow-1'],
+      },
+      logger
+    );
+
+    const { message, level } = logger._parse(logger._last);
+    t.is(level, 'error');
+    t.regex(message as string, /mutually exclusive/);
+  }
+);

--- a/packages/lightning-mock/src/api-dev.ts
+++ b/packages/lightning-mock/src/api-dev.ts
@@ -72,7 +72,10 @@ const setupDevAPI = (
       project = proj.serialize('state', {
         format: 'json',
       }) as Provisioner.Project_v1;
+    } else {
+      project = JSON.parse(JSON.stringify(project));
     }
+    // @ts-ignore
     state.projects[project.id] = project;
   };
 

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -23,3 +23,5 @@ export {
 } from './util/version';
 
 export { mapWorkflow } from './parse/from-app-state';
+
+export type { MergeProjectOptions } from './merge/merge-project';

--- a/packages/project/src/merge/merge-project.ts
+++ b/packages/project/src/merge/merge-project.ts
@@ -16,21 +16,21 @@ export const REPLACE_MERGE = 'replace';
 export class UnsafeMergeError extends Error {}
 
 export type MergeProjectOptions = {
-  workflowMappings: Record<string, string>; // <source, target>
-  removeUnmapped: boolean;
-  force: boolean;
+  workflowMappings?: Record<string, string>; // <source, target>
+  removeUnmapped?: boolean;
+  force?: boolean;
 
   /**
    * If mode is sandbox, basically only content will be merged and all metadata/settings/options/config is ignored
    * If mode is replace, all properties on the source will override the target (including UUIDs, name)
    */
-  mode: typeof SANDBOX_MERGE | typeof REPLACE_MERGE;
+  mode?: typeof SANDBOX_MERGE | typeof REPLACE_MERGE;
 
   /**
    * If true, only workflows that have changed in the source
    * will be merged.
    */
-  onlyUpdated: boolean;
+  onlyUpdated?: boolean;
 };
 
 const defaultOptions: MergeProjectOptions = {
@@ -54,7 +54,7 @@ const defaultOptions: MergeProjectOptions = {
 export function merge(
   source: Project,
   target: Project,
-  opts?: Partial<MergeProjectOptions>
+  opts?: MergeProjectOptions
 ) {
   const options = defaultsDeep(
     opts,


### PR DESCRIPTION
## Short Description

Allows the user to control which workflows get merged by passing `--workflows` to deploy and merge commands

Fixes #1337

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
