### PR TITLE
chore: ignore sentry errors by regexp

### DIFF
--- a/.changeset/honest-maps-know.md
+++ b/.changeset/honest-maps-know.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Add the ability to ignore and override errors messsages before reporting to sentry

--- a/packages/ws-worker/src/events/run-error.ts
+++ b/packages/ws-worker/src/events/run-error.ts
@@ -6,6 +6,7 @@ import { RUN_COMPLETE } from '../events';
 import { Context, onJobError } from '../api/execute';
 import logFinalReason from '../util/log-final-reason';
 import { sendEvent } from '../util/send-event';
+import { getIgnoredErrorSeverity } from '../util/ignored-errors';
 
 export default async function onRunError(
   context: Context,
@@ -16,6 +17,9 @@ export default async function onRunError(
   try {
     // Ok, let's try that, let's just generate a reason from the event
     const reason = calculateJobExitReason('', { data: {} }, event);
+    const severityOverride = getIgnoredErrorSeverity(reason.error_message);
+    if (severityOverride) reason.reason = severityOverride;
+
     // If there's a job still running, make sure it gets marked complete
     if (state.activeJob) {
       await onJobError(context, { error: event });

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -30,6 +30,7 @@ import type { Socket, Channel } from './types';
 import { convertRun } from './util';
 import parseWorkloops from './util/parse-workloops';
 import getDefaultWorkloopConfig from './util/get-default-workloop-config';
+import { matchesIgnoredError } from './util/ignored-errors';
 
 const exec = promisify(_exec);
 
@@ -100,8 +101,6 @@ type SocketAndChannel = {
 const DEFAULT_PORT = 2222;
 const MIN_BACKOFF = 1000;
 const MAX_BACKOFF = 1000 * 30;
-
-const IGNORED_ERROR_PATTERNS: RegExp[] = [/OAuth token has expired/i];
 
 // TODO move out into another file, make testable, test in isolation
 function connect(app: ServerApp, logger: Logger, options: ServerOptions = {}) {
@@ -253,7 +252,7 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
         const error = hint.originalException as Error | undefined;
         const message = error?.message ?? event.message ?? '';
 
-        if (IGNORED_ERROR_PATTERNS.some((pattern) => pattern.test(message))) {
+        if (matchesIgnoredError(message)) {
           return null;
         }
 

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -249,7 +249,6 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
     Sentry.init({
       environment: options.sentryEnv,
       dsn: options.sentryDsn,
-      debug: true,
       beforeSend(event, hint) {
         const error = hint.originalException as Error | undefined;
         const message = error?.message ?? event.message ?? '';

--- a/packages/ws-worker/src/server.ts
+++ b/packages/ws-worker/src/server.ts
@@ -101,6 +101,8 @@ const DEFAULT_PORT = 2222;
 const MIN_BACKOFF = 1000;
 const MAX_BACKOFF = 1000 * 30;
 
+const IGNORED_ERROR_PATTERNS: RegExp[] = [/OAuth token has expired/i];
+
 // TODO move out into another file, make testable, test in isolation
 function connect(app: ServerApp, logger: Logger, options: ServerOptions = {}) {
   logger.debug('Connecting to Lightning at', options.lightning);
@@ -247,6 +249,17 @@ function createServer(engine: RuntimeEngine, options: ServerOptions = {}) {
     Sentry.init({
       environment: options.sentryEnv,
       dsn: options.sentryDsn,
+      debug: true,
+      beforeSend(event, hint) {
+        const error = hint.originalException as Error | undefined;
+        const message = error?.message ?? event.message ?? '';
+
+        if (IGNORED_ERROR_PATTERNS.some((pattern) => pattern.test(message))) {
+          return null;
+        }
+
+        return event;
+      },
     });
     Sentry.setupKoaErrorHandler(app);
   }

--- a/packages/ws-worker/src/util/ignored-errors.ts
+++ b/packages/ws-worker/src/util/ignored-errors.ts
@@ -1,0 +1,25 @@
+import type { ExitReasonStrings } from '@openfn/lexicon/lightning';
+
+type IgnoredError = {
+  pattern: RegExp; // matches errors to be ignored by sentry
+  severity?: ExitReasonStrings;
+};
+
+// list of errors here!
+export const IGNORED_ERROR_PATTERNS: IgnoredError[] = [
+  { pattern: /OAuth token has expired/i, severity: 'crash' },
+];
+
+const findIgnoredError = (message?: string | null) => {
+  if (!message) {
+    return undefined;
+  }
+  return IGNORED_ERROR_PATTERNS.find(({ pattern }) => pattern.test(message));
+};
+
+export const matchesIgnoredError = (message?: string | null): boolean =>
+  Boolean(findIgnoredError(message));
+
+export const getIgnoredErrorSeverity = (
+  message?: string | null
+): ExitReasonStrings | undefined => findIgnoredError(message)?.severity;


### PR DESCRIPTION
## Short Description

This PR allows us to ignore specific errors from going through sentry. 
We currently don't want Oauth error to pass through sentry. hence we use a beforeSend hook in sentry to filter the errors 

(in the image below, the error is intercepted and logged to not be reported to sentry)
<img width="1279" height="387" alt="ha" src="https://github.com/user-attachments/assets/7032dbca-256a-4020-9e07-8cba573f30a6" />


Fixes #1429 

## Implementation Details

A more detailed breakdown of the changes, including motivations (if not provided in the issue).

## QA Notes

On Lighting there's a branch that simulates Oauth always failing
Branch: https://github.com/OpenFn/lightning/tree/ignore-sentry-errors (`ignore-sentry-errors`)

1. Run lighTning without a work (That's with RTM=false)
2. Build and run the worker pointing to that lightning server (remember to set the secret to match that of lightning)
3. To see Sentry debug logs, update the code to have `debug:true` at https://github.com/OpenFn/kit/blob/8e29d122daab29c07381d10d9d9fd777fcbbf3a8/packages/ws-worker/src/server.ts#L249-L262
4. Create a workflow and pick a credential for one of the nodes in lightning
5. Run the workflow and then check the worker logs
6. You should see the Oauth error captured in the logs but sentry debug logs should notify that this specific error isn't going to be reported.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Release branch checklist

Delete this section if this is not a release PR.

If this IS a release branch:

- [ ] Run `pnpm changeset version` from root to bump versions
- [ ] Run `pnpm install`
- [ ] Commit the new version numbers
- [ ] Run `pnpm changeset tag` to generate tags
- [ ] Push tags `git push --tags`

Tags may need updating if commits come in after the tags are first generated.
