### PR TITLE
fix(cli): fix cache .gitignore written to fs root and undefined workflow name

### DIFF
--- a/packages/cli/src/util/cache.ts
+++ b/packages/cli/src/util/cache.ts
@@ -23,12 +23,10 @@ export const getCachePath = (
     return path.resolve(cachePath);
   }
 
-  // path.resolve throws on undefined, so filter it out; when workflowName
-  // is absent the path resolves to the bare CACHE_DIR root.
   const basePath = path.resolve(
-    ...([baseDir ?? process.cwd(), CACHE_DIR, workflowName].filter(
-      Boolean
-    ) as string[])
+    baseDir ?? process.cwd(),
+    CACHE_DIR,
+    workflowName ?? ''
   );
 
   if (stepId) {

--- a/packages/cli/src/util/cache.ts
+++ b/packages/cli/src/util/cache.ts
@@ -13,7 +13,7 @@ export const CACHE_DIR = '.cli-cache';
 export const getCachePath = (
   options: Pick<Opts, 'baseDir' | 'cachePath'>,
   workflowName?: string,
-  stepId?: string,
+  stepId?: string
 ) => {
   const { baseDir, cachePath } = options;
   if (cachePath) {
@@ -26,9 +26,9 @@ export const getCachePath = (
   // path.resolve throws on undefined, so filter it out; when workflowName
   // is absent the path resolves to the bare CACHE_DIR root.
   const basePath = path.resolve(
-    ...([baseDir ?? process.cwd(), CACHE_DIR, workflowName].filter(
-      Boolean,
-    ) as string[]),
+    ...[baseDir ?? process.cwd(), CACHE_DIR, workflowName].filter(
+      Boolean
+    ) as string[]
   );
 
   if (stepId) {
@@ -55,7 +55,7 @@ export const saveToCache = async (
   stepId: string,
   output: any,
   options: Pick<Opts, 'baseDir' | 'cachePath' | 'cacheSteps'>,
-  logger: Logger,
+  logger: Logger
 ) => {
   if (options.cacheSteps) {
     const cachePath = getCachePath(options, plan.workflow.name, stepId);
@@ -73,7 +73,7 @@ export const saveToCache = async (
 export const clearCache = async (
   plan: ExecutionPlan,
   options: Pick<Opts, 'baseDir' | 'cachePath'>,
-  logger: Logger,
+  logger: Logger
 ) => {
   const cacheDir = getCachePath(options, plan.workflow?.name);
 

--- a/packages/cli/src/util/cache.ts
+++ b/packages/cli/src/util/cache.ts
@@ -26,9 +26,9 @@ export const getCachePath = (
   // path.resolve throws on undefined, so filter it out; when workflowName
   // is absent the path resolves to the bare CACHE_DIR root.
   const basePath = path.resolve(
-    ...[baseDir ?? process.cwd(), CACHE_DIR, workflowName].filter(
+    ...([baseDir ?? process.cwd(), CACHE_DIR, workflowName].filter(
       Boolean
-    ) as string[]
+    ) as string[])
   );
 
   if (stepId) {

--- a/packages/cli/src/util/cache.ts
+++ b/packages/cli/src/util/cache.ts
@@ -8,7 +8,6 @@ import type { Logger } from './logger';
 
 export const CACHE_DIR = '.cli-cache';
 
-// TODO this is all a bit over complicated tbh
 export const getCachePath = (
   options: Pick<Opts, 'baseDir' | 'cachePath'>,
   workflowName?: string,
@@ -24,7 +23,7 @@ export const getCachePath = (
 
   const basePath = path.resolve(
     baseDir ?? process.cwd(),
-    `${CACHE_DIR}/${workflowName}`
+    `${CACHE_DIR}/${workflowName ?? 'workflow'}`
   );
 
   if (stepId) {
@@ -33,38 +32,41 @@ export const getCachePath = (
   return basePath;
 };
 
-const ensureGitIgnore = (options: any, cachePath: string) => {
+// Returns the root cache directory where .gitignore should live
+const getCacheRoot = (options: Pick<Opts, 'baseDir' | 'cachePath'>): string => {
+  const { baseDir, cachePath } = options;
+  if (cachePath) {
+    return path.resolve(cachePath);
+  }
+  return path.resolve(baseDir ?? process.cwd(), CACHE_DIR);
+};
+
+const ensureGitIgnore = (options: any, cacheRoot: string) => {
   if (!options._hasGitIgnore) {
-    // Find the root cache folder
-    let root = cachePath;
-    while (root.length > 1 && !root.endsWith(CACHE_DIR)) {
-      root = path.dirname(root);
-    }
-    // From the root cache, look for a .gitignore
-    const ignorePath = path.resolve(root, '.gitignore');
+    const ignorePath = path.join(cacheRoot, '.gitignore');
     try {
       fs.accessSync(ignorePath);
     } catch (e) {
       // doesn't exist!
       fs.writeFileSync(ignorePath, '*');
     }
+    options._hasGitIgnore = true;
   }
-  options._hasGitIgnore = true;
 };
 
 export const saveToCache = async (
   plan: ExecutionPlan,
   stepId: string,
   output: any,
-  options: Pick<Opts, 'baseDir' | 'cacheSteps'>,
+  options: Pick<Opts, 'baseDir' | 'cachePath' | 'cacheSteps'>,
   logger: Logger
 ) => {
   if (options.cacheSteps) {
-    const cachePath = await getCachePath(options, plan.workflow.name, stepId);
+    const cachePath = getCachePath(options, plan.workflow.name, stepId);
     // Note that this is sync because other execution order gets messed up
     fs.mkdirSync(path.dirname(cachePath), { recursive: true });
 
-    ensureGitIgnore(options, path.dirname(cachePath));
+    ensureGitIgnore(options, getCacheRoot(options));
 
     logger.info(`Writing ${stepId} output to ${cachePath}`);
     fs.writeFileSync(cachePath, JSON.stringify(output));
@@ -73,10 +75,10 @@ export const saveToCache = async (
 
 export const clearCache = async (
   plan: ExecutionPlan,
-  options: Pick<Opts, 'baseDir'>,
+  options: Pick<Opts, 'baseDir' | 'cachePath'>,
   logger: Logger
 ) => {
-  const cacheDir = await getCachePath(options, plan.workflow?.name);
+  const cacheDir = getCachePath(options, plan.workflow?.name);
 
   try {
     await rmdir(cacheDir, { recursive: true });

--- a/packages/cli/src/util/cache.ts
+++ b/packages/cli/src/util/cache.ts
@@ -8,6 +8,8 @@ import type { Logger } from './logger';
 
 export const CACHE_DIR = '.cli-cache';
 
+// When called without workflowName/stepId, returns the CACHE_DIR root.
+// This is used directly in saveToCache to locate the .gitignore.
 export const getCachePath = (
   options: Pick<Opts, 'baseDir' | 'cachePath'>,
   workflowName?: string,
@@ -21,24 +23,18 @@ export const getCachePath = (
     return path.resolve(cachePath);
   }
 
+  // path.resolve throws on undefined, so filter it out; when workflowName
+  // is absent the path resolves to the bare CACHE_DIR root.
   const basePath = path.resolve(
-    baseDir ?? process.cwd(),
-    `${CACHE_DIR}/${workflowName ?? 'workflow'}`
+    ...[baseDir ?? process.cwd(), CACHE_DIR, workflowName].filter(
+      Boolean
+    ) as string[]
   );
 
   if (stepId) {
     return `${basePath}/${stepId.replace(/ /, '-')}.json`;
   }
   return basePath;
-};
-
-// Returns the root cache directory where .gitignore should live
-const getCacheRoot = (options: Pick<Opts, 'baseDir' | 'cachePath'>): string => {
-  const { baseDir, cachePath } = options;
-  if (cachePath) {
-    return path.resolve(cachePath);
-  }
-  return path.resolve(baseDir ?? process.cwd(), CACHE_DIR);
 };
 
 const ensureGitIgnore = (options: any, cacheRoot: string) => {
@@ -66,7 +62,8 @@ export const saveToCache = async (
     // Note that this is sync because other execution order gets messed up
     fs.mkdirSync(path.dirname(cachePath), { recursive: true });
 
-    ensureGitIgnore(options, getCacheRoot(options));
+    // getCachePath with no workflowName returns the CACHE_DIR root
+    ensureGitIgnore(options, getCachePath(options));
 
     logger.info(`Writing ${stepId} output to ${cachePath}`);
     fs.writeFileSync(cachePath, JSON.stringify(output));

--- a/packages/cli/src/util/cache.ts
+++ b/packages/cli/src/util/cache.ts
@@ -13,7 +13,7 @@ export const CACHE_DIR = '.cli-cache';
 export const getCachePath = (
   options: Pick<Opts, 'baseDir' | 'cachePath'>,
   workflowName?: string,
-  stepId?: string
+  stepId?: string,
 ) => {
   const { baseDir, cachePath } = options;
   if (cachePath) {
@@ -26,9 +26,9 @@ export const getCachePath = (
   // path.resolve throws on undefined, so filter it out; when workflowName
   // is absent the path resolves to the bare CACHE_DIR root.
   const basePath = path.resolve(
-    ...[baseDir ?? process.cwd(), CACHE_DIR, workflowName].filter(
-      Boolean
-    ) as string[]
+    ...([baseDir ?? process.cwd(), CACHE_DIR, workflowName].filter(
+      Boolean,
+    ) as string[]),
   );
 
   if (stepId) {
@@ -55,7 +55,7 @@ export const saveToCache = async (
   stepId: string,
   output: any,
   options: Pick<Opts, 'baseDir' | 'cachePath' | 'cacheSteps'>,
-  logger: Logger
+  logger: Logger,
 ) => {
   if (options.cacheSteps) {
     const cachePath = getCachePath(options, plan.workflow.name, stepId);
@@ -73,7 +73,7 @@ export const saveToCache = async (
 export const clearCache = async (
   plan: ExecutionPlan,
   options: Pick<Opts, 'baseDir' | 'cachePath'>,
-  logger: Logger
+  logger: Logger,
 ) => {
   const cacheDir = getCachePath(options, plan.workflow?.name);
 

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -223,7 +223,7 @@ test.serial(
 
     await handler(options, logger);
     t.truthy(logger._find('debug', /credential map not found/i));
-  }
+  },
 );
 
 test.serial('run a workflow with state', async (t) => {
@@ -285,7 +285,7 @@ test.serial(
     t.regex(err.message, /typeerror: cannot read properties of undefined/i);
     t.is(err.pos.line, 2);
     t.is(err.pos.column, 23);
-  }
+  },
 );
 
 test.serial(
@@ -314,11 +314,11 @@ test.serial(
     t.truthy(result.errors);
     t.regex(
       result.errors.x.message,
-      /typeerror: cannot read properties of undefined/i
+      /typeerror: cannot read properties of undefined/i,
     );
     t.is(result.errors.x.pos.line, 2);
     t.is(result.errors.x.pos.column, 23);
-  }
+  },
 );
 
 test.serial(
@@ -348,11 +348,11 @@ test.serial(
     t.truthy(result.errors);
     t.regex(
       result.errors.x.message,
-      /typeerror: cannot read properties of undefined/i
+      /typeerror: cannot read properties of undefined/i,
     );
     t.is(result.errors.x.pos.line, 2);
     t.is(result.errors.x.pos.column, 23);
-  }
+  },
 );
 
 test.serial('run a workflow with cached steps', async (t) => {
@@ -441,28 +441,31 @@ test.serial('cache steps when running a .js expression', async (t) => {
   t.true(files[0].endsWith('.json'));
 
   const cached = JSON.parse(
-    await fs.readFile(`/.cli-cache/job/${files[0]}`, 'utf8')
+    await fs.readFile(`/.cli-cache/job/${files[0]}`, 'utf8'),
   );
   t.is(cached.x, 1);
 });
 
-test.serial('.cli-cache has a gitignore when caching a .js expression', async (t) => {
-  mockFs({
-    '/job.js': `${fn}fn((state) => ({ ...state, x: 1 }));`,
-  });
+test.serial(
+  '.cli-cache has a gitignore when caching a .js expression',
+  async (t) => {
+    mockFs({
+      '/job.js': `${fn}fn((state) => ({ ...state, x: 1 }));`,
+    });
 
-  const options = {
-    ...defaultOptions,
-    expressionPath: '/job.js',
-    baseDir: '/',
-    cacheSteps: true,
-  };
+    const options = {
+      ...defaultOptions,
+      expressionPath: '/job.js',
+      baseDir: '/',
+      cacheSteps: true,
+    };
 
-  await handler(options, logger);
+    await handler(options, logger);
 
-  const gitignore = await fs.readFile('/.cli-cache/.gitignore', 'utf8');
-  t.is(gitignore, '*');
-});
+    const gitignore = await fs.readFile('/.cli-cache/.gitignore', 'utf8');
+    t.is(gitignore, '*');
+  },
+);
 
 test.serial('run a workflow with initial state from stdin', async (t) => {
   const workflow = {

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -419,7 +419,6 @@ test.serial('.cli-cache has a gitignore', async (t) => {
 });
 
 // Regression test for https://github.com/OpenFn/kit/issues/669
-// Running a .js expression (not a workflow JSON) with caching enabled must not crash.
 test.serial('cache steps when running a .js expression', async (t) => {
   mockFs({
     '/job.js': `${fn}fn((state) => ({ ...state, x: 1 }));`,
@@ -447,7 +446,7 @@ test.serial('cache steps when running a .js expression', async (t) => {
   t.is(cached.x, 1);
 });
 
-test.serial('.cli-cache gitignore is written when caching a .js expression', async (t) => {
+test.serial('.cli-cache has a gitignore when caching a .js expression', async (t) => {
   mockFs({
     '/job.js': `${fn}fn((state) => ({ ...state, x: 1 }));`,
   });

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -446,23 +446,26 @@ test.serial('cache steps when running a .js expression', async (t) => {
   t.is(cached.x, 1);
 });
 
-test.serial('.cli-cache has a gitignore when caching a .js expression', async (t) => {
-  mockFs({
-    '/job.js': `${fn}fn((state) => ({ ...state, x: 1 }));`,
-  });
+test.serial(
+  '.cli-cache has a gitignore when caching a .js expression',
+  async (t) => {
+    mockFs({
+      '/job.js': `${fn}fn((state) => ({ ...state, x: 1 }));`,
+    });
 
-  const options = {
-    ...defaultOptions,
-    expressionPath: '/job.js',
-    baseDir: '/',
-    cacheSteps: true,
-  };
+    const options = {
+      ...defaultOptions,
+      expressionPath: '/job.js',
+      baseDir: '/',
+      cacheSteps: true,
+    };
 
-  await handler(options, logger);
+    await handler(options, logger);
 
-  const gitignore = await fs.readFile('/.cli-cache/.gitignore', 'utf8');
-  t.is(gitignore, '*');
-});
+    const gitignore = await fs.readFile('/.cli-cache/.gitignore', 'utf8');
+    t.is(gitignore, '*');
+  }
+);
 
 test.serial('run a workflow with initial state from stdin', async (t) => {
   const workflow = {

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -423,7 +423,6 @@ test.serial('.cli-cache has a gitignore', async (t) => {
 test.serial('cache steps when running a .js expression', async (t) => {
   mockFs({
     '/job.js': `${fn}fn((state) => ({ ...state, x: 1 }));`,
-    '/.cli-cache/': {},
   });
 
   const options = {
@@ -436,13 +435,14 @@ test.serial('cache steps when running a .js expression', async (t) => {
   const result = await handler(options, logger);
   t.is(result.x, 1);
 
-  // A cache file was written (name is a generated id, so glob via readdir)
-  const files = await fs.readdir('/.cli-cache/workflow');
+  // workflow name is derived from the filename: 'job'
+  // step id is a generated uuid, so list the directory
+  const files = await fs.readdir('/.cli-cache/job');
   t.is(files.length, 1);
   t.true(files[0].endsWith('.json'));
 
   const cached = JSON.parse(
-    await fs.readFile(`/.cli-cache/workflow/${files[0]}`, 'utf8')
+    await fs.readFile(`/.cli-cache/job/${files[0]}`, 'utf8')
   );
   t.is(cached.x, 1);
 });
@@ -450,7 +450,6 @@ test.serial('cache steps when running a .js expression', async (t) => {
 test.serial('.cli-cache gitignore is written when caching a .js expression', async (t) => {
   mockFs({
     '/job.js': `${fn}fn((state) => ({ ...state, x: 1 }));`,
-    '/.cli-cache/': {},
   });
 
   const options = {

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -418,6 +418,54 @@ test.serial('.cli-cache has a gitignore', async (t) => {
   t.is(gitignore, '*');
 });
 
+// Regression test for https://github.com/OpenFn/kit/issues/669
+// Running a .js expression (not a workflow JSON) with caching enabled must not crash.
+test.serial('cache steps when running a .js expression', async (t) => {
+  mockFs({
+    '/job.js': `${fn}fn((state) => ({ ...state, x: 1 }));`,
+    '/.cli-cache/': {},
+  });
+
+  const options = {
+    ...defaultOptions,
+    expressionPath: '/job.js',
+    baseDir: '/',
+    cacheSteps: true,
+  };
+
+  const result = await handler(options, logger);
+  t.is(result.x, 1);
+
+  // A cache file was written (name is a generated id, so glob via readdir)
+  const files = await fs.readdir('/.cli-cache/workflow');
+  t.is(files.length, 1);
+  t.true(files[0].endsWith('.json'));
+
+  const cached = JSON.parse(
+    await fs.readFile(`/.cli-cache/workflow/${files[0]}`, 'utf8')
+  );
+  t.is(cached.x, 1);
+});
+
+test.serial('.cli-cache gitignore is written when caching a .js expression', async (t) => {
+  mockFs({
+    '/job.js': `${fn}fn((state) => ({ ...state, x: 1 }));`,
+    '/.cli-cache/': {},
+  });
+
+  const options = {
+    ...defaultOptions,
+    expressionPath: '/job.js',
+    baseDir: '/',
+    cacheSteps: true,
+  };
+
+  await handler(options, logger);
+
+  const gitignore = await fs.readFile('/.cli-cache/.gitignore', 'utf8');
+  t.is(gitignore, '*');
+});
+
 test.serial('run a workflow with initial state from stdin', async (t) => {
   const workflow = {
     workflow: {

--- a/packages/cli/test/execute/execute.test.ts
+++ b/packages/cli/test/execute/execute.test.ts
@@ -223,7 +223,7 @@ test.serial(
 
     await handler(options, logger);
     t.truthy(logger._find('debug', /credential map not found/i));
-  },
+  }
 );
 
 test.serial('run a workflow with state', async (t) => {
@@ -285,7 +285,7 @@ test.serial(
     t.regex(err.message, /typeerror: cannot read properties of undefined/i);
     t.is(err.pos.line, 2);
     t.is(err.pos.column, 23);
-  },
+  }
 );
 
 test.serial(
@@ -314,11 +314,11 @@ test.serial(
     t.truthy(result.errors);
     t.regex(
       result.errors.x.message,
-      /typeerror: cannot read properties of undefined/i,
+      /typeerror: cannot read properties of undefined/i
     );
     t.is(result.errors.x.pos.line, 2);
     t.is(result.errors.x.pos.column, 23);
-  },
+  }
 );
 
 test.serial(
@@ -348,11 +348,11 @@ test.serial(
     t.truthy(result.errors);
     t.regex(
       result.errors.x.message,
-      /typeerror: cannot read properties of undefined/i,
+      /typeerror: cannot read properties of undefined/i
     );
     t.is(result.errors.x.pos.line, 2);
     t.is(result.errors.x.pos.column, 23);
-  },
+  }
 );
 
 test.serial('run a workflow with cached steps', async (t) => {
@@ -441,31 +441,28 @@ test.serial('cache steps when running a .js expression', async (t) => {
   t.true(files[0].endsWith('.json'));
 
   const cached = JSON.parse(
-    await fs.readFile(`/.cli-cache/job/${files[0]}`, 'utf8'),
+    await fs.readFile(`/.cli-cache/job/${files[0]}`, 'utf8')
   );
   t.is(cached.x, 1);
 });
 
-test.serial(
-  '.cli-cache has a gitignore when caching a .js expression',
-  async (t) => {
-    mockFs({
-      '/job.js': `${fn}fn((state) => ({ ...state, x: 1 }));`,
-    });
+test.serial('.cli-cache has a gitignore when caching a .js expression', async (t) => {
+  mockFs({
+    '/job.js': `${fn}fn((state) => ({ ...state, x: 1 }));`,
+  });
 
-    const options = {
-      ...defaultOptions,
-      expressionPath: '/job.js',
-      baseDir: '/',
-      cacheSteps: true,
-    };
+  const options = {
+    ...defaultOptions,
+    expressionPath: '/job.js',
+    baseDir: '/',
+    cacheSteps: true,
+  };
 
-    await handler(options, logger);
+  await handler(options, logger);
 
-    const gitignore = await fs.readFile('/.cli-cache/.gitignore', 'utf8');
-    t.is(gitignore, '*');
-  },
-);
+  const gitignore = await fs.readFile('/.cli-cache/.gitignore', 'utf8');
+  t.is(gitignore, '*');
+});
 
 test.serial('run a workflow with initial state from stdin', async (t) => {
   const workflow = {


### PR DESCRIPTION
## Summary

Fixes the CLI cache bug reported in #669 where running a `.js` expression with caching enabled (via `OPENFN_ALWAYS_CACHE_STEPS=true` or `--cache-steps`) caused a `TypeError [ERR_INVALID_ARG_TYPE]` crash.

- **`ensureGitIgnore` rewritten**: The old implementation walked up the cache file path looking for a segment ending in `.cli-cache`. If the path did not contain that segment (e.g. a custom `cachePath`), the loop traversed all the way to the filesystem root and wrote `/.gitignore`. Replaced with a direct call to `getCachePath(options)` (no `workflowName`/`stepId`), which naturally returns the cache root, so no traversal is needed.
- **Undefined workflow name crash fixed**: `path.resolve` throws `ERR_INVALID_ARG_TYPE` when passed `undefined`. `getCachePath` now uses `.filter(Boolean)` before spreading into `path.resolve`, so an absent `plan.workflow.name` is simply omitted from the path rather than crashing.
- **Eliminated `getCacheRoot` helper**: After the above two fixes, `getCachePath(options)` with no extra arguments already returns the cache root directly — no separate helper needed.
- **Type fix for `saveToCache` and `clearCache`**: Both were typed as `Pick<Opts, 'baseDir' | 'cacheSteps'>`, missing `cachePath`, so the `cachePath` branch inside `getCachePath` was unreachable from these functions. Added `cachePath` to both Pick types.

## Test plan

- [x] Added `cache steps when running a .js expression` — runs an expression with `cacheSteps: true` and verifies the cache file is written under `.cli-cache/<name>/` (this is the exact scenario from #669, which had zero test coverage)
- [x] Added `.cli-cache has a gitignore when caching a .js expression` — verifies `.gitignore` is correctly placed in `.cli-cache/` and not at the filesystem root
- [x] All existing cache tests continue to pass

Closes #669