### PR TITLE
fix(cli): create output directory if it doesn't exist

### DIFF
--- a/packages/cli/src/collections/handler.ts
+++ b/packages/cli/src/collections/handler.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 
 import { Logger } from '../util/logger';
 import request from './request';
@@ -94,6 +94,7 @@ export const get = async (options: GetOptions, logger: Logger) => {
       null,
       options.pretty ? 2 : undefined
     );
+    await mkdir(path.dirname(options.outputPath!), { recursive: true });
     await writeFile(options.outputPath!, content);
     logger.always(`Wrote items to ${options.outputPath}`);
   } else {

--- a/packages/cli/src/compile/handler.ts
+++ b/packages/cli/src/compile/handler.ts
@@ -1,4 +1,5 @@
-import { writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import type { CompileOptions } from './command';
 import type { Logger } from '../util/logger';
 
@@ -22,6 +23,7 @@ const compileHandler = async (options: CompileOptions, logger: Logger) => {
   if (options.outputStdout) {
     logger.success('Result:\n\n' + result);
   } else {
+    await mkdir(dirname(options.outputPath!), { recursive: true });
     await writeFile(options.outputPath!, result as string);
     logger.success(`Compiled to ${options.outputPath}`);
   }


### PR DESCRIPTION
## Summary

Fixes #859. The `compile` and `collections get` commands threw `ENOENT` when `--output-path` pointed to a directory that hadn't been created yet, forcing users to manually `mkdir` before running the CLI.

- **`compile/handler.ts`**: added `await mkdir(dirname(outputPath), { recursive: true })` before `writeFile`
- **`collections/handler.ts`**: same fix in the `get` command's output branch

The `execute` command's `serialize-output.ts` already had this pattern — this PR brings the other two commands in line with it.

## Test plan

- [ ] `openfn compile job.js -o new/nested/dir/out.js` — should create `new/nested/dir/` and write the file
- [ ] `openfn collections get myCollection myKey -o new/nested/dir/out.json` — same
- [ ] Both commands still work normally when the output directory already exists

Closes #859