### PR TITLE
Fix incorrect divergence warnings on checkout

### DIFF
--- a/.changeset/hungry-lights-love.md
+++ b/.changeset/hungry-lights-love.md
@@ -1,0 +1,5 @@
+---
+'@openfn/lexicon': patch
+---
+
+Allow project.alias to be null

--- a/.changeset/late-needles-scream.md
+++ b/.changeset/late-needles-scream.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Fix an issue on checkout where incorrect divergence warnings can be shown

--- a/.changeset/yummy-balloons-search.md
+++ b/.changeset/yummy-balloons-search.md
@@ -1,0 +1,5 @@
+---
+'@openfn/project': patch
+---
+
+Set the correct alias on the checked out project

--- a/integration-tests/cli/test/errors.test.ts
+++ b/integration-tests/cli/test/errors.test.ts
@@ -22,7 +22,6 @@ test.serial('expression not found', async (t) => {
   const stdlogs = extractLogs(stdout);
   assertLog(t, stdlogs, /expression not found/i);
   assertLog(t, stdlogs, /failed to load the expression from blah.js/i);
-  assertLog(t, stdlogs, /critical error: aborting command/i);
 });
 
 test.serial('workflow not found', async (t) => {
@@ -33,7 +32,6 @@ test.serial('workflow not found', async (t) => {
 
   assertLog(t, stdlogs, /workflow not found/i);
   assertLog(t, stdlogs, /failed to load a workflow from blah.json/i);
-  assertLog(t, stdlogs, /critical error: aborting command/i);
 });
 
 test.serial('job contains invalid js', async (t) => {
@@ -45,7 +43,6 @@ test.serial('job contains invalid js', async (t) => {
   assertLog(t, stdlogs, /failed to compile job/i);
   assertLog(t, stdlogs, /unexpected token \(2:10\)/i);
   assertLog(t, stdlogs, /check the syntax of the job expression/i);
-  assertLog(t, stdlogs, /critical error: aborting command/i);
 });
 
 // TODO this should really mention which job threw the error
@@ -60,7 +57,6 @@ test.serial('workflow references a job with invalid js', async (t) => {
   assertLog(t, stdlogs, /failed to compile job/i);
   assertLog(t, stdlogs, /unexpected token \(2:10\)/i);
   assertLog(t, stdlogs, /check the syntax of the job expression/i);
-  assertLog(t, stdlogs, /critical error: aborting command/i);
 });
 
 test.serial("can't find an expression referenced in a workflow", async (t) => {
@@ -77,7 +73,6 @@ test.serial("can't find an expression referenced in a workflow", async (t) => {
     stdlogs,
     /This workflow references a file which cannot be found at does-not-exist.js/i
   );
-  assertLog(t, stdlogs, /critical error: aborting command/i);
 });
 
 test.serial("can't find config referenced in a workflow", async (t) => {
@@ -98,7 +93,6 @@ test.serial("can't find config referenced in a workflow", async (t) => {
     stdlogs,
     /This workflow references a file which cannot be found at does-not-exist.js/i
   );
-  assertLog(t, stdlogs, /critical error: aborting command/i);
 });
 
 test.serial('circular workflow', async (t) => {

--- a/integration-tests/cli/test/errors.test.ts
+++ b/integration-tests/cli/test/errors.test.ts
@@ -135,7 +135,6 @@ test.serial('invalid end (ambiguous)', async (t) => {
   const stdlogs = extractLogs(stdout);
 
   assertLog(t, stdlogs, /Error: end pattern matched multiple steps/i);
-  assertLog(t, stdlogs, /aborting/i);
 });
 
 // These test error outputs within valid workflows

--- a/integration-tests/cli/test/project-v1.test.ts
+++ b/integration-tests/cli/test/project-v1.test.ts
@@ -193,10 +193,9 @@ test.serial('merge a project', async (t) => {
   t.is(initial, 'fn(() => ({ x: 1}))');
 
   // Run the merge
-  await run(
-    `openfn merge hello-world-staging --workspace ${projectsPath} --force`
+  const { stdout } = await run(
+    `openfn merge hello-world-staging --workspace ${projectsPath} --force --log debug`
   );
-
   // Check the step is updated
   const merged = await readStep();
   t.is(merged, "log('hello world')");

--- a/integration-tests/cli/test/project-v2.test.ts
+++ b/integration-tests/cli/test/project-v2.test.ts
@@ -174,12 +174,13 @@ steps:
 
 test.serial('execute a workflow from the checked out project', async (t) => {
   // cheeky bonus test of checkout by alias
-  await run(`openfn checkout main --workspace ${TMP_DIR}`);
+  await run(`openfn checkout main --workspace ${TMP_DIR} --force`);
 
   // execute a workflow
-  await run(
+  const { stdout } = await run(
     `openfn hello-workflow  -o ${TMP_DIR}/output.json  --workspace ${TMP_DIR}`
   );
+  console.log(stdout);
 
   const output = await readFile(`${TMP_DIR}/output.json`, 'utf8');
   const finalState = JSON.parse(output);

--- a/packages/cli/src/projects/checkout.ts
+++ b/packages/cli/src/projects/checkout.ts
@@ -84,6 +84,7 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
       // TODO is alias robust here? Should we get by alias and domain?
       const tracked = workspace.get(localProject.alias ?? localProject.id);
       const changed = hasUntrackedChanges(localProject, tracked);
+      logger?.debug(changed);
       if (changed.length && !options.force) {
         const err = {
           details: `Changes may be lost by checking out ${
@@ -144,29 +145,29 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
 const hasUntrackedChanges = (
   activeProject: Project,
   tracked?: Project | null
-): string[] => {
+) => {
   if (!tracked) {
     // if there's no tracking we can't compare
     // should we log a warning then?
     return [];
   }
 
-  const changedWorkflows: string[] = [];
+  const changedWorkflows: Array<{
+    id: string;
+    type: 'new' | 'changed' | 'removed';
+  }> = [];
 
   // Check for changed and added workflows
   for (const workflow of activeProject.workflows) {
-    const currentHash = workflow.getVersionHash();
-
     const trackedWorkflow = tracked.getWorkflow(workflow.id);
     if (!trackedWorkflow) {
       // this is a new workflow added locally
-      changedWorkflows.push(workflow.id);
+      changedWorkflows.push({ id: workflow.id, type: 'new' });
       continue;
     }
 
-    const trackedHash = trackedWorkflow!.getVersionHash();
-    if (!versionsEqual(currentHash, trackedHash)) {
-      changedWorkflows.push(workflow.id);
+    if (!tracked.canMergeInto(activeProject)) {
+      changedWorkflows.push({ id: workflow.id, type: 'changed' });
     }
   }
 
@@ -174,7 +175,7 @@ const hasUntrackedChanges = (
   for (const workflow of tracked.workflows) {
     const localWorkflow = activeProject.getWorkflow(workflow.id);
     if (!localWorkflow) {
-      changedWorkflows.push(workflow.id);
+      changedWorkflows.push({ id: workflow.id, type: 'removed' });
     }
   }
 

--- a/packages/cli/src/projects/checkout.ts
+++ b/packages/cli/src/projects/checkout.ts
@@ -50,8 +50,10 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
   const { project: _, ...config } = workspace.getConfig() as any;
 
   const localProject = await workspace.getCheckedOutProject(
-    workspace.activeProject.alias ?? null
+    // TODO not sold on this assignment - I think my test case must be wrong
+    workspace.activeProject!.alias as any
   );
+
   // get the project
   let switchProject;
   if (/\.(yaml|json)$/.test(projectIdentifier)) {
@@ -75,7 +77,7 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
   // get the current state of the checked out project
   try {
     // If there's no project checked out, there's nothing to compare
-    if (localProject.workflows.length) {
+    if (localProject?.workflows.length) {
       logger?.info(
         `Loaded currently checked out project ${localProject.alias} to check for untracked changes`
       );
@@ -84,7 +86,9 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
       const changed = hasUntrackedChanges(localProject, tracked);
       if (changed.length && !options.force) {
         const err = {
-          details: `Changes may be lost by checking out ${localProject.alias} right now`,
+          details: `Changes may be lost by checking out ${
+            localProject.alias ?? localProject.id
+          } right now`,
           // TODO how can users save changes? Not really possible right now
           fix: 'Pass --force or -f to override this warning and continue',
         };

--- a/packages/cli/src/projects/checkout.ts
+++ b/packages/cli/src/projects/checkout.ts
@@ -50,7 +50,7 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
   const { project: _, ...config } = workspace.getConfig() as any;
 
   const localProject = await workspace.getCheckedOutProject(
-    workspace.activeProject.alias
+    workspace.activeProject.alias ?? null
   );
   // get the project
   let switchProject;
@@ -80,7 +80,7 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
         `Loaded currently checked out project ${localProject.alias} to check for untracked changes`
       );
       // TODO is alias robust here? Should we get by alias and domain?
-      const tracked = workspace.get(localProject.alias);
+      const tracked = workspace.get(localProject.alias ?? localProject.id);
       const changed = hasUntrackedChanges(localProject, tracked);
       if (changed.length && !options.force) {
         const err = {
@@ -157,6 +157,7 @@ const hasUntrackedChanges = (
     if (!trackedWorkflow) {
       // this is a new workflow added locally
       changedWorkflows.push(workflow.id);
+      continue;
     }
 
     const trackedHash = trackedWorkflow!.getVersionHash();

--- a/packages/cli/src/projects/checkout.ts
+++ b/packages/cli/src/projects/checkout.ts
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import Project, { versionsEqual, Workspace } from '@openfn/project';
+import Project, { Workspace } from '@openfn/project';
 import path from 'path';
 import fs from 'fs';
 import { rimraf } from 'rimraf';

--- a/packages/cli/src/projects/checkout.ts
+++ b/packages/cli/src/projects/checkout.ts
@@ -16,6 +16,7 @@ import {
   updateForkedFrom,
 } from './util';
 import { createProjectCredentials } from './create-credentials';
+import abort from '../util/abort';
 
 export type CheckoutOptions = Pick<
   Opts,
@@ -71,34 +72,32 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
       `Project with id ${projectIdentifier} not found in the workspace`
     );
   }
+  logger?.info(`Checking out ${switchProject.alias}`);
 
   // get the current state of the checked out project
   try {
     const localProject = await Project.from('fs', {
       root: options.workspace || '.',
     });
-    logger?.success(`Loaded local project ${localProject.alias}`);
+    logger?.info(
+      `Loaded currently checked out project ${localProject.alias} to check for divergence`
+    );
     const changed = await findLocallyChangedWorkflows(
       workspace,
       localProject,
       'assume-ok'
     );
     if (changed.length && !options.force) {
-      logger?.break();
-      logger?.warn(
-        'WARNING: detected changes on your currently checked-out project'
+      const err = {
+        details: `Changes may be lost by checking out ${localProject.alias} right now`,
+        // TODO how can users save changes? Not really possible right now
+        fix: 'Pass --force or -f to override this warning and continue',
+      };
+      abort(
+        logger!,
+        `${switchProject.alias} has diverged from ${localProject.alias}!`,
+        err
       );
-      logger?.warn(
-        `Changes may be lost by checking out ${localProject.alias} right now`
-      );
-      logger?.warn(`Pass --force or -f to override this warning and continue`);
-      // TODO log to run with force
-      // TODO need to implement a save function
-      const e = new Error(
-        `The currently checked out project has diverged! Changes may be lost`
-      );
-      delete e.stack;
-      throw e;
     }
   } catch (e: any) {
     if (e.message.match('ENOENT')) {

--- a/packages/cli/src/projects/checkout.ts
+++ b/packages/cli/src/projects/checkout.ts
@@ -51,7 +51,7 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
 
   const localProject = await workspace.getCheckedOutProject(
     // TODO not sold on this assignment - I think my test case must be wrong
-    workspace.activeProject!.alias as any
+    workspace.activeProject?.alias as any
   );
 
   // get the project

--- a/packages/cli/src/projects/checkout.ts
+++ b/packages/cli/src/projects/checkout.ts
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import Project, { Workspace } from '@openfn/project';
+import Project, { versionsEqual, Workspace } from '@openfn/project';
 import path from 'path';
 import fs from 'fs';
 import { rimraf } from 'rimraf';
@@ -10,11 +10,7 @@ import * as o from '../options';
 import * as po from './options';
 
 import type { Opts } from './options';
-import {
-  findLocallyChangedWorkflows,
-  tidyWorkflowDir,
-  updateForkedFrom,
-} from './util';
+import { tidyWorkflowDir, updateForkedFrom } from './util';
 import { createProjectCredentials } from './create-credentials';
 import abort from '../util/abort';
 
@@ -53,7 +49,9 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
   // TODO: try to retain the endpoint for the projects
   const { project: _, ...config } = workspace.getConfig() as any;
 
-  const currentProject = await workspace.getCheckedOutProject();
+  const localProject = await workspace.getCheckedOutProject(
+    workspace.activeProject.alias
+  );
   // get the project
   let switchProject;
   if (/\.(yaml|json)$/.test(projectIdentifier)) {
@@ -76,28 +74,26 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
 
   // get the current state of the checked out project
   try {
-    const localProject = await Project.from('fs', {
-      root: options.workspace || '.',
-    });
-    logger?.info(
-      `Loaded currently checked out project ${localProject.alias} to check for divergence`
-    );
-    const changed = await findLocallyChangedWorkflows(
-      workspace,
-      localProject,
-      'assume-ok'
-    );
-    if (changed.length && !options.force) {
-      const err = {
-        details: `Changes may be lost by checking out ${localProject.alias} right now`,
-        // TODO how can users save changes? Not really possible right now
-        fix: 'Pass --force or -f to override this warning and continue',
-      };
-      abort(
-        logger!,
-        `${switchProject.alias} has diverged from ${localProject.alias}!`,
-        err
+    // If there's no project checked out, there's nothing to compare
+    if (localProject.workflows.length) {
+      logger?.info(
+        `Loaded currently checked out project ${localProject.alias} to check for untracked changes`
       );
+      // TODO is alias robust here? Should we get by alias and domain?
+      const tracked = workspace.get(localProject.alias);
+      const changed = hasUntrackedChanges(localProject, tracked);
+      if (changed.length && !options.force) {
+        const err = {
+          details: `Changes may be lost by checking out ${localProject.alias} right now`,
+          // TODO how can users save changes? Not really possible right now
+          fix: 'Pass --force or -f to override this warning and continue',
+        };
+        abort(
+          logger!,
+          `${switchProject.alias} has diverged from ${localProject.alias}!`,
+          err
+        );
+      }
     }
   } catch (e: any) {
     if (e.message.match('ENOENT')) {
@@ -112,7 +108,7 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
   if (options.clean) {
     await rimraf(workspace.workflowsPath);
   } else {
-    await tidyWorkflowDir(currentProject, switchProject, false, workspacePath);
+    await tidyWorkflowDir(localProject, switchProject, false, workspacePath);
   }
 
   // write the forked from map
@@ -135,4 +131,47 @@ export const handler = async (options: CheckoutOptions, logger?: Logger) => {
   }
 
   logger?.success(`Expanded project to ${workspacePath}`);
+};
+
+// This function will tell us if the active/checked out project
+// has any changes compared to the tracked state file
+// It implies that changes will be lost on checkout
+// (later, users can save a project to an arbitrary save file and so this may not be true)
+const hasUntrackedChanges = (
+  activeProject: Project,
+  tracked?: Project | null
+): string[] => {
+  if (!tracked) {
+    // if there's no tracking we can't compare
+    // should we log a warning then?
+    return [];
+  }
+
+  const changedWorkflows: string[] = [];
+
+  // Check for changed and added workflows
+  for (const workflow of activeProject.workflows) {
+    const currentHash = workflow.getVersionHash();
+
+    const trackedWorkflow = tracked.getWorkflow(workflow.id);
+    if (!trackedWorkflow) {
+      // this is a new workflow added locally
+      changedWorkflows.push(workflow.id);
+    }
+
+    const trackedHash = trackedWorkflow!.getVersionHash();
+    if (!versionsEqual(currentHash, trackedHash)) {
+      changedWorkflows.push(workflow.id);
+    }
+  }
+
+  // Check for removed workflows
+  for (const workflow of tracked.workflows) {
+    const localWorkflow = activeProject.getWorkflow(workflow.id);
+    if (!localWorkflow) {
+      changedWorkflows.push(workflow.id);
+    }
+  }
+
+  return changedWorkflows;
 };

--- a/packages/cli/src/projects/list.ts
+++ b/packages/cli/src/projects/list.ts
@@ -7,6 +7,7 @@ import * as o from '../options';
 import * as po from './options';
 
 import type { Opts } from './options';
+import abort from '../util/abort';
 
 export type ProjectListOptions = Pick<Opts, 'log' | 'workspace'>;
 
@@ -34,7 +35,9 @@ export const handler = async (options: ProjectListOptions, logger: Logger) => {
     // eg, this will happen if there's no openfn.yaml file
     // basically we need the workspace to return a reason
     // (again, I'm thinking of removing the validation entirely)
-    throw new Error('No OpenFn projects found');
+    abort(logger, `No OpenFn projects found at ${options.workspace}`, {
+      fix: 'Run this command from a folder with an openfn.yaml file, or pass --workspace to set the workspace root',
+    });
   }
 
   logger.always(`Available openfn projects\n\n${workspace

--- a/packages/cli/src/projects/merge.ts
+++ b/packages/cli/src/projects/merge.ts
@@ -171,6 +171,8 @@ export const handler = async (options: MergeOptions, logger: Logger) => {
       workspace: workspacePath,
       project: options.outputPath ? finalPath : final.id,
       log: options.log,
+      // after the merge, we have to force the output to be checked out, ignoring divergence
+      force: true,
     },
     logger
   );

--- a/packages/cli/src/projects/util.ts
+++ b/packages/cli/src/projects/util.ts
@@ -268,7 +268,6 @@ export const findLocallyChangedWorkflows = async (
 ) => {
   // Check openfn.yaml for the forked_from versions
   const { forked_from } = workspace.activeProject ?? {};
-  console.log({ forked_from });
   // If there are no forked_from references, we have no baseline
   // so assume everything has changed
   if (!forked_from || Object.keys(forked_from).length === 0) {

--- a/packages/cli/src/projects/util.ts
+++ b/packages/cli/src/projects/util.ts
@@ -259,6 +259,8 @@ export const updateForkedFrom = (proj: Project) => {
   return proj;
 };
 
+// Compare a project to its version hashed when forked
+// This tells us whether the project was edited since it was created
 export const findLocallyChangedWorkflows = async (
   workspace: Workspace,
   project: Project,

--- a/packages/cli/src/projects/util.ts
+++ b/packages/cli/src/projects/util.ts
@@ -266,7 +266,7 @@ export const findLocallyChangedWorkflows = async (
 ) => {
   // Check openfn.yaml for the forked_from versions
   const { forked_from } = workspace.activeProject ?? {};
-
+  console.log({ forked_from });
   // If there are no forked_from references, we have no baseline
   // so assume everything has changed
   if (!forked_from || Object.keys(forked_from).length === 0) {

--- a/packages/cli/src/util/abort.ts
+++ b/packages/cli/src/util/abort.ts
@@ -16,24 +16,24 @@ interface CLIFriendlyError extends Error {
 export default (
   logger: Logger,
   reason: string,
-  error?: CLIFriendlyError,
+  error?: Partial<CLIFriendlyError>,
   help?: string
 ) => {
   const e = new AbortError(reason);
   logger.break();
   logger.error(reason);
   if (error) {
-    logger.error(error.message);
-    logger.break();
+    if (error.message) {
+      logger.error(error.message);
+      logger.break();
+    }
 
     if (error.details) {
-      logger.error('ERROR DETAILS:');
       logger.error(error.details);
       logger.break();
     }
     if (error.fix) {
-      logger.error('FIX HINT:');
-      logger.error(error.fix);
+      logger.always(error.fix);
       logger.break();
     }
   }
@@ -41,7 +41,7 @@ export default (
     logger.always(help);
   }
   logger.break();
-  logger.error('Critical error: aborting command');
+  // logger.error('Critical error: aborting command');
 
   process.exitCode = 1;
 

--- a/packages/cli/test/compile/compile.test.ts
+++ b/packages/cli/test/compile/compile.test.ts
@@ -87,9 +87,10 @@ test.serial('throw an AbortError if a job is uncompilable', async (t) => {
     message: 'Failed to compile job',
   });
 
+  console.log(logger._history);
+
   t.assert(logger._find('error', /unexpected token/i));
   t.assert(logger._find('always', /check the syntax of the job expression/i));
-  t.assert(logger._find('error', /critical error: aborting command/i));
 });
 
 test.serial(
@@ -111,7 +112,6 @@ test.serial(
 
     t.assert(logger._find('error', /unexpected token/i));
     t.assert(logger._find('always', /check the syntax of the job expression/i));
-    t.assert(logger._find('error', /critical error: aborting command/i));
   }
 );
 

--- a/packages/cli/test/compile/compile.test.ts
+++ b/packages/cli/test/compile/compile.test.ts
@@ -87,8 +87,6 @@ test.serial('throw an AbortError if a job is uncompilable', async (t) => {
     message: 'Failed to compile job',
   });
 
-  console.log(logger._history);
-
   t.assert(logger._find('error', /unexpected token/i));
   t.assert(logger._find('always', /check the syntax of the job expression/i));
 });

--- a/packages/cli/test/projects/checkout.test.ts
+++ b/packages/cli/test/projects/checkout.test.ts
@@ -722,3 +722,167 @@ test.serial(
     t.true(fs.existsSync('/ws5/workflows/workflow-a'));
   }
 );
+
+const main = `id: sandboxing
+name: sandboxing
+schema_version: '4.0'
+collections: []
+channels: []
+credentials:
+  - uuid: 8c675997-117b-4e8a-a65e-1ddea0d0e525
+    name: name
+    owner: editor@openfn.org
+openfn:
+  uuid: 44c0c920-5635-4984-ade2-b95fb24cbaf0
+  endpoint: http://localhost:4000
+  inserted_at: 2025-10-15T11:29:36Z
+  updated_at: 2026-03-17T11:59:53Z
+options:
+  env: main
+  allow_support_access: false
+  requires_mfa: false
+  retention_policy: retain_all
+workflows:
+  - name: A
+    steps:
+      - id: aaa
+        name: aaa
+        expression: // abc
+        adaptor: '@openfn/language-common@latest'
+        openfn:
+          uuid: 7b6a6de4-eed2-4204-8ac0-4da8fa64206c
+        next:
+          bbb:
+            disabled: false
+            condition: on_job_success
+            openfn:
+              uuid: 64f1b20f-bfdf-4626-87de-403008cfb05d
+      - id: bbb
+        name: bbb
+        expression: '2'
+        adaptor: '@openfn/language-common@3.3.1'
+        openfn:
+          uuid: 832f5560-69c5-4eae-89cc-823b93af82c8
+      - id: webhook
+        type: webhook
+        enabled: true
+        webhook_reply: before_start
+        openfn:
+          uuid: 16ddedbb-1d70-44b7-8653-26f8dc802757
+        next:
+          aaa:
+            disabled: false
+            condition: always
+            openfn:
+              uuid: eccb03ef-990d-4ca7-877b-5452bbc8f63b
+    history:
+      - app:0a97362c97b3
+      - app:8eb248f07744
+    openfn:
+      uuid: 4b2c13aa-2497-421a-9bb2-783309254130
+      updated_at: 2026-05-14T10:25:36Z
+      inserted_at: 2026-05-14T10:25:10Z
+      lock_version: 6
+    id: a
+    start: webhook
+`;
+const staging = `id: joe-2
+name: joe-2
+schema_version: '4.0'
+cli:
+  forked_from:
+    a: cli:145ff1ae62e5
+collections: []
+channels: []
+credentials: []
+openfn:
+  uuid: 7c478de6-4c82-427d-aad2-875b1b9eccb8
+  endpoint: http://localhost:4000
+  alias: staging
+  inserted_at: 2026-05-26T16:27:05Z
+  updated_at: 2026-05-26T16:27:05Z
+options:
+  allow_support_access: false
+  requires_mfa: false
+  retention_policy: retain_all
+workflows:
+  - name: A
+    steps:
+      - id: aaa
+        name: aaa
+        expression: // 2
+        adaptor: '@openfn/language-common@latest'
+        openfn:
+          uuid: 8227ae53-81f8-447f-bb93-213d5721f884
+        next:
+          bbb:
+            disabled: false
+            condition: on_job_success
+            openfn:
+              uuid: 474d6861-bb47-4fad-953d-a7762751bae0
+      - id: bbb
+        name: bbb
+        expression: '2'
+        adaptor: '@openfn/language-http@7.2.11'
+        openfn:
+          uuid: 862bec16-ef94-4438-b307-8594a70276fe
+      - id: webhook
+        type: webhook
+        enabled: false
+        webhook_reply: before_start
+        openfn:
+          uuid: d7dfdd68-ecb8-4adc-90cf-8a4ed8cc0235
+        next:
+          aaa:
+            disabled: false
+            condition: always
+            openfn:
+              uuid: 067cab97-bef8-4d70-b484-5d013d27142b
+    history:
+      - cli:145ff1ae62e5
+    openfn:
+      uuid: 9746c1d9-1499-4413-9edc-c23577e9308e
+      inserted_at: 2026-05-26T16:27:05Z
+      updated_at: 2026-05-26T16:27:05Z
+      lock_version: 1
+    id: a
+    start: webhook
+`;
+
+// is this "check out unrelated projects" ?
+// which case its project a and project b, not main and staging
+// unrelated projects should not throw a divergence warning if not changed
+// note that there seem to be no divergence tests in this file
+// so probably I need a basic divergence test too
+test.serial.only('local issue', async (t) => {
+  mock({
+    '/tmp/openfn.yaml': '',
+    '/tmp/.projects/main@server.yaml': main,
+    '/tmp/.projects/staging@server.yaml': staging,
+  });
+
+  // first checkout main to set up the file system
+  await checkoutHandler(
+    {
+      command: 'project-checkout',
+      project: 'main',
+      workspace: '/tmp',
+    },
+    logger
+  );
+  console.log('main ok');
+  logger._reset();
+
+  // now checkout staging
+  // this throws, which reproduces my issue
+  await checkoutHandler(
+    {
+      command: 'project-checkout',
+      project: 'staging',
+      workspace: '/tmp',
+    },
+    logger
+  );
+});
+
+// TODO: unrelated projects should throw a divergence warning if changed

--- a/packages/cli/test/projects/checkout.test.ts
+++ b/packages/cli/test/projects/checkout.test.ts
@@ -241,55 +241,52 @@ test.serial(
   }
 );
 
-test.serial.only(
-  'checkout: switching to and back between projects',
-  async (t) => {
-    // before checkout. my-project is active and expanded
-    const bcheckout = new Workspace('/ws');
-    t.is(bcheckout.activeProject!.id, 'my-project');
+test.serial('checkout: switching to and back between projects', async (t) => {
+  // before checkout. my-project is active and expanded
+  const bcheckout = new Workspace('/ws');
+  t.is(bcheckout.activeProject!.id, 'my-project');
 
-    // 1. switch from my-project to my-staging
-    await checkoutHandler(
-      { command: 'project-checkout', project: 'my-staging', workspace: '/ws' },
-      logger
-    );
-    const { message } = logger._parse(logger._last);
-    t.is(message, 'Expanded project to /ws');
+  // 1. switch from my-project to my-staging
+  await checkoutHandler(
+    { command: 'project-checkout', project: 'my-staging', workspace: '/ws' },
+    logger
+  );
+  const { message } = logger._parse(logger._last);
+  t.is(message, 'Expanded project to /ws');
 
-    // after checkout. my-staging is active and expanded
-    const acheckout = new Workspace('/ws');
-    t.is(acheckout.activeProject!.id, 'my-staging');
+  // after checkout. my-staging is active and expanded
+  const acheckout = new Workspace('/ws');
+  t.is(acheckout.activeProject!.id, 'my-staging');
 
-    // check if files where well expanded
-    t.deepEqual(
-      fs.readdirSync('/ws/workflows').sort(),
-      ['simple-workflow', 'another-workflow'].sort()
-    );
+  // check if files where well expanded
+  t.deepEqual(
+    fs.readdirSync('/ws/workflows').sort(),
+    ['simple-workflow', 'another-workflow'].sort()
+  );
 
-    // 2. switch back from my-project to my-project
-    await checkoutHandler(
-      {
-        command: 'project-checkout',
-        project: 'my-project',
-        workspace: '/ws',
-        clean: true,
-      },
-      logger
-    );
-    const { message: lastMsg } = logger._parse(logger._last);
-    t.is(lastMsg, 'Expanded project to /ws');
+  // 2. switch back from my-project to my-project
+  await checkoutHandler(
+    {
+      command: 'project-checkout',
+      project: 'my-project',
+      workspace: '/ws',
+      clean: true,
+    },
+    logger
+  );
+  const { message: lastMsg } = logger._parse(logger._last);
+  t.is(lastMsg, 'Expanded project to /ws');
 
-    // after checkout. my-project is active and expanded
-    const fcheckout = new Workspace('/ws');
-    t.is(fcheckout.activeProject!.id, 'my-project');
+  // after checkout. my-project is active and expanded
+  const fcheckout = new Workspace('/ws');
+  t.is(fcheckout.activeProject!.id, 'my-project');
 
-    // check if files where well expanded
-    t.deepEqual(
-      fs.readdirSync('/ws/workflows').sort(),
-      ['simple-workflow-main', 'another-workflow-main'].sort()
-    );
-  }
-);
+  // check if files where well expanded
+  t.deepEqual(
+    fs.readdirSync('/ws/workflows').sort(),
+    ['simple-workflow-main', 'another-workflow-main'].sort()
+  );
+});
 
 test.serial('checkout: switch with id', async (t) => {
   const before = new Workspace('/ws');
@@ -533,6 +530,8 @@ test.serial(
         command: 'project-checkout',
         project: 'main-project',
         workspace: '/ws3',
+        // the project on-disk has diverged from the statefile, so we need to force it through
+        force: true,
       },
       logger
     );
@@ -573,6 +572,8 @@ test.serial(
         command: 'project-checkout',
         project: 'main-project',
         workspace: '/ws4',
+        // the project on-disk has diverged from the statefile, so we need to force it through
+        force: true,
       },
       logger
     );
@@ -717,6 +718,8 @@ test.serial(
         command: 'project-checkout',
         project: 'main-project',
         workspace: '/ws5',
+        // the project on-disk has diverged from the statefile, so we need to force it through
+        force: true,
       },
       logger
     );

--- a/packages/cli/test/projects/checkout.test.ts
+++ b/packages/cli/test/projects/checkout.test.ts
@@ -241,52 +241,55 @@ test.serial(
   }
 );
 
-test.serial('checkout: switching to and back between projects', async (t) => {
-  // before checkout. my-project is active and expanded
-  const bcheckout = new Workspace('/ws');
-  t.is(bcheckout.activeProject!.id, 'my-project');
+test.serial.only(
+  'checkout: switching to and back between projects',
+  async (t) => {
+    // before checkout. my-project is active and expanded
+    const bcheckout = new Workspace('/ws');
+    t.is(bcheckout.activeProject!.id, 'my-project');
 
-  // 1. switch from my-project to my-staging
-  await checkoutHandler(
-    { command: 'project-checkout', project: 'my-staging', workspace: '/ws' },
-    logger
-  );
-  const { message } = logger._parse(logger._last);
-  t.is(message, 'Expanded project to /ws');
+    // 1. switch from my-project to my-staging
+    await checkoutHandler(
+      { command: 'project-checkout', project: 'my-staging', workspace: '/ws' },
+      logger
+    );
+    const { message } = logger._parse(logger._last);
+    t.is(message, 'Expanded project to /ws');
 
-  // after checkout. my-staging is active and expanded
-  const acheckout = new Workspace('/ws');
-  t.is(acheckout.activeProject!.id, 'my-staging');
+    // after checkout. my-staging is active and expanded
+    const acheckout = new Workspace('/ws');
+    t.is(acheckout.activeProject!.id, 'my-staging');
 
-  // check if files where well expanded
-  t.deepEqual(
-    fs.readdirSync('/ws/workflows').sort(),
-    ['simple-workflow', 'another-workflow'].sort()
-  );
+    // check if files where well expanded
+    t.deepEqual(
+      fs.readdirSync('/ws/workflows').sort(),
+      ['simple-workflow', 'another-workflow'].sort()
+    );
 
-  // 2. switch back from my-project to my-project
-  await checkoutHandler(
-    {
-      command: 'project-checkout',
-      project: 'my-project',
-      workspace: '/ws',
-      clean: true,
-    },
-    logger
-  );
-  const { message: lastMsg } = logger._parse(logger._last);
-  t.is(lastMsg, 'Expanded project to /ws');
+    // 2. switch back from my-project to my-project
+    await checkoutHandler(
+      {
+        command: 'project-checkout',
+        project: 'my-project',
+        workspace: '/ws',
+        clean: true,
+      },
+      logger
+    );
+    const { message: lastMsg } = logger._parse(logger._last);
+    t.is(lastMsg, 'Expanded project to /ws');
 
-  // after checkout. my-project is active and expanded
-  const fcheckout = new Workspace('/ws');
-  t.is(fcheckout.activeProject!.id, 'my-project');
+    // after checkout. my-project is active and expanded
+    const fcheckout = new Workspace('/ws');
+    t.is(fcheckout.activeProject!.id, 'my-project');
 
-  // check if files where well expanded
-  t.deepEqual(
-    fs.readdirSync('/ws/workflows').sort(),
-    ['simple-workflow-main', 'another-workflow-main'].sort()
-  );
-});
+    // check if files where well expanded
+    t.deepEqual(
+      fs.readdirSync('/ws/workflows').sort(),
+      ['simple-workflow-main', 'another-workflow-main'].sort()
+    );
+  }
+);
 
 test.serial('checkout: switch with id', async (t) => {
   const before = new Workspace('/ws');
@@ -853,7 +856,7 @@ workflows:
     start: webhook
 `;
 
-test.serial.only(
+test.serial(
   'Checkout unrelated bar from unrelated project foo without divergence warning',
   async (t) => {
     mock({
@@ -899,7 +902,7 @@ test.serial.only(
   }
 );
 
-test.serial.only(
+test.serial(
   'Checkout unrelated foo from unrelated project bar without divergence warning',
   async (t) => {
     mock({
@@ -945,4 +948,46 @@ test.serial.only(
   }
 );
 
-// TODO: unrelated projects should throw a divergence warning if changed
+test.serial(
+  'If the checked out project has diverged from the tracked version, show a divergence warning on checkout',
+  async (t) => {
+    mock({
+      '/tmp/openfn.yaml': '',
+      '/tmp/.projects/main@server.yaml': foo,
+      '/tmp/.projects/staging@server.yaml': bar,
+    });
+
+    await checkoutHandler(
+      {
+        command: 'project-checkout',
+        project: 'bar',
+        workspace: '/tmp',
+      },
+      logger
+    );
+    logger._reset();
+
+    // assert that main was checked out ok
+    let openfn = yamlToJson(fs.readFileSync('/tmp/openfn.yaml', 'utf8'));
+    t.is(openfn.project.id, 'bar');
+
+    // Now make a change - on checkout, this change will be lost (it is not saved anywhere)
+    fs.writeFileSync('/tmp/workflows/a/aaa.js', 'foobar');
+
+    // now try to checkout foo
+    await t.throwsAsync(
+      () =>
+        checkoutHandler(
+          {
+            command: 'project-checkout',
+            project: 'foo',
+            workspace: '/tmp',
+          },
+          logger
+        ),
+      {
+        message: 'main has diverged from staging!',
+      }
+    );
+  }
+);

--- a/packages/cli/test/projects/checkout.test.ts
+++ b/packages/cli/test/projects/checkout.test.ts
@@ -723,8 +723,12 @@ test.serial(
   }
 );
 
-const main = `id: sandboxing
-name: sandboxing
+/**
+ * Using projects foo and bar here which come from a real issue
+ * Keeping those exact state files to keep diversity in the tests
+ */
+const foo = `id: foo
+name: foo
 schema_version: '4.0'
 collections: []
 channels: []
@@ -786,8 +790,8 @@ workflows:
     id: a
     start: webhook
 `;
-const staging = `id: joe-2
-name: joe-2
+const bar = `id: bar
+name: bar
 schema_version: '4.0'
 cli:
   forked_from:
@@ -849,40 +853,96 @@ workflows:
     start: webhook
 `;
 
-// is this "check out unrelated projects" ?
-// which case its project a and project b, not main and staging
-// unrelated projects should not throw a divergence warning if not changed
-// note that there seem to be no divergence tests in this file
-// so probably I need a basic divergence test too
-test.serial.only('local issue', async (t) => {
-  mock({
-    '/tmp/openfn.yaml': '',
-    '/tmp/.projects/main@server.yaml': main,
-    '/tmp/.projects/staging@server.yaml': staging,
-  });
+test.serial.only(
+  'Checkout unrelated bar from unrelated project foo without divergence warning',
+  async (t) => {
+    mock({
+      '/tmp/openfn.yaml': '',
+      '/tmp/.projects/main@server.yaml': foo,
+      '/tmp/.projects/staging@server.yaml': bar,
+    });
 
-  // first checkout main to set up the file system
-  await checkoutHandler(
-    {
-      command: 'project-checkout',
-      project: 'main',
-      workspace: '/tmp',
-    },
-    logger
-  );
-  console.log('main ok');
-  logger._reset();
+    // first checkout foo to set up the file system
+    await checkoutHandler(
+      {
+        command: 'project-checkout',
+        project: 'foo',
+        workspace: '/tmp',
+      },
+      logger
+    );
 
-  // now checkout staging
-  // this throws, which reproduces my issue
-  await checkoutHandler(
-    {
-      command: 'project-checkout',
-      project: 'staging',
-      workspace: '/tmp',
-    },
-    logger
-  );
-});
+    // assert that staging was checked out ok
+    let openfn = yamlToJson(fs.readFileSync('/tmp/openfn.yaml', 'utf8'));
+    t.is(openfn.project.id, 'foo');
+
+    let expression = fs.readFileSync('/tmp/workflows/a/aaa.js', 'utf8');
+    t.is(expression, '// abc');
+
+    // now checkout bar
+    await checkoutHandler(
+      {
+        command: 'project-checkout',
+        project: 'bar',
+        workspace: '/tmp',
+      },
+      logger
+    );
+    logger._reset();
+
+    // assert that main was checked out ok
+    openfn = yamlToJson(fs.readFileSync('/tmp/openfn.yaml', 'utf8'));
+    t.is(openfn.project.id, 'bar');
+
+    expression = fs.readFileSync('/tmp/workflows/a/aaa.js', 'utf8');
+    t.is(expression, '// 2');
+  }
+);
+
+test.serial.only(
+  'Checkout unrelated foo from unrelated project bar without divergence warning',
+  async (t) => {
+    mock({
+      '/tmp/openfn.yaml': '',
+      '/tmp/.projects/main@server.yaml': foo,
+      '/tmp/.projects/staging@server.yaml': bar,
+    });
+
+    // first checkout bar to set up the file system
+    await checkoutHandler(
+      {
+        command: 'project-checkout',
+        project: 'bar',
+        workspace: '/tmp',
+      },
+      logger
+    );
+    logger._reset();
+
+    // assert that main was checked out ok
+    let openfn = yamlToJson(fs.readFileSync('/tmp/openfn.yaml', 'utf8'));
+    t.is(openfn.project.id, 'bar');
+
+    let expression = fs.readFileSync('/tmp/workflows/a/aaa.js', 'utf8');
+    t.is(expression, '// 2');
+
+    // now checkout foo
+    await checkoutHandler(
+      {
+        command: 'project-checkout',
+        project: 'foo',
+        workspace: '/tmp',
+      },
+      logger
+    );
+
+    // assert that staging was checked out ok
+    openfn = yamlToJson(fs.readFileSync('/tmp/openfn.yaml', 'utf8'));
+    t.is(openfn.project.id, 'foo');
+
+    expression = fs.readFileSync('/tmp/workflows/a/aaa.js', 'utf8');
+    t.is(expression, '// abc');
+  }
+);
 
 // TODO: unrelated projects should throw a divergence warning if changed

--- a/packages/cli/test/projects/list.test.ts
+++ b/packages/cli/test/projects/list.test.ts
@@ -135,7 +135,7 @@ test('throw for invalid workspace directory', async (t) => {
   await t.throwsAsync(
     () => list({ command: 'projects', workspace: '/invalid' }, logger),
     {
-      message: 'No OpenFn projects found',
+      message: 'No OpenFn projects found at /invalid',
     }
   );
   // const { message } = logger._parse(logger._last);
@@ -146,7 +146,7 @@ test('throw if dir is not a workspace', async (t) => {
   await t.throwsAsync(
     () => list({ command: 'projects', workspace: '/no-ws' }, logger),
     {
-      message: 'No OpenFn projects found',
+      message: 'No OpenFn projects found at /no-ws',
     }
   );
 });

--- a/packages/lexicon/core.d.ts
+++ b/packages/lexicon/core.d.ts
@@ -94,7 +94,7 @@ export interface LocalMeta {
   This only affects how a state file ondisk is parsed */
   version?: number;
   /** Shorthand identifier used by CLI commands */
-  alias?: string;
+  alias?: string | null;
   [key: string]: any;
 }
 

--- a/packages/project/src/Project.ts
+++ b/packages/project/src/Project.ts
@@ -36,7 +36,7 @@ type UUIDMap = {
 
 type CLIMeta = {
   version?: number;
-  alias?: string;
+  alias?: string | null;
   forked_from?: Record<string, string>;
 };
 
@@ -169,11 +169,11 @@ export class Project {
   }
 
   /** Local alias for the project. Comes from the file name. Not shared with Lightning. */
-  get alias() {
-    return this.cli.alias ?? 'main';
+  get alias(): string | null {
+    return this.cli.alias ?? null;
   }
 
-  set alias(value: string) {
+  set alias(value: string | null) {
     this.cli ??= {};
     this.cli.alias = value;
   }

--- a/packages/project/src/Workflow.ts
+++ b/packages/project/src/Workflow.ts
@@ -208,7 +208,6 @@ class Workflow {
       this.workflow.history?.concat(this.getVersionHash()) ?? [];
     const targetHistory =
       target.workflow.history?.concat(target.getVersionHash()) ?? [];
-
     const targetHead = targetHistory[targetHistory.length - 1];
     return thisHistory.indexOf(targetHead) > -1;
   }

--- a/packages/project/src/Workspace.ts
+++ b/packages/project/src/Workspace.ts
@@ -123,10 +123,13 @@ export class Workspace {
     );
   }
 
-  async getCheckedOutProject() {
+  async getCheckedOutProject(alias: string | null = null) {
     return await Project.from('fs', {
       root: this.root,
       config: this.config,
+      // The checked out project can't meaningfully be said to have an alias
+      // But we can force one if it makes sense from context
+      alias: alias,
     }).catch((e) => {
       if (e.code === 'ENOENT') return undefined;
       throw e;

--- a/packages/project/src/Workspace.ts
+++ b/packages/project/src/Workspace.ts
@@ -48,6 +48,13 @@ export class Workspace {
       }
     }
     this.config = buildConfig(context.workspace);
+
+    // TODO: work out the alias of the active project
+    //       and make sure it's written
+    // tbh as activeProject is just the metadata in openfn.yaml,
+    // it's not super reliable
+    // Actually would it not be better to find the ACTUAL project and just
+    // reference that?
     this.activeProject = context.project;
 
     const projectsPath = path.join(workspacePath, this.config.dirs.projects);
@@ -123,13 +130,13 @@ export class Workspace {
     );
   }
 
-  async getCheckedOutProject(alias: string | null = null) {
+  async getCheckedOutProject(alias?: string | null) {
     return await Project.from('fs', {
       root: this.root,
       config: this.config,
       // The checked out project can't meaningfully be said to have an alias
       // But we can force one if it makes sense from context
-      alias: alias,
+      alias: alias ?? null,
     }).catch((e) => {
       if (e.code === 'ENOENT') return undefined;
       throw e;

--- a/packages/project/src/parse/from-fs.ts
+++ b/packages/project/src/parse/from-fs.ts
@@ -19,7 +19,7 @@ export type FromFsConfig = {
   root: string;
   config?: Partial<l.WorkspaceConfig>;
   logger?: Logger;
-  alias?: string;
+  alias?: string | null;
   name?: string;
 };
 

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -71,7 +71,6 @@ export default (
     for (const root of monorepoRoots) {
       const candidate = path.resolve(root, 'packages', shortName);
       if (fs.existsSync(path.join(candidate, 'package.json'))) {
-        console.log(' >>>> found ', candidate);
         return candidate;
       }
     }
@@ -84,7 +83,6 @@ export default (
   };
 
   const appendLocalVersions = (job: Job) => {
-    console.log({ monorepoRoots });
     if (monorepoRoots.length && job.adaptors!) {
       for (const adaptor of job.adaptors) {
         const { name, version } = getNameAndVersion(adaptor);
@@ -97,7 +95,6 @@ export default (
               path: localPath,
               version: 'local',
             };
-            console.log(job);
           }
         }
       }

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -71,6 +71,7 @@ export default (
     for (const root of monorepoRoots) {
       const candidate = path.resolve(root, 'packages', shortName);
       if (fs.existsSync(path.join(candidate, 'package.json'))) {
+        console.log(' >>>> found ', candidate);
         return candidate;
       }
     }
@@ -83,6 +84,7 @@ export default (
   };
 
   const appendLocalVersions = (job: Job) => {
+    console.log({ monorepoRoots });
     if (monorepoRoots.length && job.adaptors!) {
       for (const adaptor of job.adaptors) {
         const { name, version } = getNameAndVersion(adaptor);
@@ -95,6 +97,7 @@ export default (
               path: localPath,
               version: 'local',
             };
+            console.log(job);
           }
         }
       }


### PR DESCRIPTION
## Short Description

The checkout code  is using the wrong algorithm to detect whether there are "unstaged" changes that could be lost on checkout. I think this was probably broken when updating the algorithm for other reasons, which subtly broke checkout.

Checkout didn't have good divergence tests so the changes went unnoticed.

This PR introduces bespoke algorithm which does the job a lot better.

Fixes #1433

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
