### PR TITLE
feat: add changeset to republish @openfn/project

### DIFF
--- a/.changeset/vast-flies-kiss.md
+++ b/.changeset/vast-flies-kiss.md
@@ -1,0 +1,5 @@
+---
+'@openfn/project': patch
+---
+
+Fix detectVersion not exported bug

--- a/.changeset/vast-flies-kiss.md
+++ b/.changeset/vast-flies-kiss.md
@@ -2,4 +2,4 @@
 '@openfn/project': patch
 ---
 
-Fix detectVersion not exported bug
+Export detectVersion utility


### PR DESCRIPTION
## Short Description

In the recent release, @openfn/project wasn't bumped up causing the import of the new `detectVersions` method by CLI to be unavailable

Fixes #1471

## Implementation Details

Just a new release to bump up the version!

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

