### PR TITLE
ws-worker image does not rely on root

### DIFF
--- a/.changeset/lazy-beds-pay.md
+++ b/.changeset/lazy-beds-pay.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': minor
+---
+
+Run Docker image as node user

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,7 @@ RUN pnpm build
 WORKDIR /app/packages/ws-worker
 # ------------------------------------------------------------------------------
 
+USER node
+
 EXPOSE 2222
 CMD [ "node", "./dist/start.js"]


### PR DESCRIPTION
## Short Description

Allows the worker to run as the node user, not the root user.

Fixes #1493 

## Implementation Details

Added an explicit USER directive in the Dockerfile.

## QA Notes



## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)


