### PR TITLE
Worker: support workOrderId on meta object

### DIFF
--- a/.changeset/fuzzy-icons-design.md
+++ b/.changeset/fuzzy-icons-design.md
@@ -1,6 +1,0 @@
----
-'@openfn/ws-worker': patch
-'@openfn/lexicon': patch
----
-
-Support metadata on the run object

--- a/.changeset/fuzzy-icons-design.md
+++ b/.changeset/fuzzy-icons-design.md
@@ -1,0 +1,6 @@
+---
+'@openfn/ws-worker': patch
+'@openfn/lexicon': patch
+---
+
+Support metadata on the run object

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfn/cli
 
+## 1.39.4
+
+### Patch Changes
+
+- Updated dependencies [e3ddfef]
+  - @openfn/lexicon@2.4.1
+
 ## 1.39.3
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/cli",
-  "version": "1.39.3",
+  "version": "1.39.4",
   "description": "CLI devtools for the OpenFn toolchain",
   "engines": {
     "node": ">=18",

--- a/packages/lexicon/CHANGELOG.md
+++ b/packages/lexicon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # lexicon
 
+## 2.4.1
+
+### Patch Changes
+
+- e3ddfef: Support metadata on the run object
+
 ## 2.4.0
 
 ### Minor Changes

--- a/packages/lexicon/lightning.d.ts
+++ b/packages/lexicon/lightning.d.ts
@@ -44,6 +44,14 @@ export type LightningPlan = {
   options?: LightningPlanOptions;
 
   globals?: string;
+
+  meta?: LightningPlanMeta;
+};
+
+export type LightningPlanMeta = {
+  work_order_id?: string;
+  workflow_id?: string;
+  project_id?: string;
 };
 
 /**

--- a/packages/lexicon/package.json
+++ b/packages/lexicon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/lexicon",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Central repo of names and type definitions",
   "author": "Open Function Group <admin@openfn.org>",
   "license": "ISC",

--- a/packages/ws-worker/CHANGELOG.md
+++ b/packages/ws-worker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ws-worker
 
+## 1.29.1
+
+### Patch Changes
+
+- e3ddfef: Support metadata on the run object
+- Updated dependencies [e3ddfef]
+  - @openfn/lexicon@2.4.1
+
 ## 1.29.0
 
 ### Minor Changes

--- a/packages/ws-worker/package.json
+++ b/packages/ws-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/ws-worker",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "A Websocket Worker to connect Lightning to a Runtime Engine",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -133,14 +133,23 @@ export default (
 
   // But some need to get passed down into the engine's options
   const engineOpts: WorkerRunOptions = {};
-  console.log(JSON.stringify(run, null, 2));
+
+  // Lightning only sends run.meta from 2.18.0. Older versions get a meta global
+  // with just the run id, rather than a set of undefined keys. project_id is on
+  // the plan itself, so it's available whatever version we're talking to.
+  const ids = {
+    workOrderId: run.meta?.work_order_id,
+    workflowId: run.meta?.workflow_id,
+    projectId: run.meta?.project_id ?? run.project_id,
+  };
+
   engineOpts.globals = {
     meta: {
       runId: run.id,
       startTime: Date.now(),
-      workOrderId: run.meta?.work_order_id,
-      workflowId: run.meta?.workflow_id,
-      projectId: run.meta?.project_id,
+      ...Object.fromEntries(
+        Object.entries(ids).filter(([_key, value]) => value !== undefined)
+      ),
     },
   };
 

--- a/packages/ws-worker/src/util/convert-lightning-plan.ts
+++ b/packages/ws-worker/src/util/convert-lightning-plan.ts
@@ -133,11 +133,14 @@ export default (
 
   // But some need to get passed down into the engine's options
   const engineOpts: WorkerRunOptions = {};
-
+  console.log(JSON.stringify(run, null, 2));
   engineOpts.globals = {
     meta: {
       runId: run.id,
       startTime: Date.now(),
+      workOrderId: run.meta?.work_order_id,
+      workflowId: run.meta?.workflow_id,
+      projectId: run.meta?.project_id,
     },
   };
 

--- a/packages/ws-worker/test/util/convert-lightning-plan.test.ts
+++ b/packages/ws-worker/test/util/convert-lightning-plan.test.ts
@@ -773,3 +773,38 @@ test('sets runId and startTime on the engine options globals meta', (t) => {
   t.true(options.globals!.meta.startTime >= before);
   t.true(options.globals!.meta.startTime <= after);
 });
+
+test('maps run.meta workorder/workflow/project ids onto globals meta', (t) => {
+  const run: Partial<LightningPlan> = {
+    id: 'some-run-id',
+    jobs: [createNode()],
+    triggers: [],
+    edges: [],
+    meta: {
+      workorder_id: 'some-workorder-id',
+      workflow_id: 'some-workflow-id',
+      project_id: 'some-project-id',
+    },
+  };
+
+  const { options } = convertPlan(run as LightningPlan);
+
+  t.is(options.globals!.meta.workorderId, 'some-workorder-id');
+  t.is(options.globals!.meta.workflowId, 'some-workflow-id');
+  t.is(options.globals!.meta.projectId, 'some-project-id');
+});
+
+test('leaves globals meta ids undefined when run.meta is missing', (t) => {
+  const run: Partial<LightningPlan> = {
+    id: 'some-run-id',
+    jobs: [createNode()],
+    triggers: [],
+    edges: [],
+  };
+
+  const { options } = convertPlan(run as LightningPlan);
+
+  t.is(options.globals!.meta.workorderId, undefined);
+  t.is(options.globals!.meta.workflowId, undefined);
+  t.is(options.globals!.meta.projectId, undefined);
+});

--- a/packages/ws-worker/test/util/convert-lightning-plan.test.ts
+++ b/packages/ws-worker/test/util/convert-lightning-plan.test.ts
@@ -774,14 +774,14 @@ test('sets runId and startTime on the engine options globals meta', (t) => {
   t.true(options.globals!.meta.startTime <= after);
 });
 
-test('maps run.meta workorder/workflow/project ids onto globals meta', (t) => {
+test('maps run.meta work order/workflow/project ids onto globals meta', (t) => {
   const run: Partial<LightningPlan> = {
     id: 'some-run-id',
     jobs: [createNode()],
     triggers: [],
     edges: [],
     meta: {
-      workorder_id: 'some-workorder-id',
+      work_order_id: 'some-work-order-id',
       workflow_id: 'some-workflow-id',
       project_id: 'some-project-id',
     },
@@ -789,12 +789,26 @@ test('maps run.meta workorder/workflow/project ids onto globals meta', (t) => {
 
   const { options } = convertPlan(run as LightningPlan);
 
-  t.is(options.globals!.meta.workorderId, 'some-workorder-id');
+  t.is(options.globals!.meta.workOrderId, 'some-work-order-id');
   t.is(options.globals!.meta.workflowId, 'some-workflow-id');
   t.is(options.globals!.meta.projectId, 'some-project-id');
 });
 
-test('leaves globals meta ids undefined when run.meta is missing', (t) => {
+test('takes projectId from the plan when run.meta is missing', (t) => {
+  const run: Partial<LightningPlan> = {
+    id: 'some-run-id',
+    project_id: 'some-project-id',
+    jobs: [createNode()],
+    triggers: [],
+    edges: [],
+  };
+
+  const { options } = convertPlan(run as LightningPlan);
+
+  t.is(options.globals!.meta.projectId, 'some-project-id');
+});
+
+test('omits globals meta ids when run.meta is missing', (t) => {
   const run: Partial<LightningPlan> = {
     id: 'some-run-id',
     jobs: [createNode()],
@@ -804,7 +818,8 @@ test('leaves globals meta ids undefined when run.meta is missing', (t) => {
 
   const { options } = convertPlan(run as LightningPlan);
 
-  t.is(options.globals!.meta.workorderId, undefined);
-  t.is(options.globals!.meta.workflowId, undefined);
-  t.is(options.globals!.meta.projectId, undefined);
+  t.deepEqual(Object.keys(options.globals!.meta).sort(), [
+    'runId',
+    'startTime',
+  ]);
 });


### PR DESCRIPTION
This PR extends the `meta` global in a run by adding `workOrderId`, `workflowId` and `projectId`. These are appended to the run by lightning.

It is safe to run against main - users simply wont see the metadata.

The docker image will be built and uploaded to dockerhub after merging to main

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
