### PR TITLE
Fix the flaky worker integration tests

### DIFF
--- a/integration-tests/worker/src/init.ts
+++ b/integration-tests/worker/src/init.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 
 import createLightningServer, { toBase64 } from '@openfn/lightning-mock';
 import createEngine from '@openfn/engine-multi';
-import createWorkerServer from '@openfn/ws-worker';
+import createWorkerServer, { INTERNAL_SOCKET_READY } from '@openfn/ws-worker';
 import { createMockLogger } from '@openfn/logger';
 import createLogger from '@openfn/logger';
 
@@ -65,6 +65,24 @@ export const initWorker = async (
     batchLogs: true,
     ...workerArgs,
   });
+
+  // The server is returned before it has connected to Lightning: it fetches the
+  // collections version over http first and only then opens the socket. Tests
+  // which swap the worker out and queue a run straight afterwards could leave
+  // that run sitting in the queue with nothing listening for it, and the whole
+  // file would hang until ava's timeout. Waiting for the socket closes that.
+  if (!worker.socket) {
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('worker did not connect to lightning within 10s'));
+      }, 10_000);
+
+      worker.events.once(INTERNAL_SOCKET_READY, () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+  }
 
   return { engine, engineLogger, worker };
 };

--- a/integration-tests/worker/src/init.ts
+++ b/integration-tests/worker/src/init.ts
@@ -10,7 +10,17 @@ import createLogger from '@openfn/logger';
 const debugWorker = process.env.OPENFN_DEBUG_WORKER;
 const debugLightning = process.env.OPENFN_DEBUG_LIGHTNING;
 
-export const randomPort = () => Math.round(2000 + Math.random() * 1000);
+// Hand out a fresh port for every server we start. This used to pick a random
+// number in a 1000 wide range without checking it was free, which collided
+// often enough to fail the integration job every few runs: the second server
+// couldn't bind, its setup hook never finished, and the file timed out.
+//
+// ava runs these files one at a time and each one is its own process, so a
+// counter is enough - ports are released when the previous file exits. The base
+// sits clear of the 3000s that the server tests walk through.
+let nextPortNumber = 4400;
+
+export const nextPort = () => nextPortNumber++;
 
 export const initLightning = (port = 4000, privateKey?: string) => {
   // TODO the lightning mock right now doesn't use the secret
@@ -30,7 +40,7 @@ export const initWorker = async (
   engineArgs = {},
   workerArgs = {}
 ) => {
-  const workerPort = randomPort();
+  const workerPort = nextPort();
 
   const engineLogger = createMockLogger('engine', {
     level: 'debug',

--- a/integration-tests/worker/src/init.ts
+++ b/integration-tests/worker/src/init.ts
@@ -10,14 +10,6 @@ import createLogger from '@openfn/logger';
 const debugWorker = process.env.OPENFN_DEBUG_WORKER;
 const debugLightning = process.env.OPENFN_DEBUG_LIGHTNING;
 
-// Hand out a fresh port for every server we start. This used to pick a random
-// number in a 1000 wide range without checking it was free, which collided
-// often enough to fail the integration job every few runs: the second server
-// couldn't bind, its setup hook never finished, and the file timed out.
-//
-// ava runs these files one at a time and each one is its own process, so a
-// counter is enough - ports are released when the previous file exits. The base
-// sits clear of the 3000s that the server tests walk through.
 let nextPortNumber = 4400;
 
 export const nextPort = () => nextPortNumber++;
@@ -66,11 +58,6 @@ export const initWorker = async (
     ...workerArgs,
   });
 
-  // The server is returned before it has connected to Lightning: it fetches the
-  // collections version over http first and only then opens the socket. Tests
-  // which swap the worker out and queue a run straight afterwards could leave
-  // that run sitting in the queue with nothing listening for it, and the whole
-  // file would hang until ava's timeout. Waiting for the socket closes that.
   if (!worker.socket) {
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/integration-tests/worker/test/autoinstall.test.ts
+++ b/integration-tests/worker/test/autoinstall.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { rm } from 'node:fs/promises';
 import { generateKeys } from '@openfn/lightning-mock';
 
-import { initLightning, initWorker } from '../src/init';
+import { initLightning, initWorker, nextPort } from '../src/init';
 import { createRun, createJob } from '../src/factories';
 
 const generate = (adaptor, version) => {
@@ -39,7 +39,7 @@ test.before(async () => {
   } catch (e) {}
 
   const keys = await generateKeys();
-  const lightningPort = 4321;
+  const lightningPort = nextPort();
 
   lightning = initLightning(lightningPort, keys.private);
 

--- a/integration-tests/worker/test/benchmark.test.ts
+++ b/integration-tests/worker/test/benchmark.test.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import path from 'node:path';
 
 import { createRun } from '../src/factories';
-import { initLightning, initWorker } from '../src/init';
+import { initLightning, initWorker, nextPort } from '../src/init';
 import { run, humanMb } from '../src/util';
 
 let lightning;
@@ -11,7 +11,7 @@ let worker;
 const maxConcurrency = 20;
 
 test.before(async () => {
-  const lightningPort = 4322;
+  const lightningPort = nextPort();
 
   lightning = initLightning(lightningPort);
 

--- a/integration-tests/worker/test/exit-reasons.test.ts
+++ b/integration-tests/worker/test/exit-reasons.test.ts
@@ -2,13 +2,13 @@ import test from 'ava';
 import crypto from 'node:crypto';
 import path from 'node:path';
 
-import { initLightning, initWorker } from '../src/init';
+import { initLightning, initWorker, nextPort } from '../src/init';
 
 let lightning;
 let worker;
 
 test.before(async () => {
-  const lightningPort = 4321;
+  const lightningPort = nextPort();
 
   lightning = initLightning(lightningPort);
 

--- a/integration-tests/worker/test/exit-reasons.test.ts
+++ b/integration-tests/worker/test/exit-reasons.test.ts
@@ -24,11 +24,6 @@ test.after(async () => {
 
 const run = async (attempt) => {
   return new Promise<any>((done) => {
-    // This used to be a plain `once` with the id checked inside it, which meant
-    // any completion for another run - a late one from the test before, or a
-    // duplicate - used up the listener and left this promise hanging for good,
-    // stalling the rest of the file until ava gave up. onSocketEvent only
-    // releases the listener once the id actually matches.
     lightning.onSocketEvent('run:complete', attempt.id, (evt) => {
       if (attempt.id === evt.runId) {
         done(evt.payload);

--- a/integration-tests/worker/test/exit-reasons.test.ts
+++ b/integration-tests/worker/test/exit-reasons.test.ts
@@ -23,8 +23,13 @@ test.after(async () => {
 });
 
 const run = async (attempt) => {
-  return new Promise<any>(async (done) => {
-    lightning.once('run:complete', (evt) => {
+  return new Promise<any>((done) => {
+    // This used to be a plain `once` with the id checked inside it, which meant
+    // any completion for another run - a late one from the test before, or a
+    // duplicate - used up the listener and left this promise hanging for good,
+    // stalling the rest of the file until ava gave up. onSocketEvent only
+    // releases the listener once the id actually matches.
+    lightning.onSocketEvent('run:complete', attempt.id, (evt) => {
       if (attempt.id === evt.runId) {
         done(evt.payload);
       }

--- a/integration-tests/worker/test/integration.test.ts
+++ b/integration-tests/worker/test/integration.test.ts
@@ -4,7 +4,7 @@ import crypto from 'node:crypto';
 import Koa from 'koa';
 import { generateKeys } from '@openfn/lightning-mock';
 
-import { initLightning, initWorker, randomPort } from '../src/init';
+import { initLightning, initWorker, nextPort } from '../src/init';
 
 let lightning;
 let worker;
@@ -14,7 +14,7 @@ let lightningPort;
 
 test.before(async () => {
   const keys = await generateKeys();
-  lightningPort = randomPort();
+  lightningPort = nextPort();
   lightning = initLightning(lightningPort, keys.private);
 
   const engineArgs = {

--- a/integration-tests/worker/test/runs.test.ts
+++ b/integration-tests/worker/test/runs.test.ts
@@ -8,14 +8,14 @@ import {
   createJob,
   createTrigger,
 } from '../src/factories';
-import { initLightning, initWorker } from '../src/init';
+import { initLightning, initWorker, nextPort } from '../src/init';
 
 let lightning;
 let worker;
 
 test.before(async () => {
   const keys = await generateKeys();
-  const lightningPort = 4321;
+  const lightningPort = nextPort();
 
   lightning = initLightning(lightningPort, keys.private);
 

--- a/integration-tests/worker/test/server.test.ts
+++ b/integration-tests/worker/test/server.test.ts
@@ -180,7 +180,6 @@ test.serial('allow a job to complete after receiving a sigterm', (t) => {
 test.serial("don't restore the claim loop after a sigterm", (t) => {
   return new Promise(async (done) => {
     let abort = false;
-    let didSendSigterm = false;
     const port = getPort();
 
     const job = createJob({
@@ -208,7 +207,6 @@ test.serial("don't restore the claim loop after a sigterm", (t) => {
     // After the second run starts, there should be no more claims
     lightning.on('run:start', (evt) => {
       if (evt.runId === b.id) {
-        didSendSigterm = true;
         // Kill the worker once the second job has started
         // This will force an overlap of two pending runs at full capacity
         workerProcess.kill('SIGTERM');
@@ -220,8 +218,15 @@ test.serial("don't restore the claim loop after a sigterm", (t) => {
     lightning.enqueueRun(a);
     lightning.enqueueRun(b);
 
-    lightning.on('claim', (e) => {
-      if (didSendSigterm && !abort) {
+    lightning.on('claim', () => {
+      // Sending the signal and the worker acting on it are not the same moment,
+      // so a claim already in flight can land here through no fault of the
+      // worker. Only count claims made after it told us it had the signal.
+      const didReceiveSigterm = workerLogs.some((l) =>
+        l.match(/SIGTERM RECEIVED/)
+      );
+
+      if (didReceiveSigterm && !abort) {
         abort = true;
         t.fail('Claim triggered after sigterm');
         done();

--- a/integration-tests/worker/test/server.test.ts
+++ b/integration-tests/worker/test/server.test.ts
@@ -219,9 +219,6 @@ test.serial("don't restore the claim loop after a sigterm", (t) => {
     lightning.enqueueRun(b);
 
     lightning.on('claim', () => {
-      // Sending the signal and the worker acting on it are not the same moment,
-      // so a claim already in flight can land here through no fault of the
-      // worker. Only count claims made after it told us it had the signal.
       const didReceiveSigterm = workerLogs.some((l) =>
         l.match(/SIGTERM RECEIVED/)
       );


### PR DESCRIPTION
Makes the worker integration tests pass reliably. Closes #1501.

That job was failing at random - a different Node version each run, and the same tree giving different results across reruns. It turned out to be four separate bugs, all in the tests rather than the worker:

**Ports were guessed.** Servers were started on a random number between 2000 and 3000 with no check that it was free. A run makes around a dozen of those picks, so collisions happened every few runs. That was the `EADDRINUSE :::2492` we kept seeing. Ports now come from a counter.

**The worker wasn't connected yet.** `initWorker` handed the server back before it had connected to Lightning - it fetches the collections version over http first, then opens the socket. Seven tests swap the worker out and queue a run straight afterwards, so the run could sit in the queue with nothing listening, hanging the file until ava's timeout. It now waits for the socket.

**The sigterm test raced its own signal.** It failed if a claim already in flight arrived after we sent the signal, which the worker can't help. It now keys off the worker reporting that it received it.

**A lost listener in the exit reason tests.** The helper every test there goes through listened with a plain `once` and checked the run id inside the callback, so a completion for any other run consumed the listener without resolving - hanging that promise for good. It now uses the mock's `onSocketEvent`, which only releases on an id match.

The four fixes are separate commits, worth reading individually.

## Validation steps

1. The three integration jobs should pass, and keep passing on reruns.
2. `cd integration-tests/worker && pnpm test` locally.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

