### PR TITLE
Worker: better reporting on socket errors

### DIFF
--- a/.changeset/calm-adults-own.md
+++ b/.changeset/calm-adults-own.md
@@ -1,0 +1,5 @@
+---
+'@openfn/lexicon': patch
+---
+
+Support dataclipSize

--- a/.changeset/calm-otters-sing.md
+++ b/.changeset/calm-otters-sing.md
@@ -1,0 +1,5 @@
+---
+'@openfn/engine-multi': patch
+---
+
+Report the size of a job's output state alongside the existing payload redaction check

--- a/.changeset/eight-buses-jump.md
+++ b/.changeset/eight-buses-jump.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Include dataclip size in sentry reports

--- a/.changeset/lucky-owls-report.md
+++ b/.changeset/lucky-owls-report.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Attribute Sentry reports to the run that produced them

--- a/packages/engine-multi/src/api/lifecycle.ts
+++ b/packages/engine-multi/src/api/lifecycle.ts
@@ -83,7 +83,16 @@ export const jobComplete = (
   event: internalEvents.JobCompleteEvent
 ) => {
   const { logger, state: runState } = context;
-  const { threadId, state, duration, jobId, next, mem, redacted } = event;
+  const {
+    threadId,
+    state,
+    duration,
+    jobId,
+    next,
+    mem,
+    redacted,
+    payloadSize_b,
+  } = event;
   logger.debug(
     `${runState.id}: sending job complete (step complete): ${event.jobId}`
   );
@@ -95,6 +104,7 @@ export const jobComplete = (
     jobId,
     next,
     redacted,
+    payloadSize_b,
     mem,
     time: timestamp(),
   });

--- a/packages/engine-multi/src/events.ts
+++ b/packages/engine-multi/src/events.ts
@@ -51,9 +51,12 @@ export type EventMap = {
 
 export type ExternalEvents = keyof EventMap;
 
-interface ExternalEvent {
+export interface ExternalEvent {
   threadId?: string;
   workflowId: UUID;
+  // Byte size of any large fields on this payload
+  // eg, dataclips, state objects, log objects
+  payloadSize_b?: number;
 }
 
 export interface WorkflowStartPayload extends ExternalEvent {

--- a/packages/engine-multi/src/util/ensure-payload-size.ts
+++ b/packages/engine-multi/src/util/ensure-payload-size.ts
@@ -1,4 +1,5 @@
 import { JsonStreamStringify } from 'json-stream-stringify';
+import type { ExternalEvent } from '../events';
 
 // This specifies which keys of an event payload to potentially redact
 // if they are too big
@@ -17,7 +18,7 @@ export const verify = async (
   value: any,
   limit_mb: number = 10,
   algo: 'stringify' | 'stream' = 'stringify'
-) => {
+): Promise<number | undefined> => {
   if (value && !isNaN(limit_mb)) {
     const limitBytes = limit_mb * 1024 * 1024;
 
@@ -33,9 +34,15 @@ export const verify = async (
       // @ts-ignore
       e.name = 'PAYLOAD_TOO_LARGE';
       e.message = `The payload exceeded the size limit of ${limit_mb}mb`;
+      // @ts-ignore carry the size we already computed out to the caller
+      e.sizeBytes = sizeBytes;
       throw e;
     }
+
+    return sizeBytes;
   }
+
+  return undefined;
 };
 
 export const calculateSizeStringify = (value: any): number => {
@@ -65,15 +72,25 @@ export const calculateSizeStream = async (
   return size_bytes;
 };
 
-export default async (payload: any, limit_mb: number = 10) => {
-  const newPayload = { ...payload };
+export default async (
+  payload: ExternalEvent,
+  limit_mb: number = 10
+): Promise<ExternalEvent> => {
+  const newPayload: any = { ...payload };
+  const rawPayload = payload as any;
 
   for (const key of KEYS_TO_VERIFY) {
     try {
-      await verify(payload[key], limit_mb);
-    } catch (e) {
+      const sizeBytes = await verify(rawPayload[key], limit_mb);
+      if (key === 'state' && sizeBytes !== undefined) {
+        newPayload.payloadSize_b = sizeBytes;
+      }
+    } catch (e: any) {
       Object.assign(newPayload[key], replacements[key] ?? replacements.default);
       newPayload.redacted = true;
+      if (key === 'state') {
+        newPayload.payloadSize_b = e.sizeBytes;
+      }
     }
   }
 

--- a/packages/engine-multi/src/worker/events.ts
+++ b/packages/engine-multi/src/worker/events.ts
@@ -39,6 +39,10 @@ interface InternalEvent {
   type: WorkerEvents;
   workflowId: UUID;
   threadId: string;
+  // Byte size of whichever field this payload had checked against the
+  // redaction limit (state, final_state or log - see KEYS_TO_VERIFY in
+  // ensure-payload-size.ts)
+  payloadSize_b?: number;
 }
 
 export interface WorkflowStartEvent extends InternalEvent {}

--- a/packages/engine-multi/src/worker/thread/runtime.ts
+++ b/packages/engine-multi/src/worker/thread/runtime.ts
@@ -7,7 +7,6 @@ import {
   type WorkerEvents,
 } from '../events';
 import ensurePayloadSize from '../../util/ensure-payload-size';
-import type { ExternalEvent } from '../../events';
 
 // This constrains the size of any payloads coming out of the worker thread
 // Payloads exceeding this will be redacted

--- a/packages/engine-multi/src/worker/thread/runtime.ts
+++ b/packages/engine-multi/src/worker/thread/runtime.ts
@@ -7,6 +7,7 @@ import {
   type WorkerEvents,
 } from '../events';
 import ensurePayloadSize from '../../util/ensure-payload-size';
+import type { ExternalEvent } from '../../events';
 
 // This constrains the size of any payloads coming out of the worker thread
 // Payloads exceeding this will be redacted
@@ -55,7 +56,8 @@ export const publish = async (
   // Redact any payloads that are too large
   const limit =
     payloadLimits?.[type as keyof PayloadLimits] ?? payloadLimits?.default;
-  const safePayload = await ensurePayloadSize(payload, limit);
+
+  const safePayload = await ensurePayloadSize(payload as any, limit);
 
   parentPort!.postMessage({
     type,

--- a/packages/engine-multi/test/api/lifecycle.test.ts
+++ b/packages/engine-multi/test/api/lifecycle.test.ts
@@ -194,6 +194,43 @@ test(`job-complete: emits ${e.JOB_COMPLETE} with key fields`, (t) => {
   });
 });
 
+test(`job-complete: forwards payloadSize_b`, (t) => {
+  return new Promise((done) => {
+    const workflowId = 'a';
+
+    const state = {
+      id: workflowId,
+      startTime: Date.now() - 1000,
+    } as WorkflowState;
+
+    const context = createContext(workflowId, state);
+
+    const event: w.JobCompleteEvent = {
+      type: w.JOB_COMPLETE,
+      workflowId,
+      threadId: '1',
+      jobId: 'j',
+      duration: 200,
+      state: 22,
+      redacted: true,
+      payloadSize_b: 12345,
+      next: [],
+      mem: { job: 100, system: 1000 },
+    };
+
+    context.on(e.JOB_COMPLETE, (evt) => {
+      // This is the number that lets a diagnostic downstream (eg the
+      // lightning worker's sentry reporting) see how big the state was even
+      // when it never tripped the redaction limit
+      t.is(evt.payloadSize_b, 12345);
+      t.true(evt.redacted);
+      done();
+    });
+
+    jobComplete(context, event);
+  });
+});
+
 test(`job-error: emits ${e.JOB_ERROR} with key fields`, (t) => {
   return new Promise((done) => {
     const workflowId = 'a';

--- a/packages/engine-multi/test/util/ensure-payload-size.test.ts
+++ b/packages/engine-multi/test/util/ensure-payload-size.test.ts
@@ -5,6 +5,13 @@ import ensurePayloadSize, {
   calculateSizeStream,
 } from '../../src/util/ensure-payload-size';
 
+// ensurePayloadSize now takes/returns the full ExternalEvent envelope, but
+// these tests exercise its redaction/sizing behaviour in isolation against
+// bare state/log/final_state fixtures, not real events - so untyped is right
+// here rather than padding every fixture with a fake workflowId
+const check = (payload: any, limit?: number): Promise<any> =>
+  ensurePayloadSize(payload, limit);
+
 (['stringify', 'stream'] as const).forEach((algo) => {
   test(algo + ': throw limit 0, payload 1 byte', async (t) => {
     await t.throwsAsync(() => verify('x', 0, algo), {
@@ -60,7 +67,7 @@ import ensurePayloadSize, {
       },
     };
 
-    const newPayload = await ensurePayloadSize(payload, 1);
+    const newPayload = await check(payload, 1);
     t.deepEqual(newPayload.state, {
       data: '[REDACTED]',
     });
@@ -74,7 +81,7 @@ import ensurePayloadSize, {
       },
     };
 
-    const newPayload = await ensurePayloadSize(payload, 1);
+    const newPayload = await check(payload, 1);
     t.deepEqual(newPayload.log, {
       message: ['[REDACTED: Message length exceeds payload limit]'],
     });
@@ -88,11 +95,47 @@ import ensurePayloadSize, {
       },
     };
 
-    const newPayload = await ensurePayloadSize(payload, 1);
+    const newPayload = await check(payload, 1);
     t.deepEqual(newPayload.final_state, {
       data: '[REDACTED]',
     });
     t.true(newPayload.redacted);
+  });
+
+  test(algo + ': attaches payloadSize_b when state is within limit', async (t) => {
+    const payload = { state: { data: 'hello world' } };
+
+    const newPayload = await check(payload, 1);
+    t.false(!!newPayload.redacted);
+    t.is(
+      newPayload.payloadSize_b,
+      calculateSizeStringify(payload.state)
+    );
+  });
+
+  test(algo + ': attaches payloadSize_b when state is redacted', async (t) => {
+    const payload = {
+      state: {
+        data: new Array(1024 * 1024).fill('z').join(''),
+      },
+    };
+    const rawSize = calculateSizeStringify(payload.state);
+
+    const newPayload = await check(payload, 1);
+    t.true(newPayload.redacted);
+    // The size must survive redaction - this is the number that explains a
+    // run which timed out sending its dataclip without tripping this limit
+    t.is(newPayload.payloadSize_b, rawSize);
+  });
+
+  test(algo + ': does not attach payloadSize_b for final_state or log', async (t) => {
+    const payload = {
+      final_state: { data: 'hello world' },
+      log: { message: ['hello world'] },
+    };
+
+    const newPayload = await check(payload, 1);
+    t.is(newPayload.payloadSize_b, undefined);
   });
 });
 

--- a/packages/lexicon/lightning.d.ts
+++ b/packages/lexicon/lightning.d.ts
@@ -228,6 +228,7 @@ export type StepCompletePayload = ExitReason & {
   run_id?: string;
   job_id: string;
   step_id: string;
+  dataclip_size_mb?: string;
   output_dataclip?: string;
   output_dataclip_id?: string;
   output_dataclip_error?: 'DATACLIP_TOO_LARGE';

--- a/packages/ws-worker/src/api/execute.ts
+++ b/packages/ws-worker/src/api/execute.ts
@@ -42,6 +42,9 @@ export type Context = {
   options: WorkerRunOptions;
   onFinish: (result: any) => void;
 
+  // This run's sentry isolation scope
+  sentryScope?: Sentry.Scope;
+
   // maybe its better for version numbers to be scribbled here as we go?
 };
 
@@ -62,6 +65,10 @@ export function execute(
 
   const state = createRunState(plan, input);
 
+  // Ensure that each execute call is in its own sentry isolated scope
+  const sentryScope = Sentry.getIsolationScope().clone();
+  sentryScope.setTag('run_id', plan.id!);
+
   const context: Context = {
     id: plan.id!,
     channel,
@@ -70,11 +77,10 @@ export function execute(
     engine,
     options,
     onFinish,
+    sentryScope,
   };
 
-  // Ensure that each execute call is in its own sentry isolated scope
-  // Because I don't trust it to automatically scope each request properly
-  Sentry.withIsolationScope(async () => {
+  Sentry.withIsolationScope(sentryScope, async () => {
     Sentry.addBreadcrumb({
       category: 'run',
       message: 'Executing run: loading metadata',

--- a/packages/ws-worker/src/api/process-events.ts
+++ b/packages/ws-worker/src/api/process-events.ts
@@ -78,7 +78,7 @@ export function eventProcessor(
   callbacks: Record<string, EventHandler>,
   options: EventProcessorOptions = {}
 ) {
-  const { id: planId, logger } = context;
+  const { id: planId, logger, sentryScope } = context;
   const {
     batchLimit = DEFAULT_BATCH_LIMIT,
     batchInterval = DEFAULT_BATCH_INTERVAL,
@@ -175,7 +175,12 @@ export function eventProcessor(
       }
     } catch (e: any) {
       if (!e.reportedToSentry) {
-        Sentry.captureException(e);
+        // Engine events fire outside the async context which created this
+        // processor, so the run's scope has to be re-entered to pick up its
+        // breadcrumb trail
+        Sentry.withIsolationScope(sentryScope, () =>
+          Sentry.captureException(e)
+        );
         logger.error(e);
       }
       // Do nothing else here: the error should have been handled
@@ -196,7 +201,7 @@ export function eventProcessor(
     trace('process', name);
     // TODO this actually shouldn't be here - should be done separately
     if (name !== 'workflow-log') {
-      Sentry.addBreadcrumb({
+      sentryScope?.addBreadcrumb({
         category: 'event',
         message: name,
         level: 'info',

--- a/packages/ws-worker/src/events/step-complete.ts
+++ b/packages/ws-worker/src/events/step-complete.ts
@@ -121,5 +121,9 @@ export default async function onStepComplete(
     `${context.id} step-complete payload is ${evt.dataclip_size_mb}mb`
   );
 
-  return sendEvent<StepCompletePayload>(context, STEP_COMPLETE, evt);
+  return sendEvent<StepCompletePayload>(context, STEP_COMPLETE, evt, {
+    // Raw bytes, not the formatted evt.dataclip_size_mb string - kept out of
+    // the Lightning-bound payload, only surfaced if this push errors or times out
+    sentryExtras: { payloadSize_b: event.payloadSize_b },
+  });
 }

--- a/packages/ws-worker/src/events/step-complete.ts
+++ b/packages/ws-worker/src/events/step-complete.ts
@@ -64,6 +64,12 @@ export default async function onStepComplete(
     duration: event.duration,
     thread_id: event.threadId,
     timestamp: timeInMicroseconds(event.time),
+    // toPrecision (not toFixed) so small dataclips don't round to "0.00" -
+    // this needs to read sensibly from a few KB up to the ~10mb redaction
+    // limit, not just near the limit
+    dataclip_size_mb: event.payloadSize_b
+      ? (event.payloadSize_b / (1024 * 1024)).toPrecision(3)
+      : undefined,
   } as StepCompletePayload;
 
   // Feed through the webhook response if it's on state
@@ -106,9 +112,13 @@ export default async function onStepComplete(
 
   const { output_dataclip, ...eventWithoutDataclip } = evt;
   context.logger?.debug(
-    `${context.id} step-complete payload: ${JSON.stringify(
+    `${context.id} step-complete (without dataclip): ${JSON.stringify(
       eventWithoutDataclip
     )}`
+  );
+
+  context.logger?.debug(
+    `${context.id} step-complete payload is ${evt.dataclip_size_mb}mb`
   );
 
   return sendEvent<StepCompletePayload>(context, STEP_COMPLETE, evt);

--- a/packages/ws-worker/src/util/send-event.ts
+++ b/packages/ws-worker/src/util/send-event.ts
@@ -7,7 +7,10 @@ import { LightningSocketError, LightningTimeoutError } from '../errors';
 const allowRetryOntimeout = false;
 
 export const sendEvent = <T>(
-  context: Pick<Context, 'logger' | 'channel' | 'id' | 'options'>,
+  context: Pick<
+    Context,
+    'logger' | 'channel' | 'id' | 'options' | 'sentryScope'
+  >,
   event: string,
   payload?: any,
   attempts?: number
@@ -18,7 +21,7 @@ export const sendEvent = <T>(
 
   const thisAttempt = attempts ?? 1;
 
-  const { channel, logger, id: runId = '<unknown run>' } = context;
+  const { channel, logger, id: runId = '<unknown run>', sentryScope } = context;
 
   return new Promise<T>((resolve, reject) => {
     const report = (error: any) => {
@@ -34,10 +37,14 @@ export const sendEvent = <T>(
         extras.rejection_reason = error.rejectMessage;
       }
 
-      Sentry.captureException(error, (scope) => {
-        scope.setContext('run', context);
-        scope.setExtras(extras);
-        return scope;
+      // report() is invoked from a phoenix receive callback, ie off the
+      // socket's async chain, so the run's scope must be re-entered by hand
+      Sentry.withIsolationScope(sentryScope, () => {
+        Sentry.captureException(error, (scope) => {
+          scope.setContext('run', context);
+          scope.setExtras(extras);
+          return scope;
+        });
       });
 
       // Mark that we've reported this to downstream handlers

--- a/packages/ws-worker/src/util/send-event.ts
+++ b/packages/ws-worker/src/util/send-event.ts
@@ -6,6 +6,18 @@ import { LightningSocketError, LightningTimeoutError } from '../errors';
 // See https://github.com/OpenFn/kit/issues/1137
 const allowRetryOntimeout = false;
 
+// channel.socket is not part of our Channel type (or of @types/phoenix's),
+// but it exists on the real phoenix Channel instance - reach for it
+// defensively so a mock channel in tests, or a future phoenix version,
+// cannot turn this into a reporting-path crash
+const getSocketState = (channel: any): string | undefined => {
+  try {
+    return channel?.socket?.connectionState?.();
+  } catch {
+    return undefined;
+  }
+};
+
 export const sendEvent = <T>(
   context: Pick<
     Context,
@@ -31,7 +43,12 @@ export const sendEvent = <T>(
         run_id: runId,
         event: event,
       };
-      const extras: any = {};
+      const extras: any = {
+        // Distinguishes a genuine timeout/error on a healthy channel from
+        // collateral damage while the channel is mid-rejoin after a drop
+        channel_state: channel.state,
+        socket_state: getSocketState(channel),
+      };
 
       if (error.rejectMessage) {
         extras.rejection_reason = error.rejectMessage;
@@ -41,6 +58,13 @@ export const sendEvent = <T>(
       // socket's async chain, so the run's scope must be re-entered by hand
       Sentry.withIsolationScope(sentryScope, () => {
         Sentry.captureException(error, (scope) => {
+          scope.setTag('run_id', runId);
+          scope.setTag('lightning_event', event);
+          // Every timeout (or every socket error) currently collapses into a
+          // single sentry issue regardless of which event caused it. Splitting
+          // the fingerprint by event name is what would have made this
+          // pattern visible without needing to dig through raw events
+          scope.setFingerprint([error.name, event]);
           scope.setContext('run', context);
           scope.setExtras(extras);
           return scope;

--- a/packages/ws-worker/src/util/send-event.ts
+++ b/packages/ws-worker/src/util/send-event.ts
@@ -18,6 +18,14 @@ const getSocketState = (channel: any): string | undefined => {
   }
 };
 
+export type SentryExtras = Record<string, any>;
+
+export type SendEventOptions = {
+  attempts?: number;
+  // Extra data to report to sentry
+  sentryExtras?: SentryExtras;
+};
+
 export const sendEvent = <T>(
   context: Pick<
     Context,
@@ -25,12 +33,13 @@ export const sendEvent = <T>(
   >,
   event: string,
   payload?: any,
-  attempts?: number
+  opts: SendEventOptions = {}
 ) => {
   // Low defaults here are better for unit tests
   const { timeoutRetryCount = 1, timeoutRetryDelay = 1 } =
     context.options ?? {};
 
+  const { attempts, sentryExtras } = opts;
   const thisAttempt = attempts ?? 1;
 
   const { channel, logger, id: runId = '<unknown run>', sentryScope } = context;
@@ -43,11 +52,12 @@ export const sendEvent = <T>(
         run_id: runId,
         event: event,
       };
-      const extras: any = {
+      const extras: SentryExtras = {
         // Distinguishes a genuine timeout/error on a healthy channel from
         // collateral damage while the channel is mid-rejoin after a drop
         channel_state: channel.state,
         socket_state: getSocketState(channel),
+        ...sentryExtras,
       };
 
       if (error.rejectMessage) {
@@ -98,7 +108,10 @@ export const sendEvent = <T>(
           );
 
           setTimeout(() => {
-            sendEvent<T>(context, event, payload, thisAttempt + 1)
+            sendEvent<T>(context, event, payload, {
+              attempts: thisAttempt + 1,
+              sentryExtras,
+            })
               .then(resolve)
               .catch(reject);
           }, timeoutRetryDelay);

--- a/packages/ws-worker/test/events/step-complete.test.ts
+++ b/packages/ws-worker/test/events/step-complete.test.ts
@@ -157,6 +157,39 @@ test('send a step:complete event', async (t) => {
   await handleStepComplete({ channel, state } as any, event);
 });
 
+test('does not put payloadSize_b on the wire, only dataclip_size_mb', async (t) => {
+  const plan = createPlan();
+  const jobId = 'job-1';
+  const result = { x: 10 };
+
+  const state = createRunState(plan);
+  state.activeJob = jobId;
+  state.activeStep = 'b';
+
+  const channel = mockChannel({
+    [STEP_COMPLETE]: (evt: StepCompletePayload) => {
+      // payloadSize_b is raw bytes for sentry diagnostics on failure - it
+      // should never reach the actual Lightning payload, only the derived,
+      // formatted dataclip_size_mb should
+      t.false('payloadSize_b' in evt);
+      t.is(evt.dataclip_size_mb, (1536 / 1024 / 1024).toPrecision(3));
+    },
+  });
+
+  const event = {
+    jobId,
+    workflowId: plan.id,
+    state: result,
+    next: ['a'],
+    mem: { job: 1, system: 10 },
+    duration: 61,
+    thread_id: 'abc',
+    time: BigInt(123),
+    payloadSize_b: 1536,
+  } as JobCompletePayload;
+  await handleStepComplete({ channel, state } as any, event);
+});
+
 test('do not include dataclips in step:complete if output_dataclip is false', async (t) => {
   const plan = createPlan();
   const jobId = 'job-1';

--- a/packages/ws-worker/test/util/send-event.test.ts
+++ b/packages/ws-worker/test/util/send-event.test.ts
@@ -1,4 +1,6 @@
 import test from 'ava';
+import { EventEmitter } from 'node:events';
+import * as Sentry from '@sentry/node';
 import { createMockLogger } from '@openfn/logger';
 
 import { mockChannel } from '../../src/mock/sockets';
@@ -268,4 +270,54 @@ test.serial('should report to sentry if the event timesout', async (t) => {
   }
   const reports = await waitForSentryReport(testkit);
   t.is(reports[0].error?.name, 'LightningTimeoutError');
+});
+
+// The real phoenix channel invokes its receive callbacks from the socket's
+// message chain, which is not the chain that called push(). mockChannel defers
+// with a setTimeout created inside push, so async context leaks through it and
+// it cannot exercise this. This mock replies from a pump created up-front, so
+// the callback runs with no inherited context, exactly like the real socket
+const mockDetachedChannel = () => {
+  const bus = new EventEmitter();
+  const pump = setInterval(() => bus.emit('reply'), 1);
+
+  return {
+    stop: () => clearInterval(pump),
+    channel: {
+      push: () => {
+        const responses = {} as Record<string, (e?: any) => void>;
+        bus.once('reply', () => responses.error?.('detached'));
+
+        const receive = {
+          receive: (status: string, callback: (e?: any) => void) => {
+            responses[status] = callback;
+            return receive;
+          },
+        };
+        return receive;
+      },
+    } as any,
+  };
+};
+
+test.serial('should report to sentry against the run scope', async (t) => {
+  const sentryScope = Sentry.getIsolationScope().clone();
+  sentryScope.setTag('run_id', 'run-1');
+  sentryScope.addBreadcrumb({ category: 'event', message: 'job-complete' });
+
+  const { channel, stop } = mockDetachedChannel();
+  const context = { id: 'run-1', channel, logger, options: {}, sentryScope };
+
+  await t.throwsAsync(() => sendEvent(context, 'step:complete', {}));
+  stop();
+
+  const reports = await waitForSentryReport(testkit);
+  t.is(reports[0].error?.name, 'LightningSocketError');
+  t.is(reports[0].tags.run_id, 'run-1');
+
+  // The run's breadcrumb trail must survive too - this is why the capture
+  // re-enters the scope rather than passing it to captureException, which
+  // merges tags but drops breadcrumbs
+  const trail = reports[0].originalReport?.breadcrumbs ?? [];
+  t.true(trail.some((b: any) => b.message === 'job-complete'));
 });

--- a/packages/ws-worker/test/util/send-event.test.ts
+++ b/packages/ws-worker/test/util/send-event.test.ts
@@ -374,3 +374,19 @@ test.serial('should report to sentry against the run scope', async (t) => {
   const trail = reports[0].originalReport?.breadcrumbs ?? [];
   t.true(trail.some((b: any) => b.message === 'job-complete'));
 });
+
+test.serial('should report caller-supplied sentryExtras alongside a failed event', async (t) => {
+  const EVENT_NAME = 'test';
+  const channel = { ...mockChannel({}), state: 'joined' };
+
+  const context = { id: 'x', channel, logger, options: {} };
+
+  await t.throwsAsync(() =>
+    sendEvent(context, EVENT_NAME, {}, { sentryExtras: { payloadSize_b: 1536 } })
+  );
+
+  const reports = await waitForSentryReport(testkit);
+  t.is(reports[0].extra?.payloadSize_b, 1536);
+  // sentryExtras must not crowd out the fields send-event already reports
+  t.is(reports[0].extra?.channel_state, 'joined');
+});

--- a/packages/ws-worker/test/util/send-event.test.ts
+++ b/packages/ws-worker/test/util/send-event.test.ts
@@ -270,6 +270,59 @@ test.serial('should report to sentry if the event timesout', async (t) => {
   }
   const reports = await waitForSentryReport(testkit);
   t.is(reports[0].error?.name, 'LightningTimeoutError');
+
+  // Tags are indexed (unlike the run context below), so these are what make
+  // it possible to ask sentry "is it only step:complete that times out?"
+  t.is(reports[0].tags.run_id, 'x');
+  t.is(reports[0].tags.lightning_event, EVENT_NAME);
+});
+
+test.serial('should fingerprint sentry reports by error type and event name', async (t) => {
+  // Without this, every timeout for every event collapses into one sentry
+  // issue - this is the change that would have made the step:complete
+  // pattern visible without digging through raw events. Each event is
+  // checked against a fresh testkit so the two reports cannot be confused
+  // with each other or raced against waitForSentryReport's "at least one"
+  // polling.
+  const channelA = mockChannel({});
+  await t.throwsAsync(() =>
+    sendEvent({ id: 'x', channel: channelA, logger, options: {} }, 'step:complete', {})
+  );
+  const [stepReport] = await waitForSentryReport(testkit);
+  t.deepEqual(stepReport.originalReport.fingerprint, [
+    'LightningTimeoutError',
+    'step:complete',
+  ]);
+
+  testkit.reset();
+
+  const channelB = mockChannel({});
+  await t.throwsAsync(() =>
+    sendEvent({ id: 'x', channel: channelB, logger, options: {} }, 'run:complete', {})
+  );
+  const [runReport] = await waitForSentryReport(testkit);
+  t.deepEqual(runReport.originalReport.fingerprint, [
+    'LightningTimeoutError',
+    'run:complete',
+  ]);
+});
+
+test.serial('should report channel and socket state alongside a failed event', async (t) => {
+  // Distinguishes a genuine failure on a healthy channel from collateral
+  // damage while the channel is mid-rejoin after a drop
+  const channel = {
+    ...mockChannel({}),
+    state: 'errored',
+    socket: { connectionState: () => 'connecting' },
+  };
+
+  await t.throwsAsync(() =>
+    sendEvent({ id: 'x', channel, logger, options: {} }, 'step:complete', {})
+  );
+
+  const reports = await waitForSentryReport(testkit);
+  t.is(reports[0].extra?.channel_state, 'errored');
+  t.is(reports[0].extra?.socket_state, 'connecting');
 });
 
 // The real phoenix channel invokes its receive callbacks from the socket's


### PR DESCRIPTION
This PR adds a few fixes to improve diagnostics

- Fix some issues in sentry reporting (more reports on error and better run scoping)
- include dataclip size in the send-complete event for tracking and debugging (sent to lightning)

This so far won't fix any of the problems we've been seeing in https://github.com/OpenFn/kit/issues/1504. I might include a fix.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
