### PR TITLE
tests: add lazy-state integration tests

### DIFF
--- a/integration-tests/execute/package.json
+++ b/integration-tests/execute/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@openfn/compiler": "workspace:^",
-    "@openfn/language-common": "3.2.3",
+    "@openfn/language-common": "3.3.4",
     "@openfn/language-http": "6.4.3",
     "@openfn/runtime": "workspace:^",
     "@types/node": "^18.19.130",

--- a/integration-tests/execute/test/lazy-state.test.ts
+++ b/integration-tests/execute/test/lazy-state.test.ts
@@ -1,6 +1,15 @@
 import test from 'ava';
 import execute from '../src/execute';
 
+const helpers = `
+const resolve = (state, value) => typeof value === 'function' ? value(state) : value;
+const upsert = (name, obj) => state => {
+  state.upserts ??= [];
+  state.upserts.push({ name, ...resolve(state, obj) });
+  return state;
+};
+`;
+
 test.serial(
   'use lazy-state in template literal & property access',
   async (t) => {
@@ -50,105 +59,55 @@ fn($.callMeMaybe($.data.name))`;
   t.deepEqual(result, { data: { name: 'John', greetings: 'Hello John' } });
 });
 
-// Note: language-common's fn() passes the resolved argument through as the
-// next state, so fn($.x) can be used to return state.x directly.
-// This helper is a minimal "adaptor operation" which resolves a lazy-state
-// argument the same way real adaptor operations do (via expandReferences).
-const helpers = `
-const resolve = (state, value) => typeof value === 'function' ? value(state) : value;
-const upsert = (name, obj) => state => {
-  state.upserts ??= [];
-  state.upserts.push({ name, ...resolve(state, obj) });
-  return state;
-};
-`;
-
-/*
- * Basic reads
- */
-
-test.serial('read a top-level boolean in a condition', async (t) => {
+test.serial('read a top level path', async (t) => {
   const state = { ready: true };
-  const job = `fnIf($.ready, fn(state => {
-  state.ran = true;
-  return state;
-}))`;
 
-  const result = await execute(job, state);
-  t.true(result.ran);
+  const result = await execute(`assert($.ready)`, state);
+  t.falsy(result.errors);
+
+  const failed = await execute(`assert(!$.ready)`, state);
+  t.is(failed.errors.src.message, 'assertion statement failed with false');
 });
 
 test.serial('read a nested path', async (t) => {
   const state = { data: { patient: { name: 'Alice' } } };
-  const job = `fnIf($.data.patient.name === 'Alice', fn(state => {
-  state.matched = true;
-  return state;
-}))`;
+  const job = `assert($.data.patient.name === 'Alice')`;
 
   const result = await execute(job, state);
-  t.true(result.matched);
+  t.falsy(result.errors);
 });
 
 test.serial('read an array index', async (t) => {
   const state = { data: { items: [{ id: 'first' }, { id: 'second' }] } };
-  const job = `fnIf($.data.items[1].id === 'second', fn(state => {
-  state.matched = true;
-  return state;
-}))`;
+  const job = `assert($.data.items[1].id === 'second')`;
 
   const result = await execute(job, state);
-  t.true(result.matched);
+  t.falsy(result.errors);
 });
 
 test.serial('read a missing path with optional chaining', async (t) => {
   const state = { data: {} };
-  const job = `fnIf($.data.missing?.id, fn(state => {
-  state.ran = true;
-  return state;
-}))`;
+  const job = `assert($.data.missing?.id === undefined)`;
 
   const result = await execute(job, state);
-  t.is(result.ran, undefined);
+  t.falsy(result.errors);
 });
-
-test.serial('return a value read from state as the next state', async (t) => {
-  const state = { data: { x: 1 }, other: 'stuff' };
-  const job = `fn($.data)`;
-
-  const result = await execute(job, state);
-  t.deepEqual(result, { x: 1 });
-});
-
-/*
- * Expressions
- */
 
 test.serial('use lazy-state in arithmetic', async (t) => {
   const state = { report: { revenue: 100, expenses: 40 } };
-  const job = `fnIf($.report.revenue - $.report.expenses === 60, fn(state => {
-  state.profit = true;
-  return state;
-}))`;
+  const job = `assert($.report.revenue - $.report.expenses === 60)`;
 
   const result = await execute(job, state);
-  t.true(result.profit);
+  t.falsy(result.errors);
 });
 
 test.serial('use lazy-state in logical expressions', async (t) => {
   const state = { a: true, b: false };
-  const job = `fnIf($.a && !$.b, fn(state => {
-  state.and = true;
-  return state;
-}))
-
-fnIf($.b || $.a, fn(state => {
-  state.or = true;
-  return state;
-}))`;
+  const job = `assert($.a && !$.b)
+assert($.b || $.a)`;
 
   const result = await execute(job, state);
-  t.true(result.and);
-  t.true(result.or);
+  t.falsy(result.errors);
 });
 
 test.serial('use lazy-state in a ternary', async (t) => {
@@ -168,10 +127,6 @@ fn(codes[$.location.country])`;
   const result = await execute(job, state);
   t.is(result as unknown as string, 'KE');
 });
-
-/*
- * Objects, mapping and iteration
- */
 
 test.serial('map state into an object argument', async (t) => {
   const state = { data: { first: 'Ada', last: 'Lovelace', age: 36 } };
@@ -233,10 +188,6 @@ test.serial('use lazy-state for both arguments of group()', async (t) => {
   });
 });
 
-/*
- * Scoping
- */
-
 test.serial('do not convert a $ parameter', async (t) => {
   const state = { data: {} };
   const job = `fn(($) => {
@@ -270,10 +221,6 @@ test.serial('do not convert $ inside a string', async (t) => {
   const result = await execute(job, state);
   t.deepEqual(result, { data: { str: '$.data.a' } });
 });
-
-/*
- * Illegal usage (compile-time errors)
- */
 
 test.serial('throw if $ is assigned to a variable', async (t) => {
   const state = { data: { url: 'x' } };

--- a/integration-tests/execute/test/lazy-state.test.ts
+++ b/integration-tests/execute/test/lazy-state.test.ts
@@ -49,3 +49,280 @@ fn($.callMeMaybe($.data.name))`;
 
   t.deepEqual(result, { data: { name: 'John', greetings: 'Hello John' } });
 });
+
+// Note: language-common's fn() passes the resolved argument through as the
+// next state, so fn($.x) can be used to return state.x directly.
+// This helper is a minimal "adaptor operation" which resolves a lazy-state
+// argument the same way real adaptor operations do (via expandReferences).
+const helpers = `
+const resolve = (state, value) => typeof value === 'function' ? value(state) : value;
+const upsert = (name, obj) => state => {
+  state.upserts ??= [];
+  state.upserts.push({ name, ...resolve(state, obj) });
+  return state;
+};
+`;
+
+/*
+ * Basic reads
+ */
+
+test.serial('read a top-level boolean in a condition', async (t) => {
+  const state = { ready: true };
+  const job = `fnIf($.ready, fn(state => {
+  state.ran = true;
+  return state;
+}))`;
+
+  const result = await execute(job, state);
+  t.true(result.ran);
+});
+
+test.serial('read a nested path', async (t) => {
+  const state = { data: { patient: { name: 'Alice' } } };
+  const job = `fnIf($.data.patient.name === 'Alice', fn(state => {
+  state.matched = true;
+  return state;
+}))`;
+
+  const result = await execute(job, state);
+  t.true(result.matched);
+});
+
+test.serial('read an array index', async (t) => {
+  const state = { data: { items: [{ id: 'first' }, { id: 'second' }] } };
+  const job = `fnIf($.data.items[1].id === 'second', fn(state => {
+  state.matched = true;
+  return state;
+}))`;
+
+  const result = await execute(job, state);
+  t.true(result.matched);
+});
+
+test.serial('read a missing path with optional chaining', async (t) => {
+  const state = { data: {} };
+  const job = `fnIf($.data.missing?.id, fn(state => {
+  state.ran = true;
+  return state;
+}))`;
+
+  const result = await execute(job, state);
+  t.is(result.ran, undefined);
+});
+
+test.serial('return a value read from state as the next state', async (t) => {
+  const state = { data: { x: 1 }, other: 'stuff' };
+  const job = `fn($.data)`;
+
+  const result = await execute(job, state);
+  t.deepEqual(result, { x: 1 });
+});
+
+/*
+ * Expressions
+ */
+
+test.serial('use lazy-state in arithmetic', async (t) => {
+  const state = { report: { revenue: 100, expenses: 40 } };
+  const job = `fnIf($.report.revenue - $.report.expenses === 60, fn(state => {
+  state.profit = true;
+  return state;
+}))`;
+
+  const result = await execute(job, state);
+  t.true(result.profit);
+});
+
+test.serial('use lazy-state in logical expressions', async (t) => {
+  const state = { a: true, b: false };
+  const job = `fnIf($.a && !$.b, fn(state => {
+  state.and = true;
+  return state;
+}))
+
+fnIf($.b || $.a, fn(state => {
+  state.or = true;
+  return state;
+}))`;
+
+  const result = await execute(job, state);
+  t.true(result.and);
+  t.true(result.or);
+});
+
+test.serial('use lazy-state in a ternary', async (t) => {
+  const state = { data: { status: 'active' } };
+  const job = `fn($.data.status === 'active' ? { result: 'yes' } : { result: 'no' })`;
+
+  const result = await execute(job, state);
+  t.deepEqual(result, { result: 'yes' });
+});
+
+test.serial('use lazy-state as a dynamic property key', async (t) => {
+  const state = { location: { country: 'Kenya' } };
+  const job = `const codes = { Kenya: 'KE', Uganda: 'UG' };
+
+fn(codes[$.location.country])`;
+
+  const result = await execute(job, state);
+  t.is(result as unknown as string, 'KE');
+});
+
+/*
+ * Objects, mapping and iteration
+ */
+
+test.serial('map state into an object argument', async (t) => {
+  const state = { data: { first: 'Ada', last: 'Lovelace', age: 36 } };
+  const job = `${helpers}
+upsert('person', {
+  fullName: $.data.first + ' ' + $.data.last,
+  age: $.data.age,
+})`;
+
+  const result = await execute(job, state);
+  t.deepEqual(result.upserts, [
+    { name: 'person', fullName: 'Ada Lovelace', age: 36 },
+  ]);
+});
+
+test.serial('use lazy-state as the data source for each()', async (t) => {
+  const state = { data: { items: [1, 2, 3] }, total: 0 };
+  const job = `each($.data.items, fn(state => {
+  state.total += state.data;
+  return state;
+}))`;
+
+  const result = await execute(job, state);
+  t.is(result.total, 6);
+});
+
+test.serial('read the current item inside each()', async (t) => {
+  const state = { data: { patients: [{ id: 'a' }, { id: 'b' }] } };
+  const job = `${helpers}
+each($.data.patients, upsert('patient', { id: $.data.id }))`;
+
+  const result = await execute(job, state);
+  t.deepEqual(result.upserts, [
+    { name: 'patient', id: 'a' },
+    { name: 'patient', id: 'b' },
+  ]);
+});
+
+test.serial('use lazy-state for both arguments of group()', async (t) => {
+  const state = {
+    data: {
+      rows: [
+        { type: 'x', v: 1 },
+        { type: 'y', v: 2 },
+        { type: 'x', v: 3 },
+      ],
+    },
+    keyPath: 'type',
+  };
+  const job = `group($.data.rows, $.keyPath)`;
+
+  const result = await execute(job, state);
+  t.deepEqual(result.data, {
+    x: [
+      { type: 'x', v: 1 },
+      { type: 'x', v: 3 },
+    ],
+    y: [{ type: 'y', v: 2 }],
+  });
+});
+
+/*
+ * Scoping
+ */
+
+test.serial('do not convert a $ parameter', async (t) => {
+  const state = { data: {} };
+  const job = `fn(($) => {
+  $.data.x = 1;
+  return $;
+})`;
+
+  const result = await execute(job, state);
+  t.deepEqual(result, { data: { x: 1 } });
+});
+
+test.serial('do not convert a locally declared $', async (t) => {
+  const state = { data: {} };
+  const job = `fn((state) => {
+  const $ = { a: 5 };
+  state.data.a = $.a;
+  return state;
+})`;
+
+  const result = await execute(job, state);
+  t.deepEqual(result, { data: { a: 5 } });
+});
+
+test.serial('do not convert $ inside a string', async (t) => {
+  const state = { data: {} };
+  const job = `fn((state) => {
+  state.data.str = "$.data.a";
+  return state;
+})`;
+
+  const result = await execute(job, state);
+  t.deepEqual(result, { data: { str: '$.data.a' } });
+});
+
+/*
+ * Illegal usage (compile-time errors)
+ */
+
+test.serial('throw if $ is assigned to a variable', async (t) => {
+  const state = { data: { url: 'x' } };
+  const job = `const url = $.data.url;
+fn(state => state)`;
+
+  await t.throwsAsync(() => execute(job, state), {
+    message: /must be inside an operation/i,
+  });
+});
+
+test.serial('throw if $ is used inside a nullary arrow', async (t) => {
+  const state = { data: { url: 'x' } };
+  const job = `fn(() => $.data.url)`;
+
+  await t.throwsAsync(() => execute(job, state), {
+    message: /wrong arity/i,
+  });
+});
+
+test.serial(
+  'throw if $ is used inside an arrow whose parameter is not called state',
+  async (t) => {
+    const state = { flag: true };
+    const job = `fnIf((s) => $.flag, fn(state => state))`;
+
+    await t.throwsAsync(() => execute(job, state), {
+      message: /parameter "s" should be called "state"/i,
+    });
+  }
+);
+
+test.serial('throw if $ is written to at the top level', async (t) => {
+  const state = { data: {} };
+  const job = `$.data.x = 10;`;
+
+  await t.throwsAsync(() => execute(job, state), {
+    message: /must be inside an operation/i,
+  });
+});
+
+test.serial('throw if $ is written to inside an operation', async (t) => {
+  const state = { data: {} };
+  const job = `fn(state => {
+  $.data.x = 10;
+  return state;
+})`;
+
+  await t.throwsAsync(() => execute(job, state), {
+    message: /must be inside an operation/i,
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/compiler
       '@openfn/language-common':
-        specifier: 3.2.3
-        version: 3.2.3
+        specifier: 3.3.4
+        version: 3.3.4
       '@openfn/language-http':
         specifier: 6.4.3
         version: 6.4.3
@@ -1379,6 +1379,9 @@ packages:
   '@openfn/language-common@3.3.1':
     resolution: {integrity: sha512-WBdDjA1gf8zmOZ6J7Y47o1reQa/np15oKFQ9EEJSMbJg8kTTbJmHU0V3ibL40M8dPVJBvr5b5UFzKytqNvSCCw==}
 
+  '@openfn/language-common@3.3.4':
+    resolution: {integrity: sha512-I5kKmrjr30BKoL0RzuLGKcw7IpDLxpQtfBS6ljhH4MBE4TJ9BUTGXFU46QI7RbkpTNdsi6mtwuRnl2tioM9Dpw==}
+
   '@openfn/language-http@6.4.3':
     resolution: {integrity: sha512-8ihgIYId+ewMuNU9hbe5JWEWvaJInDrIEiy4EyO7tbzu5t/f1kO18JIzQWm6r7dcHiMfcG2QaXe6O3br1xOrDA==}
 
@@ -2194,6 +2197,9 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -4978,6 +4984,17 @@ snapshots:
       lodash: 4.18.1
       undici: 7.28.0
 
+  '@openfn/language-common@3.3.4':
+    dependencies:
+      ajv: 8.20.0
+      csv-parse: 5.6.0
+      csvtojson: 2.0.14
+      date-fns: 2.30.0
+      http-status-codes: 2.3.0
+      jsonpath-plus: 10.4.0
+      lodash: 4.18.1
+      undici: 7.28.0
+
   '@openfn/language-http@6.4.3':
     dependencies:
       '@openfn/language-common': 2.0.1
@@ -5805,6 +5822,13 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-colors@4.1.3: {}
 
   ansi-escapes@4.3.2:
@@ -6211,7 +6235,7 @@ snapshots:
 
   csvtojson@2.0.14:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   currently-unhandled@0.4.1:
     dependencies:


### PR DESCRIPTION
## Short Description

Adds 21 lazy-state (`$`) tests to `integration-tests/execute/test/lazy-state.test.ts`, building up from simple reads to expressions, mapping/iteration, scoping rules and illegal usage.

Fixes #840

## Implementation Details

The new tests are grouped and ordered methodically, following the examples on the [Lazy State Operator docs page](https://docs.openfn.org/documentation/jobs/lazy-state-operator):

- **Basic reads** – top-level value, nested path, array index, optional chaining on a missing path, and `fn($.data)` returning a value from state as the next state.
- **Expressions** – arithmetic, `&&` / `||` / `!`, ternary, and `$` as a dynamic property key (`codes[$.location.country]`).
- **Objects, mapping and iteration** – mapping state into an object argument (the docs' `create('agent', { name: $.patient.name })` shape, via a tiny in-job `upsert` helper that resolves its argument the way `expandReferences` does), `each($.data.items, …)`, reading the current item with `$.data` inside `each()`, and `group($.data.rows, $.keyPath)`.
- **Scoping** – `$` declared as a parameter or a local `const` is left alone; `$` inside a string literal is not converted.
- **Illegal usage** – every ❌ example from the docs asserts the `LazyStateError` message: assigning `$` to a variable, using it inside a nullary arrow, inside an arrow whose parameter isn't named `state`, and writing to `$` at the top level or inside an operation.

No source changes; only the test file is touched. No changeset added since `@openfn/integration-tests-execute` is private (same as previous test-only changes here).

One thing I noticed while writing these and deliberately left out: a method call on a *nested* state value, e.g. `fnIf($.name.toUpperCase() === 'JOHN', …)`, currently compiles to `(state => state.name.toUpperCase)() === 'JOHN'` – the arrow wraps the callee rather than the call (the special case in `ensureParentArrow` only handles `$.method()` directly on state). Happy to open a separate issue for that if useful.

## QA Notes

Ran in a clean `node:22` Linux container (fresh `pnpm install --frozen-lockfile` + `pnpm -r --filter=./packages/* run build`):

```
integration-tests/execute $ pnpm ava test/lazy-state.test.ts --verbose
  ✔ … (23 tests)
  23 tests passed

integration-tests/execute $ pnpm ava
  35 tests passed
  1 test skipped
```

Also `tsc --noEmit -p integration-tests/execute/tsconfig.json` and `prettier --check` on the file pass.

(Side note, not addressed here: on Windows the whole `execute` integration suite fails before any test runs because the runtime linker builds `file://C:\…` instead of a `file:///C:/…` URL; CI on Linux is unaffected.)

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI
