### PR TITLE
Worker: don't hang when fetch:plan replies with an error

### DIFF
--- a/.changeset/khaki-jars-relax.md
+++ b/.changeset/khaki-jars-relax.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Fail a run cleanly instead of hanging when Lightning rejects the plan fetch after a claim

--- a/packages/ws-worker/src/channels/run.ts
+++ b/packages/ws-worker/src/channels/run.ts
@@ -37,11 +37,16 @@ const joinRunChannel = (
         if (!didReceiveOk) {
           didReceiveOk = true;
           logger.success(`connected to ${channelName}`, e);
-          const run = await sendEvent<GetPlanReply>(
-            { channel, logger, id: runId, options: {} },
-            GET_PLAN
-          );
-          resolve({ channel, run });
+          try {
+            const run = await sendEvent<GetPlanReply>(
+              { channel, logger, id: runId, options: {} },
+              GET_PLAN
+            );
+            resolve({ channel, run });
+          } catch (err) {
+            channel?.leave();
+            reject(err);
+          }
         }
       })
       .receive('error', (err: any) => {

--- a/packages/ws-worker/test/channels/run.test.ts
+++ b/packages/ws-worker/test/channels/run.test.ts
@@ -44,6 +44,30 @@ test('should fail to join an run channel with an invalid token', async (t) => {
   }
 });
 
+test('should reject (not hang) when fetch:plan replies an error', async (t) => {
+  const logger = createMockLogger();
+  const socket = new MockSocket('www', {
+    'run:a': mockChannel({
+      join: () => ({ status: 'ok' }),
+      [GET_PLAN]: () => {
+        throw { reason: 'adaptor_not_ready' };
+      },
+    }),
+  });
+
+  // race against a short timeout so a hang fails fast instead of hanging CI
+  const result = await Promise.race([
+    joinRunChannel(socket, 'x.y.z', 'a', logger).then(
+      () => 'resolved',
+      () => 'rejected'
+    ),
+    new Promise((resolve) => setTimeout(() => resolve('timed-out'), 200)),
+  ]);
+
+  // 'timed-out' would mean joinRunChannel's promise never settled
+  t.is(result, 'rejected');
+});
+
 test('should log an error including channel state when the channel errors', async (t) => {
   const logger = createMockLogger();
   const channel = mockChannel({


### PR DESCRIPTION
## Short Description

Fixes a bug where the worker would hang forever (and quietly leak a capacity slot) if Lightning rejected a `fetch:plan` request after a run had already been claimed.

## Implementation Details

Lightning is going to start being able to reply with an error to `fetch:plan` (e.g. when it can't resolve the job's adaptor — `adaptor_not_ready`, `adaptor_not_found`, etc).

Found a loose unresolved promise when the run channel is joined and `sendEvent` rejects when fetching the plan. Turns out we were leaving it stuck (not catching the rejection). 

What happens is that `joinRunChannel` just hung forever, the upstream try/catch in `server.ts` (which does the clean up) doesn't get the exception, and the worker's slot for that run was occupied forever. The lost runs janitor does mark it as lost, so it's not completely "silent" but it doesn't look like we'd get the slot back.

So wrapping the call in a try/catch makes a failed call do the same as a failed or timed out join on the run channel.

## QA Notes

Theres a test that forces `fetch:plan` to error and confirms `joinRunChannel` rejects instead of hanging.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI
