### PR TITLE
CLI: fix issues removing stuff on deploy

### DIFF
--- a/.changeset/fruity-moles-dream.md
+++ b/.changeset/fruity-moles-dream.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Fix issues removing workflows in `project deploy`

--- a/.changeset/fruity-moles-dream.md
+++ b/.changeset/fruity-moles-dream.md
@@ -2,4 +2,4 @@
 '@openfn/cli': patch
 ---
 
-Fix issues removing workflows in `project deploy`
+`project deploy`: fix issues removing workflows, steps and edges while deploying.

--- a/.changeset/metal-words-go.md
+++ b/.changeset/metal-words-go.md
@@ -1,0 +1,5 @@
+---
+'@openfn/lightning-mock': minor
+---
+
+Improve support for removing workflows, steps and edges"

--- a/.changeset/metal-words-go.md
+++ b/.changeset/metal-words-go.md
@@ -2,4 +2,4 @@
 '@openfn/lightning-mock': minor
 ---
 
-Improve support for removing workflows, steps and edges"
+Improve support for removing workflows, steps and edges

--- a/.changeset/small-cougars-check.md
+++ b/.changeset/small-cougars-check.md
@@ -1,0 +1,5 @@
+---
+'@openfn/project': patch
+---
+
+Fix an issue where removing a workflow triggers an error on merge

--- a/.changeset/small-cougars-check.md
+++ b/.changeset/small-cougars-check.md
@@ -2,4 +2,6 @@
 '@openfn/project': patch
 ---
 
-Fix an issue where removing a workflow triggers an error on merge
+- Fix an issue where removing a workflow triggers an error on merge
+- Allow Workflows to track deleted entities internally via the `removed` index
+- Recognise `delete` state on workflows, steps and edges when parsing from/to app state

--- a/.changeset/upset-cougars-smile.md
+++ b/.changeset/upset-cougars-smile.md
@@ -1,0 +1,5 @@
+---
+'@openfn/lexicon': patch
+---
+
+Recognise delete key in provisioner state

--- a/integration-tests/cli/test/deploy.v2.test.ts
+++ b/integration-tests/cli/test/deploy.v2.test.ts
@@ -2,9 +2,7 @@ import test from 'ava';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import run from '../src/run';
-import createLightningServer, {
-  DEFAULT_PROJECT_ID,
-} from '@openfn/lightning-mock';
+import createLightningServer from '@openfn/lightning-mock';
 import Project from '@openfn/project';
 import { extractLogs, assertLog } from '../src/util';
 import { rimraf } from 'rimraf';
@@ -190,6 +188,147 @@ test.serial('deploy then pull, change one workflow, deploy', async (t) => {
       log.level === 'always' && /^\s*-\s*my-workflow/.test(`${log.message}`)
   );
   t.falsy(myWorkflowLog);
+});
+
+test.serial('Remove a whole workflow', async (t) => {
+  const projectId = 'remove-workflow';
+  server.addProject(makeMultiProject(projectId) as any);
+
+  // pull multi workflow project
+  const pullResult = await run(
+    `openfn project pull ${projectId} --log-json -l debug`
+  );
+  t.falsy(pullResult.stderr);
+  assertLog(t, extractLogs(pullResult.stdout), /Checked out project locally/i);
+
+  let proj = server.state.projects[projectId];
+  t.is(Object.keys(proj.workflows).length, 2);
+
+  // remove another-workflow locally, like a user deleting the folder
+  await rimraf(path.join(tmpDir, 'workflows/another-workflow'));
+
+  // deploy
+  const { stdout, stderr } = await run(
+    `openfn project deploy --no-confirm --log-json -l debug`
+  );
+  t.falsy(stderr);
+
+  const logs = extractLogs(stdout);
+  assertLog(t, logs, /Updated project/);
+  assertLog(t, logs, /Another Workflow: deleted/);
+
+  // the workflow must actually be gone from the server, not just unmentioned
+  proj = server.state.projects[projectId];
+  const workflows = Object.values(proj.workflows) as any[];
+  t.is(workflows.length, 1);
+  t.is(workflows[0].name, 'My Workflow');
+});
+
+test.serial('remove a step and its edge from a workflow', async (t) => {
+  const projectId = 'remove-step';
+  server.addProject(makeProject(projectId) as any);
+
+  const pullResult = await run(
+    `openfn project pull ${projectId} --log-json -l debug`
+  );
+  t.falsy(pullResult.stderr);
+  assertLog(t, extractLogs(pullResult.stdout), /Checked out project locally/i);
+
+  // Remove my-job and the edge into it, consistently, in the same edit - the
+  // local project file has to do this itself, the CLI won't clean up a
+  // dangling edge left pointing at a step that's no longer there.
+  const workflowYamlPath = path.join(
+    tmpDir,
+    'workflows/my-workflow/my-workflow.yaml'
+  );
+  await fs.writeFile(
+    workflowYamlPath,
+    `id: my-workflow
+name: My Workflow
+start: webhook
+steps:
+  - id: webhook
+    type: webhook
+    enabled: true
+    next: {}
+`
+  );
+  await rimraf(path.join(tmpDir, 'workflows/my-workflow/my-job.js'));
+
+  const { stdout, stderr } = await run(
+    `openfn project deploy --no-confirm --log-json -l debug`
+  );
+  t.falsy(stderr);
+
+  const logs = extractLogs(stdout);
+  assertLog(t, logs, /Updated project/);
+  assertLog(t, logs, /My Job: removed/);
+
+  // the job and its edge must actually be gone from the server
+  const proj = server.state.projects[projectId];
+  const wf = Object.values(proj.workflows).find(
+    (w: any) => w.id === 'my-workflow-1'
+  ) as any;
+  const jobs = Array.isArray(wf.jobs) ? wf.jobs : Object.values(wf.jobs ?? {});
+  const edges = Array.isArray(wf.edges)
+    ? wf.edges
+    : Object.values(wf.edges ?? {});
+  t.is(jobs.length, 0);
+  t.is(edges.length, 0);
+});
+
+test.serial('remove an edge, leaving both steps in place', async (t) => {
+  const projectId = 'remove-edge';
+  server.addProject(makeProject(projectId) as any);
+
+  const pullResult = await run(
+    `openfn project pull ${projectId} --log-json -l debug`
+  );
+  t.falsy(pullResult.stderr);
+  assertLog(t, extractLogs(pullResult.stdout), /Checked out project locally/i);
+
+  // Remove just the edge from webhook -> my-job, keeping both steps as they
+  // are. The local project file drops the `next` entry itself.
+  const workflowYamlPath = path.join(
+    tmpDir,
+    'workflows/my-workflow/my-workflow.yaml'
+  );
+  await fs.writeFile(
+    workflowYamlPath,
+    `id: my-workflow
+name: My Workflow
+start: webhook
+steps:
+  - id: my-job
+    name: My Job
+    adaptor: '@openfn/language-common@latest'
+    expression: ./my-job.js
+  - id: webhook
+    type: webhook
+    enabled: true
+    next: {}
+`
+  );
+
+  const { stdout, stderr } = await run(
+    `openfn project deploy --no-confirm --log-json -l debug`
+  );
+  t.falsy(stderr);
+
+  const logs = extractLogs(stdout);
+  assertLog(t, logs, /Updated project/);
+
+  // both steps survive, but the edge between them must actually be gone
+  const proj = server.state.projects[projectId];
+  const wf = Object.values(proj.workflows).find(
+    (w: any) => w.id === 'my-workflow-1'
+  ) as any;
+  const jobs = Array.isArray(wf.jobs) ? wf.jobs : Object.values(wf.jobs ?? {});
+  const edges = Array.isArray(wf.edges)
+    ? wf.edges
+    : Object.values(wf.edges ?? {});
+  t.is(jobs.length, 1);
+  t.is(edges.length, 0);
 });
 
 /**

--- a/packages/lexicon/lightning.d.ts
+++ b/packages/lexicon/lightning.d.ts
@@ -350,6 +350,7 @@ export namespace Provisioner {
     source_trigger_id: string | null;
     target_job_id: string;
     enabled?: boolean;
+    delete?: boolean;
   };
 
   export type KafkaConfiguration = {

--- a/packages/lightning-mock/src/api-dev.ts
+++ b/packages/lightning-mock/src/api-dev.ts
@@ -75,6 +75,20 @@ const setupDevAPI = (
     } else {
       project = JSON.parse(JSON.stringify(project));
     }
+
+    // Give every workflow a baseline version_history
+    const workflows: any[] = Array.isArray((project as any).workflows)
+      ? (project as any).workflows
+      : Object.values((project as any).workflows ?? {});
+
+    for (const wf of workflows) {
+      if (!wf.version_history?.length) {
+        wf.version_history = [
+          generateVersionHash(mapWorkflow(wf) as any, { source: 'app' }),
+        ];
+      }
+    }
+
     // @ts-ignore
     state.projects[project.id] = project;
   };

--- a/packages/lightning-mock/src/api-rest.ts
+++ b/packages/lightning-mock/src/api-rest.ts
@@ -86,9 +86,17 @@ workflows:
 const ensureArray = (x: any): any[] =>
   Array.isArray(x) ? x : Object.values(x ?? {});
 
-// Removes jobs/triggers/edges with delete: true
-const stripDeleted = (x: any) =>
-  ensureArray(x).filter((item: any) => !item.delete);
+// Removes jobs/triggers/edges with delete: true - Lightning wouldn't persist or
+// return them, so neither should the mock.
+const stripDeleted = (x: any) => {
+  if (!x) return [];
+  if (Array.isArray(x)) {
+    return x.filter((item: any) => !item.delete);
+  }
+  return Object.fromEntries(
+    Object.entries(x).filter(([, item]: any) => !item.delete)
+  );
+};
 
 // Validates a provisioner payload, returning an error body if invalid or null if valid.
 // Mirrors Lightning's error format so deploy code sees realistic rejection responses.

--- a/packages/lightning-mock/src/api-rest.ts
+++ b/packages/lightning-mock/src/api-rest.ts
@@ -83,16 +83,23 @@ workflows:
         enabled: true
 `;
 
+const ensureArray = (x: any): any[] =>
+  Array.isArray(x) ? x : Object.values(x ?? {});
+
+// Removes jobs/triggers/edges with delete: true
+const stripDeleted = (x: any) =>
+  ensureArray(x).filter((item: any) => !item.delete);
+
 // Validates a provisioner payload, returning an error body if invalid or null if valid.
 // Mirrors Lightning's error format so deploy code sees realistic rejection responses.
 export function validateProvisionPayload(
-  incoming: any
+  incoming: any,
+  existingProject?: any
 ): Record<string, any> | null {
   const workflowErrors: Record<string, any> = {};
 
-  const wfList: any[] = Array.isArray(incoming.workflows)
-    ? incoming.workflows
-    : Object.values(incoming.workflows ?? {});
+  const wfList: any[] = ensureArray(incoming.workflows);
+  const existingWfList: any[] = ensureArray(existingProject?.workflows);
 
   for (const wf of wfList) {
     const wfErrors: Record<string, any> = {};
@@ -102,9 +109,7 @@ export function validateProvisionPayload(
     }
 
     const edgeErrors: Record<string, any> = {};
-    const edgeList: any[] = Array.isArray(wf.edges)
-      ? wf.edges
-      : Object.values(wf.edges ?? {});
+    const edgeList: any[] = ensureArray(wf.edges);
 
     for (const edge of edgeList) {
       const key = edge.id ?? '->';
@@ -129,9 +134,7 @@ export function validateProvisionPayload(
     }
 
     const jobErrors: Record<string, any> = {};
-    const jobList: any[] = Array.isArray(wf.jobs)
-      ? wf.jobs
-      : Object.values(wf.jobs ?? {});
+    const jobList: any[] = ensureArray(wf.jobs);
 
     for (const job of jobList) {
       if (!job.id) {
@@ -145,9 +148,7 @@ export function validateProvisionPayload(
     }
 
     const triggerErrors: Record<string, any> = {};
-    const triggerList: any[] = Array.isArray(wf.triggers)
-      ? wf.triggers
-      : Object.values(wf.triggers ?? {});
+    const triggerList: any[] = ensureArray(wf.triggers);
 
     for (const trigger of triggerList) {
       if (!trigger.id) {
@@ -163,6 +164,17 @@ export function validateProvisionPayload(
     if (Object.keys(wfErrors).length > 0) {
       const wfKey = wf.name ?? wf.id ?? 'unknown';
       workflowErrors[wfKey] = wfErrors;
+    }
+  }
+
+  // a whole workflow, unlike its jobs/triggers/edges, must be explicit about removal
+  const incomingWfIds = new Set(wfList.map((wf: any) => wf.id));
+  for (const wf of existingWfList) {
+    if (!incomingWfIds.has(wf.id)) {
+      const wfKey = wf.name ?? wf.id ?? 'unknown';
+      workflowErrors[wfKey] = {
+        delete: ['missing from payload - flag delete: true to remove it'],
+      };
     }
   }
 
@@ -212,7 +224,10 @@ export default (
   router.post('/api/provision', (ctx) => {
     const incoming: any = ctx.request.body;
 
-    const validationErrors = validateProvisionPayload(incoming);
+    const validationErrors = validateProvisionPayload(
+      incoming,
+      state.projects[incoming.id]
+    );
     if (validationErrors) {
       ctx.response.status = 422;
       ctx.response.body = validationErrors;
@@ -241,7 +256,12 @@ export default (
       ? incoming.workflows
       : Object.values(incoming.workflows ?? {});
     wfList.forEach((wf: any) => {
-      app.updateWorkflow(incoming.id, wf);
+      app.updateWorkflow(incoming.id, {
+        ...wf,
+        jobs: stripDeleted(wf.jobs),
+        triggers: stripDeleted(wf.triggers),
+        edges: stripDeleted(wf.edges),
+      });
     });
 
     ctx.response.status = 200;

--- a/packages/lightning-mock/test/rest.test.ts
+++ b/packages/lightning-mock/test/rest.test.ts
@@ -59,6 +59,65 @@ test.serial('should deploy a project and fetch it back', async (t) => {
   t.is(proj.name, 'my project');
 });
 
+test.serial('should actually delete a job flagged delete: true', async (t) => {
+  const response = await fetch(`${endpoint}/api/provision`, {
+    method: 'POST',
+    body: JSON.stringify({
+      id: DEFAULT_PROJECT_ID,
+      name: 'aaa',
+      workflows: [
+        {
+          id: '72ca3eb0-042c-47a0-a2a1-a545ed4a8406',
+          name: 'wf1',
+          jobs: [{ id: '66add020-e6eb-4eec-836b-20008afca816', delete: true }],
+        },
+      ],
+    }),
+    headers: { 'content-type': 'application/json' },
+  });
+  t.is(response.status, 200);
+
+  const res = await fetch(`${endpoint}/api/provision/${DEFAULT_PROJECT_ID}`);
+  const { data: proj } = await res.json();
+  const wf = proj.workflows.find(
+    (w: any) => w.id === '72ca3eb0-042c-47a0-a2a1-a545ed4a8406'
+  );
+  const jobs = Array.isArray(wf.jobs) ? wf.jobs : Object.values(wf.jobs ?? {});
+  t.is(jobs.length, 0);
+});
+
+test.serial(
+  'should delete a job that is simply omitted, same as delete: true',
+  async (t) => {
+    const workflowId = '72ca3eb0-042c-47a0-a2a1-a545ed4a8406';
+
+    // seed a job directly, rather than via a setup deploy
+    server.addNode(DEFAULT_PROJECT_ID, workflowId, {
+      id: 'temp-job',
+      name: 'Temp job',
+      adaptor: 'common',
+      body: 'fn(s => s)',
+    });
+
+    const response = await fetch(`${endpoint}/api/provision`, {
+      method: 'POST',
+      body: JSON.stringify({
+        id: DEFAULT_PROJECT_ID,
+        name: 'aaa',
+        workflows: [{ id: workflowId, name: 'wf1', jobs: [] }],
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    t.is(response.status, 200);
+
+    const res = await fetch(`${endpoint}/api/provision/${DEFAULT_PROJECT_ID}`);
+    const { data: proj } = await res.json();
+    const wf = proj.workflows.find((w: any) => w.id === workflowId);
+    const jobs = Array.isArray(wf.jobs) ? wf.jobs : Object.values(wf.jobs ?? {});
+    t.is(jobs.length, 0);
+  }
+);
+
 test.serial('should fetch many items from a collection', async (t) => {
   server.collections.createCollection('stuff');
   server.collections.upsert('stuff', 'x', { id: 'x' });
@@ -189,6 +248,127 @@ test('validateProvisionPayload: returns null when there are no edges', (t) => {
     id: 'proj-1',
     workflows: [{ id: 'wf-1', name: 'wf1', edges: [] }],
   };
+  t.is(validateProvisionPayload(payload), null);
+});
+
+// Unlike a whole workflow, an omitted job/trigger/edge is not an error - for
+// these, omission and delete: true mean exactly the same thing.
+test('validateProvisionPayload: a job silently vanishing is not an error', (t) => {
+  const existingProject = {
+    workflows: [
+      {
+        id: 'wf-1',
+        name: 'wf1',
+        jobs: [{ id: 'job-1', name: 'Transform data' }],
+      },
+    ],
+  };
+  const payload = {
+    id: 'proj-1',
+    workflows: [{ id: 'wf-1', name: 'wf1', jobs: [] }],
+  };
+
+  t.is(validateProvisionPayload(payload, existingProject), null);
+});
+
+test('validateProvisionPayload: returns null when a missing job is flagged delete: true', (t) => {
+  const existingProject = {
+    workflows: [
+      {
+        id: 'wf-1',
+        name: 'wf1',
+        jobs: [{ id: 'job-1', name: 'Transform data' }],
+      },
+    ],
+  };
+  const payload = {
+    id: 'proj-1',
+    workflows: [
+      { id: 'wf-1', name: 'wf1', jobs: [{ id: 'job-1', delete: true }] },
+    ],
+  };
+
+  t.is(validateProvisionPayload(payload, existingProject), null);
+});
+
+test('validateProvisionPayload: a trigger silently vanishing is not an error', (t) => {
+  const existingProject = {
+    workflows: [
+      {
+        id: 'wf-1',
+        name: 'wf1',
+        triggers: [{ id: 'trig-1', type: 'webhook' }],
+      },
+    ],
+  };
+  const payload = {
+    id: 'proj-1',
+    workflows: [{ id: 'wf-1', name: 'wf1', triggers: [] }],
+  };
+
+  t.is(validateProvisionPayload(payload, existingProject), null);
+});
+
+test('validateProvisionPayload: an edge silently vanishing is not an error', (t) => {
+  const existingProject = {
+    workflows: [
+      {
+        id: 'wf-1',
+        name: 'wf1',
+        edges: [
+          {
+            id: 'edge-1',
+            source_trigger_id: 'trig-1',
+            target_job_id: 'job-1',
+          },
+        ],
+      },
+    ],
+  };
+  const payload = {
+    id: 'proj-1',
+    workflows: [{ id: 'wf-1', name: 'wf1', edges: [] }],
+  };
+
+  t.is(validateProvisionPayload(payload, existingProject), null);
+});
+
+test('validateProvisionPayload: errors when a whole workflow silently vanishes without delete: true', (t) => {
+  const existingProject = {
+    workflows: [{ id: 'wf-1', name: 'wf1' }],
+  };
+  const payload = { id: 'proj-1', workflows: [] };
+
+  const result = validateProvisionPayload(payload, existingProject);
+  t.deepEqual(result, {
+    errors: {
+      workflows: {
+        wf1: {
+          delete: ['missing from payload - flag delete: true to remove it'],
+        },
+      },
+    },
+  });
+});
+
+test('validateProvisionPayload: returns null when a missing workflow is flagged delete: true', (t) => {
+  const existingProject = {
+    workflows: [{ id: 'wf-1', name: 'wf1' }],
+  };
+  const payload = {
+    id: 'proj-1',
+    workflows: [{ id: 'wf-1', delete: true }],
+  };
+
+  t.is(validateProvisionPayload(payload, existingProject), null);
+});
+
+test('validateProvisionPayload: no existing project means nothing can have vanished', (t) => {
+  const payload = {
+    id: 'proj-1',
+    workflows: [{ id: 'wf-1', name: 'wf1', jobs: [], triggers: [], edges: [] }],
+  };
+
   t.is(validateProvisionPayload(payload), null);
 });
 

--- a/packages/lightning-mock/test/rest.test.ts
+++ b/packages/lightning-mock/test/rest.test.ts
@@ -118,6 +118,49 @@ test.serial(
   }
 );
 
+test.serial(
+  'should actually delete a whole workflow flagged delete: true',
+  async (t) => {
+    const wf1Id = '72ca3eb0-042c-47a0-a2a1-a545ed4a8406';
+    const tempWorkflowId = 'temp-workflow';
+
+    const first = await fetch(`${endpoint}/api/provision`, {
+      method: 'POST',
+      body: JSON.stringify({
+        id: DEFAULT_PROJECT_ID,
+        name: 'aaa',
+        // wf1 must be included in every payload - a whole workflow (unlike
+        // its jobs/triggers/edges) has to be explicit about its own removal
+        workflows: [
+          { id: wf1Id, name: 'wf1' },
+          { id: tempWorkflowId, name: 'temp workflow' },
+        ],
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    t.is(first.status, 200);
+
+    const second = await fetch(`${endpoint}/api/provision`, {
+      method: 'POST',
+      body: JSON.stringify({
+        id: DEFAULT_PROJECT_ID,
+        name: 'aaa',
+        workflows: [
+          { id: wf1Id, name: 'wf1' },
+          { id: tempWorkflowId, delete: true },
+        ],
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    t.is(second.status, 200);
+
+    const res = await fetch(`${endpoint}/api/provision/${DEFAULT_PROJECT_ID}`);
+    const { data: proj } = await res.json();
+    t.falsy(proj.workflows.find((w: any) => w.id === tempWorkflowId));
+    t.truthy(proj.workflows.find((w: any) => w.id === wf1Id));
+  }
+);
+
 test.serial('should fetch many items from a collection', async (t) => {
   server.collections.createCollection('stuff');
   server.collections.upsert('stuff', 'x', { id: 'x' });

--- a/packages/project/src/Workflow.ts
+++ b/packages/project/src/Workflow.ts
@@ -23,13 +23,9 @@ class Workflow {
       edges: {}, // edges by from-id id
       uuid: {}, // id to uuid
       id: {}, // uuid to ids
-
-      // Flags entities removed from this workflow via remove(), keyed by step
-      // id or by the edge's composite `from-to` id.
-      // Used when converting to app state to generate delete: true entries.
       removed: {
         self: false,
-        ids: {} as Record<string, boolean>,
+        ids: {} as Record<string, boolean>, // step id, or edge's `from-to` id
       },
     };
 
@@ -136,8 +132,7 @@ class Workflow {
     return item;
   }
 
-  // Flag a step, an edge the whole workflow as removed
-  // to-app-state reads this to generate delete: true entries.
+  // Flags a step, edge, or (no args) the whole workflow removed - to-app-state reads this to generate delete: true entries
   remove(): this;
   remove(stepId: string): this;
   remove(from: string, to: string): this;
@@ -163,8 +158,6 @@ class Workflow {
     return this;
   }
 
-  // Check whether a step, an edge, or (with no argument) the whole workflow
-  // has been flagged as removed via remove().
   isRemoved(): boolean;
   isRemoved(stepId: string): boolean;
   isRemoved(from: string, to: string): boolean;
@@ -177,9 +170,6 @@ class Workflow {
     return !!this.index.removed.ids[id];
   }
 
-  // Whether the whole workflow was removed via remove(), plus the ids (step id,
-  // or edge composite `from-to` id) of everything flagged removed via remove().
-  // Used by to-app-state to generate `delete: true` entries.
   get removed(): { self: boolean; ids: Record<string, boolean> } {
     return this.index.removed;
   }

--- a/packages/project/src/Workflow.ts
+++ b/packages/project/src/Workflow.ts
@@ -23,6 +23,14 @@ class Workflow {
       edges: {}, // edges by from-id id
       uuid: {}, // id to uuid
       id: {}, // uuid to ids
+
+      // Flags entities removed from this workflow via remove(), keyed by step
+      // id or by the edge's composite `from-to` id.
+      // Used when converting to app state to generate delete: true entries.
+      removed: {
+        self: false,
+        ids: {} as Record<string, boolean>,
+      },
     };
 
     this.workflow = clone(workflow);
@@ -126,6 +134,54 @@ class Workflow {
     }
 
     return item;
+  }
+
+  // Flag a step, an edge the whole workflow as removed
+  // to-app-state reads this to generate delete: true entries.
+  remove(): this;
+  remove(stepId: string): this;
+  remove(from: string, to: string): this;
+  remove(a?: string, b?: string): this {
+    if (a === undefined) {
+      this.index.removed.self = true;
+      return this;
+    }
+
+    if (b === undefined) {
+      if (!(a in this.index.steps)) {
+        throw new Error(`step with id "${a}" does not exist in workflow`);
+      }
+      this.index.removed.ids[a] = true;
+    } else {
+      const edgeId = `${a}-${b}`;
+      if (!(edgeId in this.index.edges)) {
+        throw new Error(`edge with id "${edgeId}" does not exist in workflow`);
+      }
+      this.index.removed.ids[edgeId] = true;
+    }
+
+    return this;
+  }
+
+  // Check whether a step, an edge, or (with no argument) the whole workflow
+  // has been flagged as removed via remove().
+  isRemoved(): boolean;
+  isRemoved(stepId: string): boolean;
+  isRemoved(from: string, to: string): boolean;
+  isRemoved(a?: string, b?: string): boolean {
+    if (a === undefined) {
+      return this.index.removed.self;
+    }
+
+    const id = b === undefined ? a : `${a}-${b}`;
+    return !!this.index.removed.ids[id];
+  }
+
+  // Whether the whole workflow was removed via remove(), plus the ids (step id,
+  // or edge composite `from-to` id) of everything flagged removed via remove().
+  // Used by to-app-state to generate `delete: true` entries.
+  get removed(): { self: boolean; ids: Record<string, boolean> } {
+    return this.index.removed;
   }
 
   // TODO needs unit tests and maybe setter

--- a/packages/project/src/merge/merge-project.ts
+++ b/packages/project/src/merge/merge-project.ts
@@ -91,6 +91,10 @@ export function merge(
 
   const potentialConflicts: Record<string, string> = {};
   for (const sourceWorkflow of sourceWorkflows) {
+    if ((sourceWorkflow as any).$deleted) {
+      continue;
+    }
+
     const targetId =
       options.workflowMappings?.[sourceWorkflow.id] ?? sourceWorkflow.id;
     const targetWorkflow = target.getWorkflow(targetId);
@@ -110,6 +114,10 @@ export function merge(
   }
 
   for (const sourceWorkflow of sourceWorkflows) {
+    if ((sourceWorkflow as any).$deleted) {
+      continue;
+    }
+
     const targetId =
       options.workflowMappings?.[sourceWorkflow.id] ?? sourceWorkflow.id;
     const targetWorkflow = target.getWorkflow(targetId);

--- a/packages/project/src/merge/merge-project.ts
+++ b/packages/project/src/merge/merge-project.ts
@@ -69,8 +69,6 @@ export function merge(
   const noMappings = isEmpty(options.workflowMappings);
 
   if (options.onlyUpdated) {
-    // only include workflows that have changed (since history or forked_from) in the list
-    // unchanged target workflows will be added to the finalWorkflows list later
     ({ changed: sourceWorkflows, removed: removedWorkflowIds } =
       findChangedWorkflows(source));
   }
@@ -130,12 +128,7 @@ export function merge(
     }
   }
 
-  // A workflow findChangedWorkflows found in forked_from but not in source
-  // any more was deleted locally. Flag it removed rather than dropping it,
-  // so to-app-state can still tell the provisioner.
-  // Clone rather than mutate target's own instance - target (typically the
-  // fetched remote project) is often read again after merge (eg for
-  // diffing), and must keep describing what's actually on the server.
+  // Flag any workflows which need removing and add to to final workflows
   for (const removedId of removedWorkflowIds) {
     const targetWorkflow = target.getWorkflow(removedId);
     if (targetWorkflow) {
@@ -146,7 +139,7 @@ export function merge(
     }
   }
 
-  // do not remove unmapped means include them too.
+  // do not remove unmapped means include them too
   if (!options?.removeUnmapped) {
     // workflows from target that didn't get merged
     for (const targetWorkflow of target.workflows) {

--- a/packages/project/src/merge/merge-project.ts
+++ b/packages/project/src/merge/merge-project.ts
@@ -64,13 +64,15 @@ export function merge(
   const finalWorkflows: Workflow[] = [];
   const usedTargetIds = new Set<string>();
   let sourceWorkflows = source.workflows;
+  let removedWorkflowIds: string[] = [];
 
   const noMappings = isEmpty(options.workflowMappings);
 
   if (options.onlyUpdated) {
     // only include workflows that have changed (since history or forked_from) in the list
     // unchanged target workflows will be added to the finalWorkflows list later
-    sourceWorkflows = findChangedWorkflows(source);
+    ({ changed: sourceWorkflows, removed: removedWorkflowIds } =
+      findChangedWorkflows(source));
   }
 
   if (!noMappings) {
@@ -91,10 +93,6 @@ export function merge(
 
   const potentialConflicts: Record<string, string> = {};
   for (const sourceWorkflow of sourceWorkflows) {
-    if ((sourceWorkflow as any).$deleted) {
-      continue;
-    }
-
     const targetId =
       options.workflowMappings?.[sourceWorkflow.id] ?? sourceWorkflow.id;
     const targetWorkflow = target.getWorkflow(targetId);
@@ -114,10 +112,6 @@ export function merge(
   }
 
   for (const sourceWorkflow of sourceWorkflows) {
-    if ((sourceWorkflow as any).$deleted) {
-      continue;
-    }
-
     const targetId =
       options.workflowMappings?.[sourceWorkflow.id] ?? sourceWorkflow.id;
     const targetWorkflow = target.getWorkflow(targetId);
@@ -133,6 +127,22 @@ export function merge(
       );
     } else {
       finalWorkflows.push(sourceWorkflow);
+    }
+  }
+
+  // A workflow findChangedWorkflows found in forked_from but not in source
+  // any more was deleted locally. Flag it removed rather than dropping it,
+  // so to-app-state can still tell the provisioner.
+  // Clone rather than mutate target's own instance - target (typically the
+  // fetched remote project) is often read again after merge (eg for
+  // diffing), and must keep describing what's actually on the server.
+  for (const removedId of removedWorkflowIds) {
+    const targetWorkflow = target.getWorkflow(removedId);
+    if (targetWorkflow) {
+      usedTargetIds.add(targetWorkflow.id);
+      const deletedWorkflow = new Workflow(targetWorkflow.toJSON() as any);
+      deletedWorkflow.remove();
+      finalWorkflows.push(deletedWorkflow);
     }
   }
 

--- a/packages/project/src/parse/from-app-state.ts
+++ b/packages/project/src/parse/from-app-state.ts
@@ -70,9 +70,12 @@ export default (
     };
   }
 
-  proj.workflows = Object.values(stateJson.workflows).map((w) =>
-    mapWorkflow(w, proj.credentials)
-  );
+  // A deleted workflow only ever appears in state we've just sent to the
+  // provisioner (see to-app-state.ts) - Lightning itself never echoes one
+  // back, since it's just gone. Skipped here for posterity/round-tripping.
+  proj.workflows = Object.values(stateJson.workflows)
+    .filter((w) => !w.delete)
+    .map((w) => mapWorkflow(w, proj.credentials));
 
   return new Project(proj as l.ProjectState, config);
 };
@@ -110,6 +113,14 @@ export const mapWorkflow = (
 ) => {
   const { jobs, edges, triggers, name, version_history, ...remoteProps } =
     workflow;
+
+  // Deleted jobs/triggers/edges only ever appear in state we've just sent to
+  // the provisioner (see to-app-state.ts) - Lightning itself never echoes one
+  // back, since it's just gone. Filtered out here for posterity/round-tripping.
+  const liveJobs = Object.values(jobs).filter((j) => !j.delete);
+  const liveTriggers = Object.values(triggers).filter((t) => !t.delete);
+  const liveEdges = Object.values(edges).filter((e) => !e.delete);
+
   const mapped: l.WorkflowState = {
     name: workflow.name,
     steps: [],
@@ -122,7 +133,7 @@ export const mapWorkflow = (
 
   // TODO what do we do if the condition is disabled?
   // I don't think that's the same as edge condition false?
-  Object.values(workflow.triggers).forEach((trigger: Provisioner.Trigger) => {
+  liveTriggers.forEach((trigger: Provisioner.Trigger) => {
     const {
       type,
       enabled,
@@ -136,7 +147,7 @@ export const mapWorkflow = (
       mapped.start = type;
     }
 
-    const connectedEdges = Object.values(edges).filter(
+    const connectedEdges = liveEdges.filter(
       (e) => e.source_trigger_id === trigger.id
     );
     mapped.steps.push(
@@ -150,9 +161,7 @@ export const mapWorkflow = (
         webhook_response_config,
         openfn: renameKeys(otherProps, { id: 'uuid' }),
         next: connectedEdges.reduce((obj: any, edge) => {
-          const target = Object.values(jobs).find(
-            (j) => j.id === edge.target_job_id
-          );
+          const target = liveJobs.find((j) => j.id === edge.target_job_id);
           if (!target) {
             throw new Error(`Failed to find ${edge.target_job_id}`);
           }
@@ -164,8 +173,8 @@ export const mapWorkflow = (
     );
   });
 
-  Object.values(workflow.jobs).forEach((step: Provisioner.Job) => {
-    const outboundEdges = Object.values(edges).filter(
+  liveJobs.forEach((step: Provisioner.Job) => {
+    const outboundEdges = liveEdges.filter(
       (e) => e.source_job_id === step.id || e.source_trigger_id === step.id
     );
 
@@ -197,9 +206,7 @@ export const mapWorkflow = (
 
     if (outboundEdges.length) {
       s.next = outboundEdges.reduce((next, edge) => {
-        const target = Object.values(jobs).find(
-          (j) => j.id === edge.target_job_id
-        );
+        const target = liveJobs.find((j) => j.id === edge.target_job_id);
         // @ts-ignore
         next[slugify(target.name)] = mapEdge(edge);
         return next;

--- a/packages/project/src/parse/from-app-state.ts
+++ b/packages/project/src/parse/from-app-state.ts
@@ -70,9 +70,7 @@ export default (
     };
   }
 
-  // A deleted workflow only ever appears in state we've just sent to the
-  // provisioner (see to-app-state.ts) - Lightning itself never echoes one
-  // back, since it's just gone. Skipped here for posterity/round-tripping.
+  // a delete: true workflow only appears in state we sent to the provisioner (to-app-state.ts) - never echoed back
   proj.workflows = Object.values(stateJson.workflows)
     .filter((w) => !w.delete)
     .map((w) => mapWorkflow(w, proj.credentials));
@@ -114,9 +112,7 @@ export const mapWorkflow = (
   const { jobs, edges, triggers, name, version_history, ...remoteProps } =
     workflow;
 
-  // Deleted jobs/triggers/edges only ever appear in state we've just sent to
-  // the provisioner (see to-app-state.ts) - Lightning itself never echoes one
-  // back, since it's just gone. Filtered out here for posterity/round-tripping.
+  // a delete: true job/trigger/edge only appears in state we sent to the provisioner - never echoed back
   const liveJobs = Object.values(jobs).filter((j) => !j.delete);
   const liveTriggers = Object.values(triggers).filter((t) => !t.delete);
   const liveEdges = Object.values(edges).filter((e) => !e.delete);

--- a/packages/project/src/parse/from-app-state.ts
+++ b/packages/project/src/parse/from-app-state.ts
@@ -4,6 +4,7 @@ import * as l from '@openfn/lexicon';
 import { Provisioner } from '@openfn/lexicon/lightning';
 
 import { Project } from '../Project';
+import Workflow from '../Workflow';
 import renameKeys from '../util/rename-keys';
 import slugify from '../util/slugify';
 import omitNil from '../util/omit-nil';
@@ -70,10 +71,36 @@ export default (
     };
   }
 
-  proj.workflows = Object.values(stateJson.workflows)
-    // Ignore provisioner  delete: true flags
-    .filter((w) => !w.delete)
-    .map((w) => mapWorkflow(w, proj.credentials));
+  // Identify any workflows, steps and edges which may have been deleted in the state,
+  // and ensure their deletion is reflected in in the parsed Project
+  proj.workflows = Object.values(stateJson.workflows).map((w) => {
+    const workflow = new Workflow(mapWorkflow(w, proj.credentials));
+
+    if (w.delete) {
+      workflow.remove();
+      return workflow;
+    }
+
+    const deletedUuids = new Set(
+      Object.values(w.jobs as any)
+        .concat(Object.values(w.triggers), Object.values(w.edges))
+        .filter((x: any) => x.delete)
+        .map((x: any) => x.id)
+    );
+
+    for (const step of workflow.steps as any[]) {
+      if (deletedUuids.has(step.openfn?.uuid)) {
+        workflow.remove(step.id);
+      }
+      for (const toId in step.next ?? {}) {
+        if (deletedUuids.has(step.next[toId].openfn?.uuid)) {
+          workflow.remove(step.id, toId);
+        }
+      }
+    }
+
+    return workflow;
+  }) as unknown as l.WorkflowState[];
 
   return new Project(proj as l.ProjectState, config);
 };
@@ -112,11 +139,6 @@ export const mapWorkflow = (
   const { jobs, edges, triggers, name, version_history, ...remoteProps } =
     workflow;
 
-  // a delete: true job/trigger/edge only appears in state we sent to the provisioner - never echoed back
-  const liveJobs = Object.values(jobs).filter((j) => !j.delete);
-  const liveTriggers = Object.values(triggers).filter((t) => !t.delete);
-  const liveEdges = Object.values(edges).filter((e) => !e.delete);
-
   const mapped: l.WorkflowState = {
     name: workflow.name,
     steps: [],
@@ -129,7 +151,7 @@ export const mapWorkflow = (
 
   // TODO what do we do if the condition is disabled?
   // I don't think that's the same as edge condition false?
-  liveTriggers.forEach((trigger: Provisioner.Trigger) => {
+  Object.values(triggers).forEach((trigger: Provisioner.Trigger) => {
     const {
       type,
       enabled,
@@ -143,7 +165,7 @@ export const mapWorkflow = (
       mapped.start = type;
     }
 
-    const connectedEdges = liveEdges.filter(
+    const connectedEdges = Object.values(edges).filter(
       (e) => e.source_trigger_id === trigger.id
     );
     mapped.steps.push(
@@ -157,7 +179,9 @@ export const mapWorkflow = (
         webhook_response_config,
         openfn: renameKeys(otherProps, { id: 'uuid' }),
         next: connectedEdges.reduce((obj: any, edge) => {
-          const target = liveJobs.find((j) => j.id === edge.target_job_id);
+          const target = Object.values(jobs).find(
+            (j) => j.id === edge.target_job_id
+          );
           if (!target) {
             throw new Error(`Failed to find ${edge.target_job_id}`);
           }
@@ -169,8 +193,8 @@ export const mapWorkflow = (
     );
   });
 
-  liveJobs.forEach((step: Provisioner.Job) => {
-    const outboundEdges = liveEdges.filter(
+  Object.values(jobs).forEach((step: Provisioner.Job) => {
+    const outboundEdges = Object.values(edges).filter(
       (e) => e.source_job_id === step.id || e.source_trigger_id === step.id
     );
 
@@ -202,7 +226,9 @@ export const mapWorkflow = (
 
     if (outboundEdges.length) {
       s.next = outboundEdges.reduce((next, edge) => {
-        const target = liveJobs.find((j) => j.id === edge.target_job_id);
+        const target = Object.values(jobs).find(
+          (j) => j.id === edge.target_job_id
+        );
         // @ts-ignore
         next[slugify(target.name)] = mapEdge(edge);
         return next;

--- a/packages/project/src/parse/from-app-state.ts
+++ b/packages/project/src/parse/from-app-state.ts
@@ -70,8 +70,8 @@ export default (
     };
   }
 
-  // a delete: true workflow only appears in state we sent to the provisioner (to-app-state.ts) - never echoed back
   proj.workflows = Object.values(stateJson.workflows)
+    // Ignore provisioner  delete: true flags
     .filter((w) => !w.delete)
     .map((w) => mapWorkflow(w, proj.credentials));
 

--- a/packages/project/src/serialize/to-app-state.ts
+++ b/packages/project/src/serialize/to-app-state.ts
@@ -101,12 +101,37 @@ export const mapWorkflow = (
 ) => {
   const useUuids = !options.asSpec;
 
+  // Captured before toJSON(): building `lookup` below mints a fresh uuid for
+  // any step that doesn't already have one, so by that point we can no longer
+  // tell a real, previously-synced uuid from one just minted for this call.
+  const removed =
+    workflow instanceof Workflow
+      ? workflow.removed
+      : { self: false, ids: {} as Record<string, boolean> };
+  const originalUuids: Record<string, string> =
+    workflow instanceof Workflow ? workflow.getUUIDMap() : {};
+
   if (workflow instanceof Workflow) {
     // @ts-ignore
     workflow = workflow.toJSON();
   }
 
   const { uuid, ...originalOpenfnProps } = workflow.openfn ?? {};
+
+  if (useUuids && removed.self && uuid) {
+    // nothing else about a deleted workflow matters to the provisioner
+    return {
+      ...originalOpenfnProps,
+      id: uuid,
+      name: workflow.name,
+      delete: true,
+      jobs: {},
+      triggers: {},
+      edges: {},
+      lock_version: workflow.openfn?.lock_version ?? null,
+    } as Provisioner.Workflow;
+  }
+
   const wfState = {
     ...originalOpenfnProps,
     jobs: {},
@@ -142,55 +167,92 @@ export const mapWorkflow = (
     let isTrigger = false;
     let node: Provisioner.Job | Provisioner.Trigger;
 
+    const isRemoved = useUuids && !!removed.ids[s.id];
+    const nodeUuid = originalUuids[s.id];
+
+    if (isRemoved && !nodeUuid) {
+      // never synced to Lightning - nothing to delete server-side
+      return;
+    }
+
     if (s.type) {
       isTrigger = true;
 
-      const { type, id, next, openfn, ...rest } = s;
-      node = {
-        ...rest,
-        type: s.type ?? 'webhook', // this is mostly for tests
-        ...(useUuids ? renameKeys(openfn, { uuid: 'id' }) : {}),
-      } as Provisioner.Trigger;
-      wfState.triggers[node.type] = node;
+      if (isRemoved) {
+        node = { id: nodeUuid, delete: true } as Provisioner.Trigger;
+      } else {
+        const { type, id, next, openfn, ...rest } = s;
+        node = {
+          ...rest,
+          type: s.type ?? 'webhook', // this is mostly for tests
+          ...(useUuids ? renameKeys(openfn, { uuid: 'id' }) : {}),
+        } as Provisioner.Trigger;
+      }
+      wfState.triggers[s.type] = node;
     } else {
-      node = omitBy(pick(s, ['name', 'adaptor']), isNil) as Provisioner.Job;
-      const { uuid, ...otherOpenFnProps } = s.openfn ?? {};
-      if (useUuids) {
-        node.id = uuid;
-      }
-      if (s.expression) {
-        node.body = s.expression;
-      }
-      if (
-        typeof s.configuration === 'string' &&
-        !s.configuration.endsWith('.json')
-      ) {
-        let projectCredentialId = s.configuration;
-        if (projectCredentialId) {
-          const mappedCredential = credentials.find((c) => {
-            const name = getCredentialName(c);
-            return name === projectCredentialId;
-          });
-          if (mappedCredential && useUuids) {
-            projectCredentialId = mappedCredential.uuid;
-          }
+      if (isRemoved) {
+        node = { id: nodeUuid, delete: true } as Provisioner.Job;
+      } else {
+        node = omitBy(pick(s, ['name', 'adaptor']), isNil) as Provisioner.Job;
+        const { uuid, ...otherOpenFnProps } = s.openfn ?? {};
+        if (useUuids) {
+          node.id = uuid;
+        }
+        if (s.expression) {
+          node.body = s.expression;
+        }
+        if (
+          typeof s.configuration === 'string' &&
+          !s.configuration.endsWith('.json')
+        ) {
+          let projectCredentialId = s.configuration;
+          if (projectCredentialId) {
+            const mappedCredential = credentials.find((c) => {
+              const name = getCredentialName(c);
+              return name === projectCredentialId;
+            });
+            if (mappedCredential && useUuids) {
+              projectCredentialId = mappedCredential.uuid;
+            }
 
-          if (useUuids) {
-            otherOpenFnProps.project_credential_id = projectCredentialId;
-          } else {
-            otherOpenFnProps.credential = projectCredentialId;
+            if (useUuids) {
+              otherOpenFnProps.project_credential_id = projectCredentialId;
+            } else {
+              otherOpenFnProps.credential = projectCredentialId;
+            }
           }
         }
+
+        Object.assign(node, useUuids ? defaultJobProps : {}, otherOpenFnProps);
       }
 
-      Object.assign(node, useUuids ? defaultJobProps : {}, otherOpenFnProps);
-
       wfState.jobs[s.id ?? slugify(s.name)] = node;
+    }
+
+    if (isRemoved) {
+      // a removed step's own edges are meaningless without being removed
+      // explicitly too, via workflow.remove(from, to) - see Workflow.ts
+      return;
     }
 
     // create an edge to each linked node
     Object.keys(s.next ?? {}).forEach((next) => {
       const rules = s.next[next];
+
+      const edgeIsRemoved = useUuids && !!removed.ids[`${s.id}-${next}`];
+      const edgeUuid = originalUuids[`${s.id}-${next}`];
+
+      if (edgeIsRemoved && !edgeUuid) {
+        return;
+      }
+
+      if (edgeIsRemoved) {
+        wfState.edges[`${s.id}->${next}`] = {
+          id: edgeUuid,
+          delete: true,
+        } as any;
+        return;
+      }
 
       const { uuid, ...otherOpenFnProps } = rules.openfn ?? {};
 

--- a/packages/project/src/serialize/to-app-state.ts
+++ b/packages/project/src/serialize/to-app-state.ts
@@ -101,9 +101,7 @@ export const mapWorkflow = (
 ) => {
   const useUuids = !options.asSpec;
 
-  // Captured before toJSON(): building `lookup` below mints a fresh uuid for
-  // any step that doesn't already have one, so by that point we can no longer
-  // tell a real, previously-synced uuid from one just minted for this call.
+  // captured before toJSON(), since the `lookup` build below mints fresh uuids for anything missing one
   const removed =
     workflow instanceof Workflow
       ? workflow.removed
@@ -230,8 +228,7 @@ export const mapWorkflow = (
     }
 
     if (isRemoved) {
-      // a removed step's own edges are meaningless without being removed
-      // explicitly too, via workflow.remove(from, to) - see Workflow.ts
+      // a removed step's edges are meaningless without also being removed via workflow.remove(from, to)
       return;
     }
 

--- a/packages/project/src/util/find-changed-workflows.ts
+++ b/packages/project/src/util/find-changed-workflows.ts
@@ -26,7 +26,7 @@ export default (project: Project) => {
       }
       delete base[wf.id];
     } else {
-      // If a workflow doens't appear in forked_from, we assume it's new
+      // If a workflow doesn't appear in forked_from, we assume it's new
       // (and so changed!)
       changed.push(wf);
     }
@@ -35,6 +35,7 @@ export default (project: Project) => {
   // Anything in forked_from that hasn't been handled
   // must have been removed (and so changed!)
   for (const removedId in base) {
+    // so the tests don't do this...
     changed.push({ id: removedId, $deleted: true } as unknown as Workflow);
   }
 

--- a/packages/project/src/util/find-changed-workflows.ts
+++ b/packages/project/src/util/find-changed-workflows.ts
@@ -1,12 +1,20 @@
 import Project from '../Project';
-import type Workflow from '../Workflow';
+import Workflow from '../Workflow';
 import { generateHash } from './version';
+
+export type ChangedWorkflows = {
+  changed: Workflow[];
+  // ids of workflows present in forked_from/history but no longer in the
+  // project - ids only, since the removed workflow itself is gone from
+  // `project`. The caller needs the *target's* copy to flag via remove().
+  removed: string[];
+};
 
 /**
  * For a given Project, identify which workflows have changed
  * Uses forked_from as the base, or history if that's unavailable
  */
-export default (project: Project) => {
+export default (project: Project): ChangedWorkflows => {
   const base: Record<string, string> =
     project.cli.forked_from ??
     project.workflows.reduce((obj: any, wf) => {
@@ -16,7 +24,7 @@ export default (project: Project) => {
       return obj;
     }, {});
 
-  const changed = [];
+  const changed: Workflow[] = [];
 
   for (const wf of project.workflows) {
     if (wf.id in base) {
@@ -32,12 +40,8 @@ export default (project: Project) => {
     }
   }
 
-  // Anything in forked_from that hasn't been handled
-  // must have been removed (and so changed!)
-  for (const removedId in base) {
-    // so the tests don't do this...
-    changed.push({ id: removedId, $deleted: true } as unknown as Workflow);
-  }
+  // Anything in forked_from that hasn't been handled must have been removed
+  const removed = Object.keys(base);
 
-  return changed;
+  return { changed, removed };
 };

--- a/packages/project/src/util/find-changed-workflows.ts
+++ b/packages/project/src/util/find-changed-workflows.ts
@@ -4,15 +4,13 @@ import { generateHash } from './version';
 
 export type ChangedWorkflows = {
   changed: Workflow[];
-  // ids of workflows present in forked_from/history but no longer in the
-  // project - ids only, since the removed workflow itself is gone from
-  // `project`. The caller needs the *target's* copy to flag via remove().
+  // ids of workflows present in forked_from/history but no longer in the project
   removed: string[];
 };
 
 /**
- * For a given Project, identify which workflows have changed
- * Uses forked_from as the base, or history if that's unavailable
+ * Identify which projects have changed or been removed since the last checkpoint.
+ * Prefers to use `forked_from` but will fallback to history
  */
 export default (project: Project): ChangedWorkflows => {
   const base: Record<string, string> =

--- a/packages/project/test/merge/merge-project.test.ts
+++ b/packages/project/test/merge/merge-project.test.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import { randomUUID } from 'node:crypto';
 import type { CredentialState } from '@openfn/lexicon';
 
-import Project from '../../src';
+import Project, { generateVersionHash } from '../../src';
 import {
   merge,
   REPLACE_MERGE,
@@ -620,7 +620,7 @@ test('remove a workflow', (t) => {
   t.is(result.workflows.length, 1);
 });
 
-test('remove a workflow with onlyUpdated: true', (t) => {
+test('remove a workflow with onlyUpdated: true and no history', (t) => {
   const wf1 = assignUUIDs({
     name: 'wf1',
     steps: [],
@@ -632,6 +632,38 @@ test('remove a workflow with onlyUpdated: true', (t) => {
 
   const main = createProject([wf1, wf2], 'a');
   const staging = createProject([wf1], 'b');
+
+  t.is(main.workflows.length, 2);
+  t.is(staging.workflows.length, 1);
+
+  const result: any = merge(staging, main, { onlyUpdated: true });
+  t.is(result.workflows.length, 1);
+});
+
+test('remove a workflow with onlyUpdated: true and a full history', (t) => {
+  const wf1 = assignUUIDs({
+    name: 'wf1',
+    steps: [],
+  });
+  const wf1Version = generateVersionHash(wf1);
+
+  const wf2 = assignUUIDs({
+    name: 'wf2',
+    steps: [],
+  });
+  const wf2Version = generateVersionHash(wf2);
+
+  const main = createProject([wf1, wf2], 'a');
+  const staging = createProject([wf1], 'b');
+  // staging needs to have main in its history for this to work
+  // the presence of history makes a big difference with onlyUpdated on
+  staging.workflows[0].history.push(wf1Version);
+
+  // Include forked_from as well, which also affects changed workflows
+  staging.cli.forked_from = {
+    wf1: wf1Version,
+    wf2: wf2Version,
+  };
 
   t.is(main.workflows.length, 2);
   t.is(staging.workflows.length, 1);

--- a/packages/project/test/merge/merge-project.test.ts
+++ b/packages/project/test/merge/merge-project.test.ts
@@ -641,16 +641,13 @@ test('remove a workflow with onlyUpdated: true and no history', (t) => {
 });
 
 test('remove a workflow with onlyUpdated: true and a full history', (t) => {
-  const wf1 = assignUUIDs({
-    name: 'wf1',
-    steps: [],
-  });
+  // NB: assignUUIDs hardcodes id: 'wf' on everything it touches, which would
+  // silently collide wf1/wf2 into the same id here - use explicit distinct
+  // ids instead, matching the forked_from keys below, as a real project would
+  const wf1: any = { id: 'wf1', name: 'wf1', openfn: { uuid: randomUUID() }, steps: [] };
   const wf1Version = generateVersionHash(wf1);
 
-  const wf2 = assignUUIDs({
-    name: 'wf2',
-    steps: [],
-  });
+  const wf2: any = { id: 'wf2', name: 'wf2', openfn: { uuid: randomUUID() }, steps: [] };
   const wf2Version = generateVersionHash(wf2);
 
   const main = createProject([wf1, wf2], 'a');
@@ -668,8 +665,84 @@ test('remove a workflow with onlyUpdated: true and a full history', (t) => {
   t.is(main.workflows.length, 2);
   t.is(staging.workflows.length, 1);
 
-  const result: any = merge(staging, main, { onlyUpdated: true });
-  t.is(result.workflows.length, 1);
+  const result = merge(staging, main, { onlyUpdated: true });
+
+  // wf1 survives untouched, wf2 survives flagged removed (not dropped)
+  t.is(result.workflows.length, 2);
+  t.false(result.getWorkflow('wf1')!.isRemoved());
+  t.true(result.getWorkflow('wf2')!.isRemoved());
+});
+
+// The tests above all give every workflow the same id ('wf', from assignUUIDs),
+// so they can't tell a real per-workflow removal from an id collision masking
+// a workflow that was simply never re-added. These use distinct ids/names.
+test('deleting a workflow flags it removed, rather than dropping or keeping it', (t) => {
+  const wf1 = {
+    id: 'wf1',
+    name: 'wf1',
+    openfn: { uuid: randomUUID() },
+    steps: [],
+  };
+  const wf2 = {
+    id: 'wf2',
+    name: 'wf2',
+    openfn: { uuid: randomUUID() },
+    steps: [],
+  };
+
+  const main = createProject([wf1, wf2], 'a');
+  const wf1Version = main.getWorkflow('wf1')!.getVersionHash();
+  const wf2Version = main.getWorkflow('wf2')!.getVersionHash();
+
+  // staging represents the local project after wf2 was deleted locally
+  const staging = createProject([wf1], 'b');
+  staging.getWorkflow('wf1')!.history.push(wf1Version);
+  staging.cli.forked_from = { wf1: wf1Version, wf2: wf2Version };
+
+  const result = merge(staging, main, { onlyUpdated: true });
+
+  // wf2 must still be present in the result and flagged removed - dropping it
+  // silently means no delete: true ever reaches the provisioner, and keeping
+  // it un-flagged means it looks unchanged
+  const wf2Result = result.getWorkflow('wf2');
+  t.truthy(wf2Result);
+  t.true(wf2Result!.isRemoved());
+
+  // wf1 was untouched and must survive normally
+  const wf1Result = result.getWorkflow('wf1');
+  t.truthy(wf1Result);
+  t.false(wf1Result!.isRemoved());
+});
+
+test('deleting a workflow produces a delete: true entry when serialized', (t) => {
+  const wf1 = {
+    id: 'wf1',
+    name: 'wf1',
+    openfn: { uuid: randomUUID() },
+    steps: [],
+  };
+  const wf2 = {
+    id: 'wf2',
+    name: 'wf2',
+    openfn: { uuid: randomUUID() },
+    steps: [],
+  };
+
+  const main = createProject([wf1, wf2], 'a');
+  const wf1Version = main.getWorkflow('wf1')!.getVersionHash();
+  const wf2Version = main.getWorkflow('wf2')!.getVersionHash();
+
+  const staging = createProject([wf1], 'b');
+  staging.getWorkflow('wf1')!.history.push(wf1Version);
+  staging.cli.forked_from = { wf1: wf1Version, wf2: wf2Version };
+
+  const result = merge(staging, main, { onlyUpdated: true });
+  const state = result.serialize('state', { format: 'json' }) as any;
+
+  t.true(state.workflows['wf2'].delete);
+  t.deepEqual(state.workflows['wf2'].jobs, {});
+
+  t.falsy(state.workflows['wf1'].delete);
 });
 
 test('id match: same workflow in source and target project', (t) => {

--- a/packages/project/test/parse/from-app-state.test.ts
+++ b/packages/project/test/parse/from-app-state.test.ts
@@ -97,6 +97,15 @@ test('should create a Project from prov state with credentials', (t) => {
   t.deepEqual(project.credentials, []);
 });
 
+test('should exclude a workflow flagged delete: true', (t) => {
+  const stateWithDeletedWorkflow: any = cloneDeep(state);
+  stateWithDeletedWorkflow.workflows['my-workflow'].delete = true;
+
+  const project = fromAppState(stateWithDeletedWorkflow, meta);
+
+  t.is(project.workflows.length, 0);
+});
+
 test('should create a Project from prov state with positions', (t) => {
   const newState = cloneDeep(state);
 
@@ -346,6 +355,37 @@ test('mapWorkflow: map a job with project credentials onto job.configuration', (
       keychain_credential_id: 'k',
     },
   });
+});
+
+test('mapWorkflow: excludes a job flagged delete: true', (t) => {
+  const wf: any = cloneDeep(state.workflows['my-workflow']);
+  wf.jobs['transform-data'].delete = true;
+  // a real delete payload flags a job's edges too - an edge left pointing at
+  // a deleted job is malformed input, not something mapWorkflow guards against
+  wf.edges['trigger->transform-data'].delete = true;
+
+  const mapped = mapWorkflow(wf);
+
+  t.falsy(mapped.steps.find((s: any) => s.id === 'transform-data'));
+});
+
+test('mapWorkflow: excludes a trigger flagged delete: true', (t) => {
+  const wf: any = cloneDeep(state.workflows['my-workflow']);
+  wf.triggers.webhook.delete = true;
+
+  const mapped = mapWorkflow(wf);
+
+  t.falsy(mapped.steps.find((s: any) => s.id === 'webhook'));
+});
+
+test('mapWorkflow: excludes an edge flagged delete: true', (t) => {
+  const wf: any = cloneDeep(state.workflows['my-workflow']);
+  wf.edges['trigger->transform-data'].delete = true;
+
+  const mapped = mapWorkflow(wf);
+
+  const [trigger] = mapped.steps as any[];
+  t.deepEqual(trigger.next, {});
 });
 
 test('mapEdge: map enabled state', (t) => {

--- a/packages/project/test/parse/from-app-state.test.ts
+++ b/packages/project/test/parse/from-app-state.test.ts
@@ -97,13 +97,61 @@ test('should create a Project from prov state with credentials', (t) => {
   t.deepEqual(project.credentials, []);
 });
 
-test('should exclude a workflow flagged delete: true', (t) => {
+test('should load a workflow flagged delete: true and flag it removed', (t) => {
   const stateWithDeletedWorkflow: any = cloneDeep(state);
   stateWithDeletedWorkflow.workflows['my-workflow'].delete = true;
 
   const project = fromAppState(stateWithDeletedWorkflow, meta);
 
-  t.is(project.workflows.length, 0);
+  t.is(project.workflows.length, 1);
+  t.true(project.workflows[0].isRemoved());
+});
+
+test('should load a job flagged delete: true and flag it removed', (t) => {
+  const stateWithDeletedJob: any = cloneDeep(state);
+  stateWithDeletedJob.workflows['my-workflow'].jobs['transform-data'].delete =
+    true;
+
+  const project = fromAppState(stateWithDeletedJob, meta);
+  const wf = project.workflows[0];
+
+  t.truthy(wf.get('transform-data'));
+  t.true(wf.isRemoved('transform-data'));
+});
+
+test('should load a trigger flagged delete: true and flag it removed', (t) => {
+  const stateWithDeletedTrigger: any = cloneDeep(state);
+  stateWithDeletedTrigger.workflows['my-workflow'].triggers.webhook.delete =
+    true;
+
+  const project = fromAppState(stateWithDeletedTrigger, meta);
+  const wf = project.workflows[0];
+
+  t.truthy(wf.get('webhook'));
+  t.true(wf.isRemoved('webhook'));
+});
+
+test('should load an edge flagged delete: true and flag it removed', (t) => {
+  const stateWithDeletedEdge: any = cloneDeep(state);
+  stateWithDeletedEdge.workflows['my-workflow'].edges[
+    'trigger->transform-data'
+  ].delete = true;
+
+  const project = fromAppState(stateWithDeletedEdge, meta);
+  const wf = project.workflows[0];
+
+  t.true(wf.isRemoved('webhook', 'transform-data'));
+});
+
+test('a delete: true job survives a parse -> serialize round trip', (t) => {
+  const stateWithDeletedJob: any = cloneDeep(state);
+  stateWithDeletedJob.workflows['my-workflow'].jobs['transform-data'].delete =
+    true;
+
+  const project = fromAppState(stateWithDeletedJob, meta);
+  const reserialized = project.serialize('state', { format: 'json' }) as any;
+
+  t.true(reserialized.workflows['my-workflow'].jobs['transform-data'].delete);
 });
 
 test('should create a Project from prov state with positions', (t) => {
@@ -357,35 +405,41 @@ test('mapWorkflow: map a job with project credentials onto job.configuration', (
   });
 });
 
-test('mapWorkflow: excludes a job flagged delete: true', (t) => {
+// mapWorkflow is a pure mapper - it maps delete: true jobs/triggers/edges just
+// like any other. Flagging them removed on the resulting Workflow is the
+// caller's job (see fromAppState), since that's the only place a uuid can be
+// resolved back to a local id.
+test('mapWorkflow: maps a job flagged delete: true like any other job', (t) => {
   const wf: any = cloneDeep(state.workflows['my-workflow']);
   wf.jobs['transform-data'].delete = true;
-  // a real delete payload flags a job's edges too - an edge left pointing at
-  // a deleted job is malformed input, not something mapWorkflow guards against
-  wf.edges['trigger->transform-data'].delete = true;
 
   const mapped = mapWorkflow(wf);
 
-  t.falsy(mapped.steps.find((s: any) => s.id === 'transform-data'));
+  const job: any = mapped.steps.find((s: any) => s.id === 'transform-data');
+  t.is(job?.openfn.uuid, '66add020-e6eb-4eec-836b-20008afca816');
 });
 
-test('mapWorkflow: excludes a trigger flagged delete: true', (t) => {
+test('mapWorkflow: maps a trigger flagged delete: true like any other trigger', (t) => {
   const wf: any = cloneDeep(state.workflows['my-workflow']);
   wf.triggers.webhook.delete = true;
 
   const mapped = mapWorkflow(wf);
 
-  t.falsy(mapped.steps.find((s: any) => s.id === 'webhook'));
+  const trigger: any = mapped.steps.find((s: any) => s.id === 'webhook');
+  t.is(trigger?.openfn.uuid, '4a06289c-15aa-4662-8dc6-f0aaacd8a058');
 });
 
-test('mapWorkflow: excludes an edge flagged delete: true', (t) => {
+test('mapWorkflow: maps an edge flagged delete: true like any other edge', (t) => {
   const wf: any = cloneDeep(state.workflows['my-workflow']);
   wf.edges['trigger->transform-data'].delete = true;
 
   const mapped = mapWorkflow(wf);
 
   const [trigger] = mapped.steps as any[];
-  t.deepEqual(trigger.next, {});
+  t.is(
+    trigger.next['transform-data'].openfn.uuid,
+    'a9a3adef-b394-4405-814d-3ac4323f4b4b'
+  );
 });
 
 test('mapEdge: map enabled state', (t) => {

--- a/packages/project/test/serialize/to-app-state.test.ts
+++ b/packages/project/test/serialize/to-app-state.test.ts
@@ -487,6 +487,127 @@ a-(condition=x)-f
   t.is(a_f.condition_expression, 'x');
 });
 
+const removableWorkflowData: any = {
+  id: 'my-project',
+  workflows: [
+    {
+      id: 'wf',
+      name: 'wf',
+      openfn: { uuid: 'wf-uuid' },
+      steps: [
+        {
+          id: 'trigger',
+          type: 'webhook',
+          openfn: { uuid: 'trigger-uuid' },
+          next: {
+            step: { openfn: { uuid: 'edge-uuid' } },
+          },
+        },
+        {
+          id: 'step',
+          name: 'step',
+          expression: '.',
+          adaptor: 'common',
+          openfn: { uuid: 'step-uuid' },
+        },
+      ],
+    },
+  ],
+};
+
+test('a removed job becomes a minimal delete: true entry', (t) => {
+  const project = new Project(cloneDeep(removableWorkflowData));
+  project.getWorkflow('wf')!.remove('step');
+
+  const state = toAppState(project, { format: 'json' }) as Provisioner.Project;
+
+  t.deepEqual(state.workflows['wf'].jobs.step, {
+    id: 'step-uuid',
+    delete: true,
+  });
+});
+
+test('a removed trigger becomes a minimal delete: true entry', (t) => {
+  const project = new Project(cloneDeep(removableWorkflowData));
+  project.getWorkflow('wf')!.remove('trigger');
+
+  const state = toAppState(project, { format: 'json' }) as Provisioner.Project;
+
+  t.deepEqual(state.workflows['wf'].triggers.webhook, {
+    id: 'trigger-uuid',
+    delete: true,
+  });
+});
+
+test('a removed edge becomes a minimal delete: true entry', (t) => {
+  const project = new Project(cloneDeep(removableWorkflowData));
+  project.getWorkflow('wf')!.remove('trigger', 'step');
+
+  const state = toAppState(project, { format: 'json' }) as Provisioner.Project;
+
+  t.deepEqual(state.workflows['wf'].edges['trigger->step'], {
+    id: 'edge-uuid',
+    delete: true,
+  });
+});
+
+test('removing a job/trigger/edge that was never synced drops it entirely', (t) => {
+  // v2ProjectData's workflow has no openfn.uuid anywhere - nothing to tell
+  // Lightning to delete, so removed items are just dropped rather than sent
+  // with a made-up id
+  const project = new Project(cloneDeep(v2ProjectData), {
+    formats: { project: 'json' },
+  });
+  const wf = project.getWorkflow('my-workflow')!;
+  wf.remove('transform-data');
+  wf.remove('webhook', 'transform-data');
+
+  const state = toAppState(project, { format: 'json' }) as Provisioner.Project;
+
+  t.deepEqual(state.workflows['my-workflow'].jobs, {});
+  t.deepEqual(state.workflows['my-workflow'].edges, {});
+});
+
+test("removing a step doesn't remove its edges automatically", (t) => {
+  const project = new Project(cloneDeep(removableWorkflowData));
+  project.getWorkflow('wf')!.remove('step');
+
+  const state = toAppState(project, { format: 'json' }) as Provisioner.Project;
+
+  // the edge is still serialized normally, since only the step was flagged -
+  // removing connected edges is the caller's job, see Workflow.ts
+  t.falsy(state.workflows['wf'].edges['trigger->step'].delete);
+});
+
+test('a removed workflow becomes a minimal delete: true entry', (t) => {
+  const project = new Project(cloneDeep(removableWorkflowData));
+  project.getWorkflow('wf')!.remove();
+
+  const state = toAppState(project, { format: 'json' }) as Provisioner.Project;
+
+  t.deepEqual(state.workflows['wf'], {
+    id: 'wf-uuid',
+    name: 'wf',
+    delete: true,
+    jobs: {},
+    triggers: {},
+    edges: {},
+    lock_version: null,
+  });
+});
+
+test('asSpec ignores removed flags', (t) => {
+  const data = cloneDeep(removableWorkflowData);
+  const project = new Project(data);
+  project.getWorkflow('wf')!.remove('step');
+
+  const result = toAppState(project, { format: 'json', asSpec: true }) as any;
+
+  // asSpec has no notion of delete: true - the step is serialized normally
+  t.truthy(result.workflows['wf'].jobs.step);
+  t.falsy(result.workflows['wf'].jobs.step.delete);
+});
+
 test('should serialize channels to app state', (t) => {
   const channels = [
     {

--- a/packages/project/test/util/find-changed-workflows.test.ts
+++ b/packages/project/test/util/find-changed-workflows.test.ts
@@ -13,9 +13,10 @@ test('should return 0 changed workflows from forked_from', (t) => {
     [b.id]: generateHash(b),
   };
 
-  const changed = findChangedWorkflows(project);
+  const { changed, removed } = findChangedWorkflows(project);
 
   t.deepEqual(changed, []);
+  t.deepEqual(removed, []);
 });
 
 test('should return 1 changed workflows from forked_from', (t) => {
@@ -31,12 +32,13 @@ test('should return 1 changed workflows from forked_from', (t) => {
   // Now change b
   b.steps[0].name = 'x1';
 
-  const changed = findChangedWorkflows(project);
+  const { changed, removed } = findChangedWorkflows(project);
   t.is(changed.length, 1);
   t.is(changed[0].id, 'b');
+  t.deepEqual(removed, []);
 });
 
-test('should return 1 removed workflow', (t) => {
+test('should return 1 removed workflow id', (t) => {
   const project = generateProject('proj', ['@id a a-b', '@id b x-y']);
   const [a, b] = project.workflows;
 
@@ -48,9 +50,9 @@ test('should return 1 removed workflow', (t) => {
   // remove workflow b
   project.workflows.pop();
 
-  const changed = findChangedWorkflows(project);
-  t.is(changed.length, 1);
-  t.is(changed[0].id, 'b');
+  const { changed, removed } = findChangedWorkflows(project);
+  t.deepEqual(changed, []);
+  t.deepEqual(removed, ['b']);
 });
 
 test('should return 1 added workflow', (t) => {
@@ -62,9 +64,10 @@ test('should return 1 added workflow', (t) => {
     // Do not include b in forked_from - it's new!
   };
 
-  const changed = findChangedWorkflows(project);
+  const { changed, removed } = findChangedWorkflows(project);
   t.is(changed.length, 1);
   t.is(changed[0].id, 'b');
+  t.deepEqual(removed, []);
 });
 
 test.todo('changed from history');

--- a/packages/project/test/workflow.test.ts
+++ b/packages/project/test/workflow.test.ts
@@ -213,6 +213,127 @@ test('map uuids to ids', (t) => {
   t.deepEqual(w.index.id[uuid_bc], 'b-c');
 });
 
+test('remove - flag a step as removed', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('a');
+
+  t.true(w.removed.ids['a']);
+});
+
+test('remove - flagging a step does not touch the live workflow', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('a');
+
+  t.notThrows(() => w.get('a'));
+  t.is(w.steps.length, 3);
+});
+
+test('remove - flag an edge as removed, via its two endpoints', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('a', 'c');
+
+  t.true(w.removed.ids['a-c']);
+});
+
+test('remove - flagging an edge does not touch the live workflow', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('a', 'c');
+
+  t.notThrows(() => w.get('a-c'));
+  const a: any = w.get('a');
+  t.truthy(a.next.c);
+});
+
+test('remove - flagging a step does not cascade to its edges', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('c');
+
+  t.true(w.removed.ids['c']);
+  t.falsy(w.removed.ids['a-c']);
+  t.falsy(w.removed.ids['b-c']);
+});
+
+test('remove - throws for an unknown step', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.throws(() => w.remove('x'), {
+    message: 'step with id "x" does not exist in workflow',
+  });
+});
+
+test('remove - throws for an unknown edge', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.throws(() => w.remove('a', 'x'), {
+    message: 'edge with id "a-x" does not exist in workflow',
+  });
+});
+
+test('remove - no argument marks the whole workflow removed', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.false(w.removed.self);
+
+  w.remove();
+
+  t.true(w.removed.self);
+});
+
+test('remove - removing the whole workflow leaves its steps untouched', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove();
+
+  t.is(w.steps.length, 3);
+});
+
+test('isRemoved - no argument checks the whole workflow', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.false(w.isRemoved());
+
+  w.remove();
+
+  t.true(w.isRemoved());
+});
+
+test('isRemoved - false for a step/edge that has not been removed', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.false(w.isRemoved('a'));
+  t.false(w.isRemoved('a', 'c'));
+});
+
+test('isRemoved - true for a removed step', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('a');
+
+  t.true(w.isRemoved('a'));
+});
+
+test('isRemoved - true for a removed edge', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('a', 'c');
+
+  t.true(w.isRemoved('a', 'c'));
+});
+
+test('isRemoved - does not cascade to edges when their step is removed', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('c');
+
+  t.false(w.isRemoved('a', 'c'));
+  t.false(w.isRemoved('b', 'c'));
+});
+
 test('canMergeInto: should merge same content source & target', (t) => {
   const main = generateWorkflow('trigger-x');
   const sbox = generateWorkflow('trigger-x');


### PR DESCRIPTION
## Short Description

This PR enables the removal of workflows, steps and edges from sync v2

Fixes #1243 

## Implementation Details

This is mostly handled by inner state tracked on the Workflow class, which tracks when entities are removed on merge. The to-app-state serializer then handles the removal in the provisioner's format.


CITATION NEEDED: note that that removal is pretty dumb: the user must ensure the workflow is consistent. Ie if you delete a step, any connected edges need manually fixing. I should test this behaviour now, but later explore automated removal.

## QA Notes

- Clone a project with sync v2 `openfn project pull <uuid>`
- Locally delete a workflow - push with `openfn project deploy` and it should be removed from the app
- Locally delete a step - push
- locally delete an edge - push

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
