### PR TITLE
fix(project): keep non-ASCII characters in slugified identifiers

### DIFF
--- a/packages/project/src/util/slugify.ts
+++ b/packages/project/src/util/slugify.ts
@@ -1,5 +1,21 @@
+/**
+ * Convert a human-readable name into a slug used as an identifier.
+ *
+ * Any run of characters which is neither a letter, a digit nor an underscore
+ * becomes a separator. Letters and digits are matched with the Unicode
+ * properties `\p{L}` and `\p{N}` rather than `\w`, which is ASCII-only and
+ * would drop every non-Latin character: `café` slugified to `caf`, and a name
+ * written entirely in a non-Latin script collapsed to an empty string.
+ *
+ * For ASCII-only input this produces exactly the same slug as before, so
+ * identifiers in existing projects are unaffected.
+ */
 export default function slugify(text: string) {
   return (
-    text?.replace(/\W/g, ' ').trim().replace(/\s+/g, '-').toLowerCase() ?? ''
+    text
+      ?.replace(/[^\p{L}\p{N}_]+/gu, ' ')
+      .trim()
+      .replace(/\s+/g, '-')
+      .toLowerCase() ?? ''
   );
 }

--- a/packages/project/test/util/slugify.test.ts
+++ b/packages/project/test/util/slugify.test.ts
@@ -1,0 +1,42 @@
+import test from 'ava';
+import slugify from '../../src/util/slugify';
+
+test('lowercases and hyphenates a plain name', (t) => {
+  t.is(slugify('My Workflow'), 'my-workflow');
+});
+
+test('collapses runs of separators', (t) => {
+  t.is(slugify('My   Workflow -- Two'), 'my-workflow-two');
+});
+
+test('keeps underscores and digits', (t) => {
+  t.is(slugify('step_1 of 2'), 'step_1-of-2');
+});
+
+test('trims leading and trailing separators', (t) => {
+  t.is(slugify('  ...My Workflow!  '), 'my-workflow');
+});
+
+test('keeps accented latin characters', (t) => {
+  t.is(slugify('café'), 'café');
+  t.is(slugify('résumé'), 'résumé');
+});
+
+test('keeps a whole accented phrase readable', (t) => {
+  t.is(slugify("Vérifier l'état du patient"), 'vérifier-l-état-du-patient');
+});
+
+test('keeps non-latin scripts instead of collapsing to an empty string', (t) => {
+  t.is(slugify('患者確認'), '患者確認');
+  t.is(slugify('проверка пациента'), 'проверка-пациента');
+  t.is(slugify('التحقق من المريض'), 'التحقق-من-المريض');
+});
+
+test('still drops characters which are neither letters nor digits', (t) => {
+  t.is(slugify('deploy 🚀 now'), 'deploy-now');
+});
+
+test('handles empty and nullish input', (t) => {
+  t.is(slugify(''), '');
+  t.is(slugify(undefined as unknown as string), '');
+});

--- a/packages/project/tsconfig.json
+++ b/packages/project/tsconfig.json
@@ -3,6 +3,9 @@
   "include": ["src/**/*.ts", "test/**/*test.ts"],
   "compilerOptions": {
     "module": "ESNext",
+    // Unicode property escapes in slugify need ES2018 or later. Build output is
+    // controlled by tsup; this only affects type validation.
+    "target": "ES2020",
     "sourceMap": true
   }
 }


### PR DESCRIPTION
Closes #1388

`slugify()` used `text.replace(/\W/g, ' ')`. JavaScript's `\W` is ASCII-only, so every non-Latin character was treated as punctuation:

| input | before | after |
| --- | --- | --- |
| `café` | `caf` | `café` |
| `résumé` | `r-sum` | `résumé` |
| `Vérifier l'état du patient` | `v-rifier-l-tat-du-patient` | `vérifier-l-état-du-patient` |
| `患者確認` | `` (empty) | `患者確認` |
| `проверка пациента` | `` (empty) | `проверка-пациента` |

As #1388 points out, these slugs are identity rather than display — they set the workflow id, the job id and the keys used for edge references — so the pull/deploy round-trip currently loses information for anyone naming steps outside ASCII.

## Change

Match letters and digits with `\p{L}` and `\p{N}` under the `u` flag instead of `\W`. Underscore is kept explicitly, since `\W` treated it as a word character too.

**Existing identifiers do not change.** For ASCII-only input the new expression produces exactly the same slug as the old one — I checked every printable-ASCII pair plus 200,000 random ASCII strings (209,025 inputs) and found zero differences. That matters here because a change in output would silently re-key workflows in existing projects.

Emoji and punctuation still become separators, so `deploy 🚀 now` is still `deploy-now`.

### On the library suggestion

@josephjclark suggested reaching for a library like `slugify` in the issue thread. I went with the Unicode-property regex instead because the popular libraries transliterate — `slugify('café')` gives `cafe`, and `slugify('патент')` gives `patent`. That conflicts with the point made in the same thread, that it's good for the user's identifier to survive without conversion, and it wouldn't help a script with no Latin transliteration at all. Happy to switch to a library if you'd rather have transliteration; it's a one-line swap plus a dependency.

I have not tried to match the Apollo rules @hanna-paasivirta linked (OpenFn/apollo#446) — that looked like a separate alignment question, and I did not want to widen this beyond the reported bug.

### tsconfig

Unicode property escapes require an ES2018 target and `tsconfig.common` sets no `target`, so `tsc` defaulted to ES5 and rejected the `u` flag with TS1501. This sets `"target": "ES2020"` on the project package only. That file is validation-only — the comment at the top of `tsconfig.common` notes build artefacts come from tsup — so runtime output is unaffected. If you would rather not touch tsconfig, building the regex through `new RegExp(..., 'gu')` sidesteps the check, but that seemed worse than declaring the real requirement.

## Tests

Adds `test/util/slugify.test.ts` (9 tests): existing ASCII behaviour, underscores and digits, separator collapsing and trimming, accented Latin, three non-Latin scripts, emoji still dropped, and empty/nullish input.

- `packages/project` suite: **252 passed**, up from 243, with the same 4 skipped, 1 todo and 7 uncaught exceptions before and after — those are the pre-existing `mock-fs` problems described in #1346.
- `tsc --noEmit`: the TS1501 error is gone; the three remaining `Cannot find module '@openfn/logger'` errors are present on a clean checkout too (unbuilt workspace dependency).
