### PR TITLE
CLI: checkout direct from project.yaml

### DIFF
--- a/.changeset/fast-boats-grin.md
+++ b/.changeset/fast-boats-grin.md
@@ -1,0 +1,5 @@
+---
+'@openfn/project': patch
+---
+
+Fix an issue where serializing a project without credential uuids to app state causes credentials on job bodies to be lost

--- a/.changeset/fast-cobras-throw.md
+++ b/.changeset/fast-cobras-throw.md
@@ -1,0 +1,5 @@
+---
+'@openfn/lexicon': patch
+---
+
+Project credentials can optionally have a UUID

--- a/.changeset/shaky-papayas-change.md
+++ b/.changeset/shaky-papayas-change.md
@@ -1,0 +1,5 @@
+---
+'@openfn/project': patch
+---
+
+Enable projects loaded from state files to be stateless

--- a/.changeset/slow-seals-type.md
+++ b/.changeset/slow-seals-type.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Ensure that new projects don't overwrite existing aliases

--- a/.changeset/tidy-hoops-jam.md
+++ b/.changeset/tidy-hoops-jam.md
@@ -1,0 +1,6 @@
+---
+'@openfn/project': patch
+'@openfn/cli': patch
+---
+
+Fix an issue where --name doens't apply to a project loaded from file

--- a/.changeset/young-brooms-drum.md
+++ b/.changeset/young-brooms-drum.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Enable a v2 project yaml file to be deployed directly, eg, `openfn project deploy .projects/main@app.openfn.org.yaml

--- a/integration-tests/cli/test/deploy.v2.test.ts
+++ b/integration-tests/cli/test/deploy.v2.test.ts
@@ -427,6 +427,91 @@ test.serial('warn when local and remote workflows have diverged', async (t) => {
 });
 
 test.serial(
+  'deploy a pulled v2 state file as a new project',
+  async (t) => {
+    const projectId = 'iiiiiiii';
+    server.addProject(makeProject(projectId) as any);
+
+    const before = Object.keys(server.state.projects);
+
+    // pull with an alias, producing a fetched v2 state file that has a uuid
+    const pullResult = await run(
+      `openfn project pull ${projectId} --alias og --log-json -l debug`
+    );
+    t.falsy(pullResult.stderr);
+
+    const pulledPath = path.join(tmpDir, '.projects', 'og@localhost.yaml');
+
+    // deploy that exact file back as a duplicate
+    const { stdout, stderr } = await run(
+      `openfn project deploy ${pulledPath} --new --name my-duplicate --no-confirm --log-json -l debug`
+    );
+    t.falsy(stderr);
+
+    const logs = extractLogs(stdout);
+    assertLog(t, logs, /Created new project/);
+
+    const after = Object.keys(server.state.projects);
+    t.is(after.length, before.length + 1);
+
+    const newId = after.find((id) => !before.includes(id));
+    t.not(newId, projectId);
+
+    const proj = server.state.projects[newId!];
+    t.is(proj.name, 'my-duplicate');
+
+    const workflows = Object.values(proj.workflows) as any[];
+    t.is(workflows.length, 1);
+    t.is(workflows[0].name, 'My Workflow');
+  }
+);
+
+test.serial(
+  'deploy a pulled state file to a different tracked project',
+  async (t) => {
+    const mainId = 'llllllll-main';
+    const stagingId = 'llllllll-staging';
+
+    server.addProject(makeProject(mainId) as any);
+    const stagingFixture = makeProject(stagingId) as any;
+    // give staging a distinct id/name and content, otherwise it's
+    // indistinguishable from main once both are tracked locally
+    stagingFixture.name = 'staging-project';
+    stagingFixture.workflows[0].jobs[0].body = "post('STAGING')";
+    server.addProject(stagingFixture);
+
+    // track both locally, same as any other pull
+    await run(
+      `openfn project pull ${mainId} --alias main --log-json -l debug`
+    );
+    await run(
+      `openfn project pull ${stagingId} --alias staging --log-json -l debug`
+    );
+
+    const mainPath = path.join(tmpDir, '.projects', 'main@localhost.yaml');
+
+    // deploy main's pulled file, but target staging instead of main
+    const { stdout, stderr } = await run(
+      `openfn project deploy ${mainPath} staging --no-confirm --log-json -l debug`
+    );
+    t.falsy(stderr);
+    assertLog(t, extractLogs(stdout), /Updated project/);
+
+    // staging's remote content now matches main's, replacing its own...
+    const stagingProj = server.state.projects[stagingId];
+    t.is(stagingProj.name, 'staging-project');
+    t.regex(
+      stagingProj.workflows['my-workflow-1'].jobs['my-job'].body,
+      /fn\(s => s\)/
+    );
+
+    // ...while main itself was left untouched
+    const mainProj = server.state.projects[mainId];
+    t.regex(mainProj.workflows[0].jobs[0].body, /fn\(s => s\)/);
+  }
+);
+
+test.serial(
   'deploy collections: add a collection via openfn.yaml',
   async (t) => {
     const projectId = 'gggggggg';

--- a/integration-tests/cli/test/deploy.v2.test.ts
+++ b/integration-tests/cli/test/deploy.v2.test.ts
@@ -426,45 +426,55 @@ test.serial('warn when local and remote workflows have diverged', async (t) => {
   assertLog(t, logs, /Projects have diverged/i);
 });
 
-test.serial(
-  'deploy a pulled v2 state file as a new project',
-  async (t) => {
-    const projectId = 'iiiiiiii';
-    server.addProject(makeProject(projectId) as any);
+test.serial('deploy a pulled v2 state file as a new project', async (t) => {
+  const projectId = 'iiiiiiii';
+  server.addProject(makeProject(projectId) as any);
 
-    const before = Object.keys(server.state.projects);
+  const before = Object.keys(server.state.projects);
 
-    // pull with an alias, producing a fetched v2 state file that has a uuid
-    const pullResult = await run(
-      `openfn project pull ${projectId} --alias og --log-json -l debug`
-    );
-    t.falsy(pullResult.stderr);
+  // pull with an alias, producing a fetched v2 state file that has a uuid
+  const pullResult = await run(
+    `openfn project pull ${projectId} --alias og --log-json -l debug`
+  );
+  t.falsy(pullResult.stderr);
 
-    const pulledPath = path.join(tmpDir, '.projects', 'og@localhost.yaml');
+  const pulledPath = path.join(tmpDir, '.projects', 'og@localhost.yaml');
 
-    // deploy that exact file back as a duplicate
-    const { stdout, stderr } = await run(
-      `openfn project deploy ${pulledPath} --new --name my-duplicate --no-confirm --log-json -l debug`
-    );
-    t.falsy(stderr);
+  // deploy that exact file back as a duplicate
+  const { stdout, stderr } = await run(
+    `openfn project deploy ${pulledPath} --new --name my-duplicate --no-confirm --log-json -l debug`
+  );
+  t.falsy(stderr);
 
-    const logs = extractLogs(stdout);
-    assertLog(t, logs, /Created new project/);
+  const logs = extractLogs(stdout);
+  assertLog(t, logs, /Created new project/);
 
-    const after = Object.keys(server.state.projects);
-    t.is(after.length, before.length + 1);
+  const after = Object.keys(server.state.projects);
+  t.is(after.length, before.length + 1);
 
-    const newId = after.find((id) => !before.includes(id));
-    t.not(newId, projectId);
+  const newId = after.find((id) => !before.includes(id));
+  t.not(newId, projectId);
 
-    const proj = server.state.projects[newId!];
-    t.is(proj.name, 'my-duplicate');
+  const proj = server.state.projects[newId!];
+  t.is(proj.name, 'my-duplicate');
 
-    const workflows = Object.values(proj.workflows) as any[];
-    t.is(workflows.length, 1);
-    t.is(workflows[0].name, 'My Workflow');
-  }
-);
+  const workflows = Object.values(proj.workflows) as any[];
+  t.is(workflows.length, 1);
+  t.is(workflows[0].name, 'My Workflow');
+
+  // --new must strip embedded state, not just the project's own uuid -
+  // the new workflow and step must get fresh ids too, not reuse the
+  // original project's
+  const original = server.state.projects[projectId];
+  const originalWorkflowId = original.workflows[0].id;
+  const originalJobId = original.workflows[0].jobs[0].id;
+
+  const newWorkflowId = Object.keys(proj.workflows)[0];
+  t.not(newWorkflowId, originalWorkflowId);
+
+  const newJobId = workflows[0].jobs['my-job'].id;
+  t.not(newJobId, originalJobId);
+});
 
 test.serial(
   'deploy a pulled state file to a different tracked project',
@@ -481,9 +491,7 @@ test.serial(
     server.addProject(stagingFixture);
 
     // track both locally, same as any other pull
-    await run(
-      `openfn project pull ${mainId} --alias main --log-json -l debug`
-    );
+    await run(`openfn project pull ${mainId} --alias main --log-json -l debug`);
     await run(
       `openfn project pull ${stagingId} --alias staging --log-json -l debug`
     );

--- a/integration-tests/cli/test/deploy.v2.test.ts
+++ b/integration-tests/cli/test/deploy.v2.test.ts
@@ -496,8 +496,6 @@ workflows:
   const exportedPath = path.join(tmpDir, 'exported-project.yaml');
   await fs.writeFile(exportedPath, specYaml);
 
-  // TODO: --name has no effect on file-based deploys yet (deploy.ts only
-  // reads options.name in the workspace/fs branch) - fix and add a test
   const { stdout, stderr } = await run(
     `openfn project deploy ${exportedPath} --name my-duplicate --no-confirm --log-json -l debug`
   );
@@ -511,6 +509,8 @@ workflows:
 
   const newId = after.find((id) => !before.includes(id));
   const proj = server.state.projects[newId!];
+
+  t.is(proj.name, 'my-duplicate');
 
   const workflows = Object.values(proj.workflows) as any[];
   t.is(workflows.length, 1);

--- a/integration-tests/cli/test/deploy.v2.test.ts
+++ b/integration-tests/cli/test/deploy.v2.test.ts
@@ -470,6 +470,65 @@ test.serial(
   }
 );
 
+test.serial('deploy a v2 project spec file as a new project', async (t) => {
+  const before = Object.keys(server.state.projects);
+
+  const specYaml = `id: exported-project
+name: My Exported Project
+schema_version: '4.0'
+workflows:
+  - id: my-workflow
+    name: My Workflow
+    start: webhook
+    steps:
+      - id: webhook
+        type: webhook
+        enabled: true
+        next:
+          transform-data:
+            condition: always
+      - id: transform-data
+        name: Transform data
+        expression: 'fn(s => s)'
+        adaptor: '@openfn/language-common@latest'
+`;
+
+  const exportedPath = path.join(tmpDir, 'exported-project.yaml');
+  await fs.writeFile(exportedPath, specYaml);
+
+  // TODO: --name has no effect on file-based deploys yet (deploy.ts only
+  // reads options.name in the workspace/fs branch) - fix and add a test
+  const { stdout, stderr } = await run(
+    `openfn project deploy ${exportedPath} --name my-duplicate --no-confirm --log-json -l debug`
+  );
+  t.falsy(stderr);
+
+  const logs = extractLogs(stdout);
+  assertLog(t, logs, /Created new project/);
+
+  const after = Object.keys(server.state.projects);
+  t.is(after.length, before.length + 1);
+
+  const newId = after.find((id) => !before.includes(id));
+  const proj = server.state.projects[newId!];
+
+  const workflows = Object.values(proj.workflows) as any[];
+  t.is(workflows.length, 1);
+  t.is(workflows[0].name, 'My Workflow');
+
+  const jobs = Object.values(workflows[0].jobs) as any[];
+  t.is(jobs.length, 1);
+  t.is(jobs[0].body, 'fn(s => s)');
+  t.is(jobs[0].adaptor, '@openfn/language-common@latest');
+
+  const triggers = Object.values(workflows[0].triggers) as any[];
+  t.is(triggers.length, 1);
+  t.is(triggers[0].type, 'webhook');
+
+  const edges = Object.values(workflows[0].edges) as any[];
+  t.is(edges.length, 1);
+});
+
 test.serial(
   'deploy collections: remove a collection via openfn.yaml',
   async (t) => {

--- a/packages/cli/src/deploy/handler.ts
+++ b/packages/cli/src/deploy/handler.ts
@@ -150,9 +150,8 @@ export const maybeConvertV2spec = async (yaml: string): Promise<string> => {
   const json = yamlToJson(yaml) as any;
   if (detectVersion(json) > 1) {
     const project = await Project.from('project', json);
-    return project.serialize('state', {
+    return project.serialize('spec', {
       format: 'yaml',
-      asSpec: true,
     }) as string;
   }
   return yaml;

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -39,14 +39,17 @@ export type DeployOptions = Pick<
   | 'logJson'
   | 'confirm'
 > & {
-  project?: string; // this is a CLI positional arg, not an option
-  workspace?: string;
-  dryRun?: boolean;
-  new?: boolean;
-  name?: string;
+  // CLI positional args, rather than options
+  project?: string;
+  target?: string;
+
   alias?: string;
+  dryRun?: boolean;
   jsonDiff?: boolean;
+  name?: string;
+  new?: boolean;
   workflow?: string[];
+  workspace?: string;
 };
 
 const options = [
@@ -74,7 +77,7 @@ const printProjectName = (project: Project) =>
   `${project.id} (${project.openfn?.uuid || '<no UUID>'})`;
 
 export const command: yargs.CommandModule<DeployOptions> = {
-  command: 'deploy [project]',
+  command: 'deploy [project] [target]',
   aliases: 'push',
   describe: `Deploy the passed or checked-out project to a Lightning Instance`,
   builder: (yargs: yargs.Argv<DeployOptions>) =>
@@ -83,13 +86,25 @@ export const command: yargs.CommandModule<DeployOptions> = {
         describe:
           'The UUID, local id or local alias of the project to deploy to',
       })
+      .positional('target', {
+        describe:
+          'When deploying a local file, the UUID or alias of the remote project to deploy it to. Defaults to the UUID embedded in the file',
+      })
       .example(
         'deploy',
-        'Deploy the checked-out project its connected remote instance'
+        'Deploy the checked-out project to its connected remote instance'
       )
       .example(
         'deploy staging',
-        'Deploy the checkout-out project to the remote project with alias "staging"'
+        'Deploy the checked-out project to the remote project with alias "staging"'
+      )
+      .example(
+        'deploy project.yaml',
+        'Deploy project.yaml to its own tracked remote project'
+      )
+      .example(
+        'deploy project.yaml staging',
+        'Deploy project.yaml to the remote project with alias "staging"'
       ),
   handler: ensure('project-deploy', options),
 };
@@ -298,15 +313,36 @@ export async function handler(options: DeployOptions, logger: Logger) {
   );
   const config = loadAppAuthConfig(options, logger);
 
+  // Work out what we're deploying (a local file, or the checked-out
+  // workspace project) and, separately, which remote project to deploy it
+  // to. These are independent - a file can target any tracked remote, not
+  // just the one it came from.
+  let filePath: string | undefined;
+  let targetIdentifier: string | undefined;
+
+  if (options.project && options.target) {
+    // two positionals: `deploy <file> <target>` - the first is always a file
+    filePath = options.project;
+    targetIdentifier = options.target;
+  } else if (options.project) {
+    // one positional: a file (`deploy project.yaml`) or a target
+    // (`deploy staging`, deploying the checked-out project)
+    if (/\.(yaml|json)$/.test(options.project)) {
+      filePath = options.project;
+    } else {
+      targetIdentifier = options.project;
+    }
+  }
+
   // The local project that we want to actually deploy
   let localProject: Project;
-  let ws;
+  let ws: Workspace | undefined;
   let alias = options.alias ?? null;
 
-  if (options.project) {
+  if (filePath) {
     const localPath = path.resolve(
       options.workspace ?? process.cwd(),
-      options.project
+      filePath
     );
     logger.debug('Reading project from path ', localPath);
     localProject = await Project.from('path', localPath, {
@@ -342,16 +378,17 @@ export async function handler(options: DeployOptions, logger: Logger) {
   }
 
   // Track the remote we want to target
-  // If the user passed a project alias, we need to use that
-  // Otherwise just sync with the local project
+  // If the user passed an explicit target, we need to use that
+  // Otherwise just sync with the local project's own tracked remote
   let tracker;
   if (!options.new) {
-    tracker = ws?.get(options.project ?? localProject.uuid!);
+    ws ??= new Workspace(options.workspace || '.');
+    tracker = ws.get(targetIdentifier ?? localProject.uuid!);
     if (!tracker) {
-      // Is this really an error? Unlikely to happen I thuink
+      // Is this really an error? Unlikely to happen I think
       console.log(
         `ERROR: Failed to find tracked remote project ${
-          options.project ?? localProject.uuid!
+          targetIdentifier ?? localProject.uuid!
         } locally`
       );
       console.log('To deploy a new project, add --new to the command');
@@ -412,7 +449,7 @@ export async function handler(options: DeployOptions, logger: Logger) {
 
   /**
    * Questions:
-   * 1. When this serializses, should project_credentials have uuids?
+   * 1. When this serializes, should project_credentials have uuids?
    */
   const state = merged.serialize('state', {
     format: 'json',

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -349,6 +349,9 @@ export async function handler(options: DeployOptions, logger: Logger) {
     localProject = await Project.from('path', localPath, {
       name: options.name,
       alias,
+      // deploying an already-stateful file as new must not carry over its
+      // old workflow/step/edge ids - strip them as we parse
+      asSpec: !!options.new,
     });
 
     // If the local project doesn't have stateful stuff,

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -359,13 +359,6 @@ export async function handler(options: DeployOptions, logger: Logger) {
       );
       options.new = true;
 
-      // Enforce a sensible alias for the new project
-      // else it might overwrite the default
-      if (!localProject.alias || localProject.alias === 'main') {
-        alias = options.name?.replace(/\s+/g, '-');
-        localProject.alias = alias ?? null;
-      }
-
       // TODO ensure the alias is unique if we're posting a new project
     }
   } else {
@@ -415,6 +408,13 @@ export async function handler(options: DeployOptions, logger: Logger) {
     localProject.openfn = {
       endpoint: config.endpoint,
     };
+
+    // Enforce a sensible alias for the new project
+    // else it might overwrite the default
+    if (!localProject.alias || localProject.alias === 'main') {
+      alias = options.name?.replace(/\s+/g, '-');
+      localProject.alias = alias ?? null;
+    }
   }
 
   // Choose the target endpoint we want to deploy to

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -76,7 +76,7 @@ const printProjectName = (project: Project) =>
 export const command: yargs.CommandModule<DeployOptions> = {
   command: 'deploy [project]',
   aliases: 'push',
-  describe: `Deploy the checked out project to a Lightning Instance`,
+  describe: `Deploy the passed or checked-out project to a Lightning Instance`,
   builder: (yargs: yargs.Argv<DeployOptions>) =>
     build(options, yargs)
       .positional('project', {
@@ -298,25 +298,52 @@ export async function handler(options: DeployOptions, logger: Logger) {
   );
   const config = loadAppAuthConfig(options, logger);
 
-  // TODO this is the hard way to load the local alias
-  // We need track alias in openfn.yaml to make this easier (and tracked in from fs)
-  const ws = new Workspace(options.workspace || '.');
+  // The local project that we want to actually deploy
+  let localProject: Project;
+  let ws;
+  let alias = options.alias ?? null;
 
-  const active = ws.getTrackedProject();
-  const alias = options.alias ?? active?.alias;
+  if (options.project) {
+    logger.debug('Reading project from path ', options.project);
+    localProject = await Project.from(
+      'path',
+      path.resolve(options.workspace ?? process.cwd(), options.project)
+    );
 
-  const localProject = await Project.from('fs', {
-    root: options.workspace || '.',
-    alias,
-    name: options.name,
-  });
+    // If the local project doesn't have stateful stuff,
+    // flag this as a new upload
+    if (!localProject.uuid) {
+      logger.debug(
+        'Local project does not have a UUID: assuming this is a new project deployment'
+      );
+      options.new = true;
+
+      // TODO ensure the alias is unique if we're posting a new project
+    }
+  } else {
+    logger.debug('Reading checked-out project from workspace');
+    // TODO this is the hard way to load the local alias
+    // We need track alias in openfn.yaml to make this easier (and tracked in from fs)
+    ws = new Workspace(options.workspace || '.');
+
+    const active = ws.getTrackedProject();
+
+    // messy
+    alias ??= active?.alias ?? null;
+
+    localProject = await Project.from('fs', {
+      root: options.workspace || '.',
+      alias,
+      name: options.name,
+    });
+  }
 
   // Track the remote we want to target
   // If the user passed a project alias, we need to use that
   // Otherwise just sync with the local project
   let tracker;
   if (!options.new) {
-    tracker = ws.get(options.project ?? localProject.uuid!);
+    tracker = ws?.get(options.project ?? localProject.uuid!);
     if (!tracker) {
       // Is this really an error? Unlikely to happen I thuink
       console.log(
@@ -369,7 +396,7 @@ export async function handler(options: DeployOptions, logger: Logger) {
     const syncResult = await syncProjects(
       options,
       config,
-      ws,
+      ws!,
       localProject,
       tracker!,
       logger
@@ -382,6 +409,12 @@ export async function handler(options: DeployOptions, logger: Logger) {
 
   const state = merged.serialize('state', {
     format: 'json',
+    // If uploading a new project, serialize to spec, not state
+    // WRONG!!!!!
+    // We DO need to convert this to  v1 state
+    // We just need to ensure that credentials are handled properly
+    // something is wrong in the conversion
+    asSpec: options.new,
   }) as Provisioner.Project_v1;
 
   if (remoteProject) {
@@ -465,11 +498,16 @@ export async function handler(options: DeployOptions, logger: Logger) {
 
     updateForkedFrom(finalProject);
     const configData = finalProject.generateConfig();
+
+    // Write the updated openfn.yaml
+    // TODO: allow us to suppress writing this stuff
+    // (useful if posting from spec)
     await writeFile(
-      path.resolve(options.workspace!, configData.path),
+      path.resolve(options.workspace ?? process.cwd(), configData.path),
       configData.content
     );
 
+    // TODO if this was marked as new, we probably need to ensure a unique alias here
     const finalOutputPath = getSerializePath(localProject, options.workspace!);
     const fullFinalPath = await serialize(finalProject, finalOutputPath);
     logger.debug('Updated local project at ', fullFinalPath);

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -337,7 +337,7 @@ export async function handler(options: DeployOptions, logger: Logger) {
   // The local project that we want to actually deploy
   let localProject: Project;
   let ws: Workspace | undefined;
-  let alias = options.alias ?? null;
+  let alias = options.alias;
 
   if (filePath) {
     const localPath = path.resolve(
@@ -345,8 +345,10 @@ export async function handler(options: DeployOptions, logger: Logger) {
       filePath
     );
     logger.debug('Reading project from path ', localPath);
+
     localProject = await Project.from('path', localPath, {
       name: options.name,
+      alias,
     });
 
     // If the local project doesn't have stateful stuff,
@@ -356,6 +358,13 @@ export async function handler(options: DeployOptions, logger: Logger) {
         'Local project does not have a UUID: assuming this is a new project deployment'
       );
       options.new = true;
+
+      // Enforce a sensible alias for the new project
+      // else it might overwrite the default
+      if (!localProject.alias || localProject.alias === 'main') {
+        alias = options.name?.replace(/\s+/g, '-');
+        localProject.alias = alias ?? null;
+      }
 
       // TODO ensure the alias is unique if we're posting a new project
     }
@@ -367,8 +376,9 @@ export async function handler(options: DeployOptions, logger: Logger) {
 
     const active = ws.getTrackedProject();
 
-    // messy
-    alias ??= active?.alias ?? null;
+    if (!alias && active?.alias) {
+      alias = active.alias;
+    }
 
     localProject = await Project.from('fs', {
       root: options.workspace || '.',
@@ -529,9 +539,11 @@ export async function handler(options: DeployOptions, logger: Logger) {
       result as any,
       {
         endpoint: endpoint,
-        alias,
       },
-      merged.config
+      {
+        ...merged.config,
+        alias: alias as string | undefined,
+      }
     );
 
     updateForkedFrom(finalProject);
@@ -546,7 +558,7 @@ export async function handler(options: DeployOptions, logger: Logger) {
     );
 
     // TODO if this was marked as new, we probably need to ensure a unique alias here
-    const finalOutputPath = getSerializePath(localProject, options.workspace!);
+    const finalOutputPath = getSerializePath(finalProject, options.workspace!);
     const fullFinalPath = await serialize(finalProject, finalOutputPath);
     logger.debug('Updated local project at ', fullFinalPath);
 

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -407,14 +407,12 @@ export async function handler(options: DeployOptions, logger: Logger) {
     ({ merged, remoteProject, locallyChangedWorkflows } = syncResult);
   }
 
+  /**
+   * Questions:
+   * 1. When this serializses, should project_credentials have uuids?
+   */
   const state = merged.serialize('state', {
     format: 'json',
-    // If uploading a new project, serialize to spec, not state
-    // WRONG!!!!!
-    // We DO need to convert this to  v1 state
-    // We just need to ensure that credentials are handled properly
-    // something is wrong in the conversion
-    asSpec: options.new,
   }) as Provisioner.Project_v1;
 
   if (remoteProject) {

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -309,7 +309,9 @@ export async function handler(options: DeployOptions, logger: Logger) {
       options.project
     );
     logger.debug('Reading project from path ', localPath);
-    localProject = await Project.from('path', localPath);
+    localProject = await Project.from('path', localPath, {
+      name: options.name,
+    });
 
     // If the local project doesn't have stateful stuff,
     // flag this as a new upload

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -176,13 +176,17 @@ export type SyncResult = {
 // This function is responsible for syncing changes in the user's local project
 // with the remote app version
 // It returns a merged state object
+//
+// skipLocallyChangedCheck: merge every workflow in the source, not just those
+// edited since its own last snapshot (that check is meaningless for a file)
 const syncProjects = async (
   options: DeployOptions,
   config: Required<AuthOptions>,
   ws: Workspace,
   localProject: Project,
   trackedProject: Project, // the project we want to update
-  logger: Logger
+  logger: Logger,
+  skipLocallyChangedCheck = false
 ): Promise<SyncResult | null> => {
   // First step, fetch the latest version and write
   // this may throw!
@@ -227,6 +231,9 @@ const syncProjects = async (
       );
     }
     mergeCandidates = options.workflow;
+  } else if (skipLocallyChangedCheck) {
+    // the source is the spec, so every workflow in it is a candidate
+    mergeCandidates = localProject.workflows.map((w) => w.id);
   } else {
     mergeCandidates = await findLocallyChangedWorkflows(ws, localProject);
   }
@@ -293,10 +300,10 @@ const syncProjects = async (
     mode: localProject.uuid === remoteProject.uuid ? 'replace' : 'sandbox',
     force: true,
   };
-  if (options.workflow?.length) {
-    // If --workflow is passed, force-include exactly the listed workflows via workflowMappings
+  if (options.workflow?.length || skipLocallyChangedCheck) {
+    // force-include exactly the candidate workflows
     mergeOptions.workflowMappings = Object.fromEntries(
-      options.workflow.map((id) => [id, id])
+      mergeCandidates.map((id) => [id, id])
     );
   } else {
     // Otherwise only merge locally updated workflows
@@ -387,9 +394,32 @@ export async function handler(options: DeployOptions, logger: Logger) {
   // If the user passed an explicit target, we need to use that
   // Otherwise just sync with the local project's own tracked remote
   let tracker;
-  if (!options.new) {
+  if (options.new) {
+    // reset all metadata
+    localProject.openfn = {
+      endpoint: config.endpoint,
+    };
+
+    // Enforce a sensible alias for the new project
+    // else it might overwrite the default
+    if (!localProject.alias || localProject.alias === 'main') {
+      alias = options.name?.replace(/\s+/g, '-');
+      localProject.alias = alias ?? null;
+    }
+  } else {
     ws ??= new Workspace(options.workspace || '.');
     tracker = ws.get(targetIdentifier ?? localProject.uuid!);
+
+    // A project loaded from a file already knows which remote it belongs
+    // to, so it can serve as its own deploy destination - we don't need a
+    // locally tracked copy of it to sync against
+    if (!tracker && filePath && localProject.uuid) {
+      logger.debug(
+        'No locally tracked project found: deploying to the remote named in the file'
+      );
+      tracker = localProject;
+    }
+
     if (!tracker) {
       // Is this really an error? Unlikely to happen I think
       console.log(
@@ -406,18 +436,10 @@ export async function handler(options: DeployOptions, logger: Logger) {
 
       throw new Error('Failed to find remote project locally');
     }
-  } else {
-    // reset all metadata
-    localProject.openfn = {
-      endpoint: config.endpoint,
-    };
 
-    // Enforce a sensible alias for the new project
-    // else it might overwrite the default
-    if (!localProject.alias || localProject.alias === 'main') {
-      alias = options.name?.replace(/\s+/g, '-');
-      localProject.alias = alias ?? null;
-    }
+    // the local copy belongs to the project we deployed at, not the one
+    // we deployed from
+    alias ??= tracker.alias ?? undefined;
   }
 
   // Choose the target endpoint we want to deploy to
@@ -452,7 +474,9 @@ export async function handler(options: DeployOptions, logger: Logger) {
       ws!,
       localProject,
       tracker!,
-      logger
+      logger,
+      // a file's own snapshot tells us nothing about the target
+      !!filePath
     );
     if (!syncResult) {
       return;

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -304,11 +304,12 @@ export async function handler(options: DeployOptions, logger: Logger) {
   let alias = options.alias ?? null;
 
   if (options.project) {
-    logger.debug('Reading project from path ', options.project);
-    localProject = await Project.from(
-      'path',
-      path.resolve(options.workspace ?? process.cwd(), options.project)
+    const localPath = path.resolve(
+      options.workspace ?? process.cwd(),
+      options.project
     );
+    logger.debug('Reading project from path ', localPath);
+    localProject = await Project.from('path', localPath);
 
     // If the local project doesn't have stateful stuff,
     // flag this as a new upload

--- a/packages/cli/src/projects/util.ts
+++ b/packages/cli/src/projects/util.ts
@@ -179,12 +179,10 @@ export async function deployProject(
       if (contentType.match('application/json')) {
         const body = await response.json();
         logger?.error(JSON.stringify(body, null, 2));
-        console.log(JSON.stringify(body, null, 2));
       } else {
         const content = await response.text();
         // TODO html errors are too long to be useful... figure this out later
         logger?.error(content);
-        console.log(JSON.stringify(content, null, 2));
       }
       throw new CLIError(
         `Failed to deploy project ${state.name}: ${response.status}`

--- a/packages/cli/src/projects/util.ts
+++ b/packages/cli/src/projects/util.ts
@@ -179,12 +179,13 @@ export async function deployProject(
       if (contentType.match('application/json')) {
         const body = await response.json();
         logger?.error(JSON.stringify(body, null, 2));
+        console.log(JSON.stringify(body, null, 2));
       } else {
         const content = await response.text();
         // TODO html errors are too long to be useful... figure this out later
         logger?.error(content);
+        console.log(JSON.stringify(content, null, 2));
       }
-
       throw new CLIError(
         `Failed to deploy project ${state.name}: ${response.status}`
       );

--- a/packages/cli/test/projects/create-credentials.test.ts
+++ b/packages/cli/test/projects/create-credentials.test.ts
@@ -51,7 +51,7 @@ test('sync-credentials: ignores duplicate references', (t) => {
   t.deepEqual(findCredentialIds(project), ['same']);
 });
 
-test.only('sync-credentials: creates credential yaml file', (t) => {
+test('sync-credentials: creates credential yaml file', (t) => {
   mock({ '/ws': {} });
 
   const project = new Project(

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -111,6 +111,8 @@ test.serial(
   }
 );
 
+// TODO I think this NAUGHTILY overwrites the main alias
+// we probably shouldn't do that.
 test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
   // the server should have 1 registered project by default - that's fine
   t.is(Object.keys(server.state.projects).length, 1);
@@ -167,6 +169,42 @@ test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
   const success = logger._find('success', /Created new project at/);
   t.truthy(success);
 });
+
+test.serial(
+  'deploy a stateful project as new from a file, with an alias',
+  async (t) => {
+    // Set up a project with a UUID
+    mockFs({
+      '/ws/.projects/main@localhost.yaml': projectYaml,
+      '/ws/openfn.yaml': '',
+    });
+
+    // Deploy it elsewhere
+    await deploy(
+      {
+        endpoint: ENDPOINT,
+        apiKey: 'test-api-key',
+        workspace: '/ws',
+        project: '/ws/.projects/main@localhost.yaml',
+        new: true,
+        alias: 'staging',
+      } as any,
+      logger
+    );
+
+    // the new project should be saved locally under the alias we asked
+    // for, not the alias of the file we deployed from
+    t.true(fs.existsSync('/ws/.projects/staging@localhost.yaml'));
+
+    // the file we deployed FROM must not be clobbered with the new
+    // project's state
+    const mainAfter = fs.readFileSync(
+      '/ws/.projects/main@localhost.yaml',
+      'utf8'
+    );
+    t.regex(mainAfter, new RegExp(`uuid: ${UUID}`));
+  }
+);
 
 test.serial('deploy a new project creates ids for collections', async (t) => {
   const yamlWithCollections = projectYaml.replace(

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -25,6 +25,7 @@ import {
   UUID,
   two_workflows_yaml as twowfs,
   TWO_WORKFLOWS_UUID,
+  myProject_spec,
 } from './fixtures';
 import { checkout } from '../../src/projects';
 
@@ -84,24 +85,58 @@ test.beforeEach(() => {
   mock.restore();
 });
 
-test.serial('deploy a new project', async (t) => {
+test.serial(
+  'deploy a project as new from the checked out project',
+  async (t) => {
+    // the server should have 1 registered project by default - that's fine
+    t.is(Object.keys(server.state.projects).length, 1);
+
+    await setup();
+
+    await deploy(
+      {
+        endpoint: ENDPOINT,
+        apiKey: 'test-api-key',
+        workspace: '/ws',
+        new: true,
+      } as any,
+      logger
+    );
+
+    // We should now have a new project with a new UUID
+    t.is(Object.keys(server.state.projects).length, 2);
+
+    const success = logger._find('success', /Created new project at/);
+    t.truthy(success);
+  }
+);
+
+// TODO this generates a UUID for credentials, but that's naughty init
+// Also the credential does not appear to be set on the job
+test.serial.only('deploy a project as new from a v2 spec yaml', async (t) => {
   // the server should have 1 registered project by default - that's fine
   t.is(Object.keys(server.state.projects).length, 1);
 
-  await setup();
+  // skip the usual setup and just set up the filesystem
+  mockFs({
+    '/ws/.projects/main@localhost.yaml': myProject_spec,
+    '/ws/openfn.yaml': '', // TODO this shouldn;'t be neeed
+  });
 
   await deploy(
     {
       endpoint: ENDPOINT,
       apiKey: 'test-api-key',
-      workspace: '/ws',
-      new: true,
+      project: '/ws/.projects/main@localhost.yaml',
     } as any,
     logger
   );
 
+  console.log(logger._history);
+
   // We should now have a new project with a new UUID
   t.is(Object.keys(server.state.projects).length, 2);
+  // TODO more assertions
 
   const success = logger._find('success', /Created new project at/);
   t.truthy(success);

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -111,16 +111,14 @@ test.serial(
   }
 );
 
-// TODO this generates a UUID for credentials, but that's naughty init
-// Also the credential does not appear to be set on the job
-test.serial.only('deploy a project as new from a v2 spec yaml', async (t) => {
+test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
   // the server should have 1 registered project by default - that's fine
   t.is(Object.keys(server.state.projects).length, 1);
 
   // skip the usual setup and just set up the filesystem
   mockFs({
     '/ws/.projects/main@localhost.yaml': myProject_spec,
-    '/ws/openfn.yaml': '', // TODO this shouldn;'t be neeed
+    '/ws/openfn.yaml': '', // TODO this shouldn't be needed
   });
 
   await deploy(
@@ -136,7 +134,10 @@ test.serial.only('deploy a project as new from a v2 spec yaml', async (t) => {
 
   // We should now have a new project with a new UUID
   t.is(Object.keys(server.state.projects).length, 2);
+
   // TODO more assertions
+  // project structure looks right (edges in particular)
+  // - credential is OK
 
   const success = logger._find('success', /Created new project at/);
   t.truthy(success);

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -130,8 +130,6 @@ test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
     logger
   );
 
-  console.log(logger._history);
-
   // We should now have a new project with a new UUID
   t.is(Object.keys(server.state.projects).length, 2);
 

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -133,9 +133,36 @@ test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
   // We should now have a new project with a new UUID
   t.is(Object.keys(server.state.projects).length, 2);
 
-  // TODO more assertions
-  // project structure looks right (edges in particular)
-  // - credential is OK
+  const newUuid = Object.keys(server.state.projects).find((id) => id !== UUID);
+  const newProject = server.state.projects[newUuid!];
+
+  // credential should have been created with a generated uuid
+  t.is(newProject.project_credentials.length, 1);
+  const credential = newProject.project_credentials[0];
+  t.is(credential.name, 'http1');
+  t.is(credential.owner, 'super@openfn.org');
+  t.truthy(credential.id);
+
+  // only one workflow, keyed by a generated uuid rather than 'my-workflow'
+  const workflows = Object.values(newProject.workflows) as any[];
+  t.is(workflows.length, 1);
+  const workflow = workflows[0];
+  t.is(workflow.name, 'My Workflow');
+
+  const job = workflow.jobs['transform-data'];
+  t.is(job.body, 'fn()');
+  t.is(job.adaptor, '@openfn/language-common@latest');
+  // the job's configuration should resolve to the new credential
+  t.is(job.project_credential_id, credential.id);
+
+  const trigger = workflow.triggers['webhook'];
+  t.truthy(trigger);
+  t.is(trigger.type, 'webhook');
+
+  const edge = workflow.edges['webhook->transform-data'];
+  t.truthy(edge);
+  t.is(edge.source_trigger_id, trigger.id);
+  t.is(edge.target_job_id, job.id);
 
   const success = logger._find('success', /Created new project at/);
   t.truthy(success);

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -49,13 +49,13 @@ const mockFs = (paths: Record<string, string>) => {
   );
   // undici v8 reads its llhttp WASM from disk on the first request, so keep
   // that dir visible or fetches to the mock server fail with ENOENT
-  const undiciLlhttp = path.join(
+  const undicihttp = path.join(
     path.dirname(require.resolve('undici')),
     'lib/llhttp'
   );
   mock({
     [iconv]: mock.load(iconv, {}),
-    [undiciLlhttp]: mock.load(undiciLlhttp, {}),
+    [undicihttp]: mock.load(undicihttp, {}),
     ...paths,
   });
 };
@@ -205,6 +205,90 @@ test.serial(
     t.regex(mainAfter, new RegExp(`uuid: ${UUID}`));
   }
 );
+
+test.serial(
+  'deploy a file to a different target must use the file, not the checked-out baseline',
+  async (t) => {
+    // "dev" is a separate, already-existing remote project with its own content
+    await server.addProject(two_workflows_yaml);
+
+    // check out "main" - openfn.yaml now tracks MAIN's own fork history,
+    // which has nothing to do with "dev"
+    await setup(projectYaml);
+
+    // track "dev" locally too, alongside "main", without disturbing what's
+    // currently checked out
+    await writeFile('/ws/.projects/dev@localhost.yaml', two_workflows_yaml);
+
+    // deploy main's own (unmodified) file to "dev" - a different target.
+    // Nothing has changed relative to MAIN's own tracked baseline, but
+    // "dev" has completely different content and must be replaced with
+    // what's in the file
+    await deploy(
+      {
+        endpoint: ENDPOINT,
+        apiKey: 'test-api-key',
+        workspace: '/ws',
+        project: '/ws/.projects/main@localhost.yaml',
+        target: 'dev',
+        confirm: false,
+      } as any,
+      logger
+    );
+
+    const devProject: any = server.state.projects[TWO_WORKFLOWS_UUID];
+    const devWorkflows = Object.values(devProject.workflows) as any[];
+
+    // dev must now contain My Workflow (from main's file) - not be left
+    // with only its own original workflow-a/workflow-b
+    const hasMyWorkflow = devWorkflows.some((wf) => wf.name === 'My Workflow');
+    t.true(hasMyWorkflow);
+
+    const success = logger._find('success', /Updated project at/);
+    t.truthy(success);
+
+    // the deploy landed on dev, so dev's local copy is the one to refresh
+    const devAfter = fs.readFileSync('/ws/.projects/dev@localhost.yaml', 'utf8');
+    t.regex(devAfter, /My Workflow/);
+
+    // and the file we deployed FROM must not be rewritten with dev's state
+    const mainAfter = fs.readFileSync(
+      '/ws/.projects/main@localhost.yaml',
+      'utf8'
+    );
+    t.regex(mainAfter, new RegExp(`uuid: ${UUID}`));
+    t.notRegex(mainAfter, new RegExp(TWO_WORKFLOWS_UUID));
+  }
+);
+
+test.serial('deploy an updated project direct to an endpoint', async (t) => {
+  const remoteProjectBefore: any = server.state.projects[UUID];
+  const wfBefore = remoteProjectBefore.workflows['my-workflow'];
+  t.is(wfBefore.jobs['transform-data'].body, 'fn()');
+
+  mockFs({
+    '/ws/dev@localhost.yaml': projectYaml.replace('fn()', 'jam()'),
+    '/ws/openfn.yaml': '',
+  });
+
+  // deploy the local project file directly
+  await deploy(
+    {
+      endpoint: ENDPOINT,
+      apiKey: 'test-api-key',
+      workspace: '/ws',
+      project: '/ws/dev@localhost.yaml',
+      target: 'dev',
+      confirm: false,
+      // log: 'debug',
+    } as any,
+    logger
+  );
+
+  const remoteProjectAfter: any = server.state.projects[UUID];
+  const wfAfter = remoteProjectAfter.workflows['my-workflow'];
+  t.is(wfAfter.jobs['transform-data'].body, 'jam()');
+});
 
 test.serial('deploy a new project creates ids for collections', async (t) => {
   const yamlWithCollections = projectYaml.replace(

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -26,6 +26,7 @@ import {
   two_workflows_yaml as twowfs,
   TWO_WORKFLOWS_UUID,
   myProject_spec,
+  myProject_v1_spec,
 } from './fixtures';
 import { checkout } from '../../src/projects';
 
@@ -111,15 +112,13 @@ test.serial(
   }
 );
 
-// TODO I think this NAUGHTILY overwrites the main alias
-// we probably shouldn't do that.
 test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
   // the server should have 1 registered project by default - that's fine
   t.is(Object.keys(server.state.projects).length, 1);
 
   // skip the usual setup and just set up the filesystem
   mockFs({
-    '/ws/.projects/main@localhost.yaml': myProject_spec,
+    '/ws/project.yaml': myProject_spec,
     '/ws/openfn.yaml': '', // TODO this shouldn't be needed
   });
 
@@ -127,7 +126,7 @@ test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
     {
       endpoint: ENDPOINT,
       apiKey: 'test-api-key',
-      project: '/ws/.projects/main@localhost.yaml',
+      project: '/ws/project.yaml',
     } as any,
     logger
   );
@@ -165,6 +164,60 @@ test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
   t.truthy(edge);
   t.is(edge.source_trigger_id, trigger.id);
   t.is(edge.target_job_id, job.id);
+
+  const success = logger._find('success', /Created new project at/);
+  t.truthy(success);
+});
+
+test.serial('deploy a project as new from a v1 spec yaml', async (t) => {
+  t.is(Object.keys(server.state.projects).length, 1);
+
+  mockFs({
+    '/ws/project.yaml': myProject_v1_spec,
+    '/ws/openfn.yaml': '',
+  });
+
+  await deploy(
+    {
+      endpoint: ENDPOINT,
+      apiKey: 'test-api-key',
+      project: '/ws/project.yaml',
+    } as any,
+    logger
+  );
+
+  t.is(Object.keys(server.state.projects).length, 2);
+
+  const newUuid = Object.keys(server.state.projects).find((id) => id !== UUID);
+  const newProject = server.state.projects[newUuid!];
+
+  // the spec's name-keyed credentials must become project_credentials.
+  // Only credentials actually referenced by a job are deployed, and just
+  // one job in the fixture names one
+  t.is(newProject.project_credentials.length, 1);
+  const credential = newProject.project_credentials[0];
+  t.is(credential.name, 'joes-test-credential');
+  t.is(credential.owner, 'jclark@openfn.org');
+
+  const workflows = Object.values(newProject.workflows) as any[];
+  t.is(workflows.length, 2);
+
+  // the three-job workflow must keep its shape
+  const multi = workflows.find((wf) => wf.name === 'my workflow');
+  t.is(Object.keys(multi.jobs).length, 3);
+  t.is(Object.keys(multi.edges).length, 3);
+
+  // every edge must join two DIFFERENT steps - no self-loops
+  for (const wf of workflows) {
+    for (const edge of Object.values(wf.edges) as any[]) {
+      t.not(edge.target_job_id, edge.source_job_id ?? edge.source_trigger_id);
+    }
+  }
+
+  // the job that named a credential should resolve to one of them
+  const eventWf = workflows.find((wf) => wf.name === 'Event-based workflow');
+  const transform = Object.values(eventWf.jobs)[0] as any;
+  t.truthy(transform.project_credential_id);
 
   const success = logger._find('success', /Created new project at/);
   t.truthy(success);

--- a/packages/cli/test/projects/fixtures.ts
+++ b/packages/cli/test/projects/fixtures.ts
@@ -104,6 +104,32 @@ workflows:
     id: my-workflow
     start: webhook`;
 
+export const myProject_spec = `id: my-project
+name: My Project
+schema_version: '4.0'
+description: my lovely project
+collections: []
+credentials:
+  - name: http1
+    owner: super@openfn.org
+workflows:
+  - name: My Workflow
+    steps:
+      - id: transform-data
+        name: Transform data
+        expression: fn()
+        adaptor: '@openfn/language-common@latest'
+        configuration: super@openfn.org|http1
+      - id: webhook
+        type: webhook
+        enabled: true
+        next:
+          transform-data:
+            disabled: false
+            condition: always
+    id: my-workflow
+    start: webhook`;
+
 export const TWO_WORKFLOWS_UUID = '4b09ddf1-35f4-4e40-9aa9-0d80c086dd9e';
 
 export const two_workflows_yaml = `id: my-project

--- a/packages/cli/test/projects/fixtures.ts
+++ b/packages/cli/test/projects/fixtures.ts
@@ -130,6 +130,92 @@ workflows:
     id: my-workflow
     start: webhook`;
 
+// A v1 spec, as exported from the Lightning app: no uuids anywhere, and
+// everything cross-referenced by name rather than id. Note that jobs use
+// `credential`, edges use `source_trigger`/`source_job`/`target_job`, and
+// credentials are a name-keyed map - none of which the v1 STATE parser reads.
+// The three-job workflow matters: a single-job workflow accidentally parses
+// fine even when edge matching is broken
+export const myProject_v1_spec = `name: joe-sync-1
+description: |
+  A test project for sync deploy. User story 1
+
+collections: null
+channels: null
+credentials:
+  jclark@openfn.org-dasd:
+    name: dasd
+    owner: jclark@openfn.org
+  jclark@openfn.org-joe-credential-2:
+    name: joe-credential-2
+    owner: jclark@openfn.org
+  jclark@openfn.org-joes-test-credential:
+    name: joes-test-credential
+    owner: jclark@openfn.org
+workflows:
+  Event-based-workflow:
+    name: Event-based workflow
+    jobs:
+      Transform-data:
+        name: Transform data
+        adaptor: '@openfn/language-common@latest'
+        credential: jclark@openfn.org-joes-test-credential
+        body: |
+          fn(state => state)
+    triggers:
+      webhook:
+        type: webhook
+        webhook_reply: after_completion
+        enabled: true
+    edges:
+      webhook->Transform-data:
+        source_trigger: webhook
+        target_job: Transform-data
+        condition_type: always
+        enabled: true
+  my-workflow:
+    name: my workflow
+    jobs:
+      'A':
+        name: 'A'
+        adaptor: '@openfn/language-http@7.0.3'
+        credential: null
+        body: |
+          get('https://jsonplaceholder.typicode.com/todos/3');
+      Common:
+        name: Common
+        adaptor: '@openfn/language-arcgis@1.0.5'
+        credential: null
+        body: |
+          fn(state => state)
+      Send-gmail-email:
+        name: Send gmail email
+        adaptor: '@openfn/language-gmail@latest'
+        credential: null
+        body: |
+          sendMessage({ to: 'recipient@example.com' });
+    triggers:
+      cron:
+        type: cron
+        cron_expression: '*/15 * * * *'
+        enabled: false
+    edges:
+      cron->A:
+        source_trigger: cron
+        target_job: 'A'
+        condition_type: always
+        enabled: true
+      A->Common:
+        source_job: 'A'
+        target_job: Common
+        condition_type: on_job_success
+        enabled: true
+      Common->Send-gmail-email:
+        source_job: Common
+        target_job: Send-gmail-email
+        condition_type: on_job_success
+        enabled: true`;
+
 export const TWO_WORKFLOWS_UUID = '4b09ddf1-35f4-4e40-9aa9-0d80c086dd9e';
 
 export const two_workflows_yaml = `id: my-project

--- a/packages/lexicon/portability.d.ts
+++ b/packages/lexicon/portability.d.ts
@@ -95,6 +95,7 @@ export interface Trigger extends Step {
 export interface Credential {
   name: string;
   owner: string;
+  uuid?: string | number;
 }
 
 export interface Collection {

--- a/packages/lightning-mock/test/rest.test.ts
+++ b/packages/lightning-mock/test/rest.test.ts
@@ -287,7 +287,43 @@ test('validateProvisionPayload: returns null for a valid edge with source_job_id
   t.is(validateProvisionPayload(payload), null);
 });
 
-test('validateProvisionPayload: returns errors when edge has no source', (t) => {
+test('validateProvisionPayload: returns errors when edge has no source job or trigger id', (t) => {
+  const payload = {
+    id: 'proj-1',
+    workflows: [
+      {
+        name: 'wf1',
+        edges: [
+          {
+            id: 'edge-1',
+            source_trigger_id: null,
+            target_job_id: '',
+            enabled: true,
+          },
+        ],
+      },
+    ],
+  };
+  const result = validateProvisionPayload(payload);
+  t.truthy(result);
+  t.deepEqual(result, {
+    errors: {
+      workflows: {
+        wf1: {
+          edges: {
+            'edge-1': {
+              source_job_id: [
+                'source_job_id or source_trigger_id must be present',
+              ],
+            },
+          },
+        },
+      },
+    },
+  });
+});
+
+test('validateProvisionPayload: for new edges allow source_job', (t) => {
   const payload = {
     id: 'proj-1',
     workflows: [

--- a/packages/lightning-mock/test/rest.test.ts
+++ b/packages/lightning-mock/test/rest.test.ts
@@ -292,6 +292,7 @@ test('validateProvisionPayload: returns errors when edge has no source job or tr
     id: 'proj-1',
     workflows: [
       {
+        id: 'wf-1',
         name: 'wf1',
         edges: [
           {

--- a/packages/project/src/Project.ts
+++ b/packages/project/src/Project.ts
@@ -91,6 +91,7 @@ export class Project {
       alias?: string;
       version?: number;
       name?: string;
+      asSpec?: boolean;
     }
   ): Promise<Project>;
   static async from(

--- a/packages/project/src/Project.ts
+++ b/packages/project/src/Project.ts
@@ -99,7 +99,7 @@ export class Project {
   static async from(
     type: 'path',
     data: string,
-    options?: { config?: FromPathConfig }
+    options?: Partial<FromPathConfig>
   ): Promise<Project>;
   static async from(
     type: 'project' | 'state' | 'path' | 'fs',

--- a/packages/project/src/Project.ts
+++ b/packages/project/src/Project.ts
@@ -202,8 +202,12 @@ export class Project {
 
   serialize(type: 'project', options?: any): SerializedProject | string;
   serialize(type: 'state', options?: any): Provisioner.Project | string;
+  serialize(type: 'spec', options?: any): Provisioner.Project | string;
   serialize(type: 'fs', options?: any): Record<string, string>;
-  serialize(type: 'project' | 'fs' | 'state' = 'project', options?: any) {
+  serialize(
+    type: 'project' | 'fs' | 'state' | 'spec' = 'project',
+    options?: any
+  ) {
     if (type in serializers) {
       // @ts-ignore
       return serializers[type](this, options);

--- a/packages/project/src/Project.ts
+++ b/packages/project/src/Project.ts
@@ -87,7 +87,11 @@ export class Project {
   static async from(
     type: 'project',
     data: any,
-    config?: Partial<l.WorkspaceConfig>
+    config?: Partial<l.WorkspaceConfig> & {
+      alias?: string;
+      version?: number;
+      name?: string;
+    }
   ): Promise<Project>;
   static async from(
     type: 'state',

--- a/packages/project/src/parse/from-app-spec.ts
+++ b/packages/project/src/parse/from-app-spec.ts
@@ -1,0 +1,134 @@
+// Convert a v1 spec (as exported from the Lightning app) into the v2 spec
+// shape, so it can be loaded by the regular v2 parser
+//
+// A v1 spec has v1's keyed-object structure but, unlike v1 state, carries no
+// uuids at all - workflows, jobs, triggers and credentials are all
+// cross-referenced by their key in the owning map. serialize/to-app-spec is
+// the inverse
+
+import * as l from '@openfn/lexicon';
+
+import slugify from '../util/slugify';
+import omitNil from '../util/omit-nil';
+import getCredentialName from '../util/get-credential-name';
+
+// v1 state always carries a `project_credentials` array; a spec instead uses a
+// name-keyed `credentials` map, and refers to steps by name rather than uuid
+export const isAppSpec = (json: any): boolean => {
+  if (!json || Array.isArray(json.project_credentials)) {
+    return false;
+  }
+  if (json.credentials && !Array.isArray(json.credentials)) {
+    return true;
+  }
+  return Object.values(json.workflows ?? {}).some((wf: any) =>
+    Object.values(wf?.edges ?? {}).some(
+      (e: any) => e && (e.source_job || e.source_trigger || e.target_job)
+    )
+  );
+};
+
+const mapCondition = (edge: any) => {
+  if (edge.condition_type === 'js_expression') {
+    return edge.condition_expression;
+  }
+  return edge.condition_type;
+};
+
+const mapWorkflow = (
+  key: string,
+  workflow: any,
+  credentialNames: Record<string, string>
+) => {
+  const steps: any[] = [];
+
+  // edges reference steps by their key in the jobs/triggers map, so track
+  // what each key becomes
+  const stepIds: Record<string, string> = {};
+  const byId: Record<string, any> = {};
+
+  const addStep = (mapKey: string, step: any) => {
+    stepIds[mapKey] = step.id;
+    byId[step.id] = step;
+    steps.push(step);
+  };
+
+  for (const [triggerKey, trigger] of Object.entries(
+    workflow.triggers ?? {}
+  ) as [string, any][]) {
+    // a trigger's id is its type, matching how v2 specs are written
+    addStep(triggerKey, omitNil({ ...trigger, id: trigger.type }));
+  }
+
+  for (const [jobKey, job] of Object.entries(workflow.jobs ?? {}) as [
+    string,
+    any
+  ][]) {
+    const { name, body, adaptor, credential, ...rest } = job;
+    addStep(
+      jobKey,
+      omitNil({
+        ...rest,
+        id: slugify(name ?? jobKey),
+        name,
+        expression: body,
+        adaptor,
+        configuration: credential
+          ? credentialNames[credential] ?? credential
+          : undefined,
+      })
+    );
+  }
+
+  // v2 hangs each edge off its source step, keyed by the target's id
+  for (const edge of Object.values(workflow.edges ?? {}) as any[]) {
+    const source = byId[stepIds[edge.source_trigger ?? edge.source_job]];
+    const target = stepIds[edge.target_job];
+    if (!source || !target) {
+      continue;
+    }
+    source.next ??= {};
+    source.next[target] = omitNil({
+      condition: mapCondition(edge),
+      disabled: !edge.enabled,
+      label: edge.condition_label,
+    });
+  }
+
+  const [firstTrigger] = Object.values(workflow.triggers ?? {}) as any[];
+
+  return omitNil({
+    id: slugify(workflow.name ?? key),
+    name: workflow.name,
+    start: firstTrigger?.type,
+    steps,
+  });
+};
+
+export default (json: any): l.ProjectState => {
+  const credentials = Object.values(json.credentials ?? {}).map((c: any) => ({
+    name: c.name,
+    owner: c.owner,
+  }));
+
+  // jobs name a credential by its key in the credentials map, but v2 refers to
+  // credentials as `owner|name`
+  const credentialNames: Record<string, string> = {};
+  for (const [key, c] of Object.entries(json.credentials ?? {}) as [
+    string,
+    any
+  ][]) {
+    credentialNames[key] = getCredentialName(c);
+  }
+
+  const workflows = Object.entries(json.workflows ?? {}).map(([key, wf]) =>
+    mapWorkflow(key, wf, credentialNames)
+  );
+
+  return omitNil({
+    ...json,
+    schema_version: '4.0',
+    credentials,
+    workflows,
+  }) as l.ProjectState;
+};

--- a/packages/project/src/parse/from-path.ts
+++ b/packages/project/src/parse/from-path.ts
@@ -8,6 +8,7 @@ export type FromPathConfig = l.WorkspaceConfig & {
   format: 'json' | 'yaml';
   alias?: string;
   name?: string;
+  asSpec?: boolean;
 };
 
 // Extract alias from filename in format: alias@domain.yaml or alias.yaml

--- a/packages/project/src/parse/from-path.ts
+++ b/packages/project/src/parse/from-path.ts
@@ -7,6 +7,7 @@ import fromProject from './from-project';
 export type FromPathConfig = l.WorkspaceConfig & {
   format: 'json' | 'yaml';
   alias?: string;
+  name?: string;
 };
 
 // Extract alias from filename in format: alias@domain.yaml or alias.yaml

--- a/packages/project/src/parse/from-project.ts
+++ b/packages/project/src/parse/from-project.ts
@@ -17,10 +17,20 @@ export type SerializedWorkflow = l.WorkflowState;
 
 export default (
   data: l.ProjectState | SerializedProject | string,
-  config?: Partial<l.WorkspaceConfig> & { alias?: string; version?: number }
+  config?: Partial<l.WorkspaceConfig> & {
+    alias?: string;
+    version?: number;
+    name?: string;
+  }
 ) => {
   // first ensure the data is in JSON format
   let rawJson = ensureJson<any>(data);
+
+  // an explicit name override (eg deploying a downloaded project.yaml as a
+  // new/duplicate project) applies regardless of source format
+  if (config?.name) {
+    rawJson = { ...rawJson, name: config.name };
+  }
 
   if (detectVersion(rawJson) > 1) {
     return new Project(from_v2(rawJson as SerializedProject), config);

--- a/packages/project/src/parse/from-project.ts
+++ b/packages/project/src/parse/from-project.ts
@@ -4,6 +4,7 @@ import Project from '../Project';
 import ensureJson from '../util/ensure-json';
 import { Provisioner } from '@openfn/lexicon/lightning';
 import fromAppState, { fromAppStateConfig } from './from-app-state';
+import fromAppSpec, { isAppSpec } from './from-app-spec';
 import detectVersion from '../util/detect-version';
 
 // Load a project from any JSON or yaml representation
@@ -44,6 +45,13 @@ export default (
       from_v2(rawJson as SerializedProject, config?.asSpec),
       config
     );
+  }
+
+  // a v1 spec has no uuids to preserve, so convert it to the v2 spec shape
+  // and let the v2 parser take it - fromAppState is for v1 STATE, and its
+  // uuid-based matching silently mangles a spec
+  if (isAppSpec(rawJson)) {
+    return new Project(fromAppSpec(rawJson), config);
   }
 
   return from_v1(rawJson as Provisioner.Project, config as fromAppStateConfig);

--- a/packages/project/src/parse/from-project.ts
+++ b/packages/project/src/parse/from-project.ts
@@ -21,6 +21,13 @@ export default (
     alias?: string;
     version?: number;
     name?: string;
+    /**
+     * Load this project as a spec, stripping any embedded remote state
+     * (workflow/step/edge uuids) as it's parsed - eg when a stateful,
+     * previously-fetched project.yaml is being deployed as a brand new
+     * project, and its old ids must not carry over.
+     */
+    asSpec?: boolean;
   }
 ) => {
   // first ensure the data is in JSON format
@@ -33,7 +40,10 @@ export default (
   }
 
   if (detectVersion(rawJson) > 1) {
-    return new Project(from_v2(rawJson as SerializedProject), config);
+    return new Project(
+      from_v2(rawJson as SerializedProject, config?.asSpec),
+      config
+    );
   }
 
   return from_v1(rawJson as Provisioner.Project, config as fromAppStateConfig);
@@ -48,10 +58,39 @@ const from_v1 = (
 };
 
 // TODO this should return a Project really!
-const from_v2 = (data: SerializedProject) => {
+const from_v2 = (data: SerializedProject, asSpec?: boolean) => {
   // nothing to do
   // (When we add v3, we'll ned to migrate through this)
+  if (asSpec) {
+    return stripState(data);
+  }
   return {
     ...data,
   };
 };
+
+// Remove embedded remote-state uuids from every workflow, step and edge
+// (but not the project itself - callers handle that separately, since
+// they also need to set a fresh endpoint)
+const stripState = (data: SerializedProject) => ({
+  ...data,
+  workflows: (data.workflows ?? []).map((wf: any) => {
+    const { openfn, steps, ...restWf } = wf;
+    return {
+      ...restWf,
+      steps: (steps ?? []).map((step: any) => {
+        const { openfn: stepOpenfn, next, ...restStep } = step;
+        if (!next) return restStep;
+        return {
+          ...restStep,
+          next: Object.fromEntries(
+            Object.entries(next).map(([id, edge]: [string, any]) => {
+              const { openfn: edgeOpenfn, ...restEdge } = edge;
+              return [id, restEdge];
+            })
+          ),
+        };
+      }),
+    };
+  }),
+});

--- a/packages/project/src/serialize/index.ts
+++ b/packages/project/src/serialize/index.ts
@@ -1,5 +1,6 @@
 import state from './to-app-state';
+import spec from './to-app-spec';
 import fs from './to-fs';
 import project from './to-project';
 
-export { project, state, fs };
+export { project, state, spec, fs };

--- a/packages/project/src/serialize/to-app-spec.ts
+++ b/packages/project/src/serialize/to-app-spec.ts
@@ -1,0 +1,169 @@
+// Serialize a Project into the v1 SPEC format, as exported by the Lightning app
+//
+// Unlike v1 state (see to-app-state), a spec carries no uuids: workflows, jobs,
+// triggers and credentials are all cross-referenced by their key in the owning
+// map. parse/from-app-spec is the inverse
+
+import { pick, omitBy, isNil, sortBy } from 'lodash-es';
+import { Provisioner } from '@openfn/lexicon/lightning';
+import { randomUUID } from 'node:crypto';
+
+import { Project } from '../Project';
+import { jsonToYaml } from '../util/yaml';
+import Workflow from '../Workflow';
+import slugify from '../util/slugify';
+import getCredentialName from '../util/get-credential-name';
+
+type Options = {
+  format?: 'json' | 'yaml';
+};
+
+export default function (
+  project: Project,
+  options: Options = {}
+): Provisioner.Project | string {
+  const {
+    uuid,
+    endpoint,
+    env,
+    id /* shouldn't be there but will cause problems if it's set*/,
+    fetched_at /* remove this metadata as it causes problems */,
+    alias, // shouldn't be written but has been caught in some legacy files
+    ...rest
+  } = project.openfn ?? {};
+
+  const state = omitBy(
+    pick(project, ['name', 'description', 'channels']),
+    isNil
+  ) as Provisioner.Project;
+
+  state.id = (uuid as string) ?? randomUUID();
+
+  // unlike ProjectState, Provisioner.Project.collections is a required
+  // field on the wire - always send it, defaulting to []
+  state.collections = (project.collections ?? []).map((c) => ({
+    id: c.uuid ?? randomUUID(),
+    name: c.name,
+  }));
+
+  Object.assign(state, rest, project.options);
+
+  // a spec names its credentials rather than referencing them by uuid
+  for (const c of project.credentials ?? []) {
+    (state as any).credentials ??= {};
+    (state as any).credentials[getCredentialName(c)] = {
+      name: c.name,
+      owner: c.owner,
+    };
+  }
+
+  state.workflows = project.workflows
+    .map((w) => mapWorkflow(w))
+    .reduce((obj: any, wf) => {
+      obj[slugify(wf.name ?? wf.id)] = wf;
+      return obj;
+    }, {});
+
+  const shouldReturnYaml =
+    options.format === 'yaml' ||
+    (!options.format && project.config.formats.project === 'yaml');
+
+  if (shouldReturnYaml) {
+    return jsonToYaml(state);
+  }
+
+  return state;
+}
+
+export const mapWorkflow = (workflow: Workflow) => {
+  if (workflow instanceof Workflow) {
+    // @ts-ignore
+    workflow = workflow.toJSON();
+  }
+
+  const { uuid, ...originalOpenfnProps } = (workflow as any).openfn ?? {};
+
+  const wfState = {
+    ...originalOpenfnProps,
+    jobs: {},
+    triggers: {},
+    edges: {},
+    lock_version: (workflow as any).openfn?.lock_version ?? null,
+  } as Provisioner.Workflow;
+
+  if (workflow.name) {
+    wfState.name = workflow.name;
+  }
+
+  // Sort steps by name (for more predictable comparisons in test)
+  sortBy((workflow as any).steps, 'name').forEach((s: any) => {
+    let isTrigger = false;
+    let node: Provisioner.Job | Provisioner.Trigger;
+
+    if (s.type) {
+      isTrigger = true;
+      const { type, id, next, openfn, ...restStep } = s;
+      node = {
+        ...restStep,
+        type: s.type ?? 'webhook', // this is mostly for tests
+      } as Provisioner.Trigger;
+      wfState.triggers[s.type] = node;
+    } else {
+      node = omitBy(pick(s, ['name', 'adaptor']), isNil) as Provisioner.Job;
+      const { uuid: _uuid, ...otherOpenFnProps } = s.openfn ?? {};
+      if (s.expression) {
+        node.body = s.expression;
+      }
+      if (
+        typeof s.configuration === 'string' &&
+        !s.configuration.endsWith('.json') &&
+        s.configuration
+      ) {
+        // a spec refers to a credential by name, exactly as authored
+        otherOpenFnProps.credential = s.configuration;
+      }
+
+      Object.assign(node, otherOpenFnProps);
+      wfState.jobs[s.id ?? slugify(s.name)] = node;
+    }
+
+    // edges name their source and target steps by key
+    Object.keys(s.next ?? {}).forEach((next) => {
+      const rules = s.next[next];
+      const { uuid: _uuid, ...otherOpenFnProps } = rules.openfn ?? {};
+
+      const e: any = {
+        enabled: !rules.disabled,
+        target_job: next,
+      };
+      Object.assign(e, otherOpenFnProps);
+      if (isTrigger) {
+        e.source_trigger = s.type;
+      } else {
+        e.source_job = s.id;
+      }
+
+      if (rules.label) {
+        e.condition_label = rules.label;
+      }
+
+      if (rules.condition) {
+        if (typeof rules.condition === 'boolean') {
+          e.condition_type = rules.condition ? 'always' : 'never';
+        } else if (
+          rules.condition.match(
+            /^(always|never|on_job_success|on_job_failure)$/
+          )
+        ) {
+          e.condition_type = rules.condition;
+        } else {
+          e.condition_type = 'js_expression';
+          e.condition_expression = rules.condition;
+        }
+      }
+      wfState.edges[`${s.id}->${next}`] = e;
+    });
+  });
+
+  return wfState;
+};

--- a/packages/project/src/serialize/to-app-state.ts
+++ b/packages/project/src/serialize/to-app-state.ts
@@ -12,13 +12,6 @@ import getCredentialName from '../util/get-credential-name';
 
 type Options = {
   format?: 'json' | 'yaml';
-  /**
-   * Serialize the project into a v1 spec format (not state)
-   * This is awkward and ugly but should only be a temporary solution
-   * If we decide we need it long term, we should generate a separate
-   * to-app-spec function which does a more focused job of it.
-   */
-  asSpec?: boolean;
 };
 
 const defaultJobProps = {
@@ -66,30 +59,17 @@ export default function (
     })) ?? [];
 
   Object.assign(state, rest, project.options);
-  if (options.asSpec) {
-    for (const c of project.credentials) {
-      // note that credentials for a spec file are not the
-      // the same format as a state file,
-      // so typings break here
-      (state as any).credentials ??= {};
-      (state as any).credentials[getCredentialName(c)] = {
-        name: c.name,
-        owner: c.owner,
-      };
-    }
-  } else {
-    state.project_credentials = project.credentials.map((c) => ({
-      // note the subtle conversion here: uuid -> id
-      // That's because the local Project uses the uuid key to track UUIDs
-      // but the provisioner spec uses id
-      id: c.uuid as string,
-      name: c.name,
-      owner: c.owner,
-    }));
-  }
+  state.project_credentials = project.credentials.map((c) => ({
+    // note the subtle conversion here: uuid -> id
+    // That's because the local Project uses the uuid key to track UUIDs
+    // but the provisioner spec uses id
+    id: c.uuid as string,
+    name: c.name,
+    owner: c.owner,
+  }));
 
   state.workflows = project.workflows
-    .map((w) => mapWorkflow(w, project.credentials, options))
+    .map((w) => mapWorkflow(w, project.credentials))
     .reduce((obj: any, wf) => {
       obj[slugify(wf.name ?? wf.id)] = wf;
       return obj;
@@ -108,11 +88,8 @@ export default function (
 
 export const mapWorkflow = (
   workflow: Workflow,
-  credentials: CredentialState[] = [],
-  options: Options = {}
+  credentials: CredentialState[] = []
 ) => {
-  const useUuids = !options.asSpec;
-
   // captured before toJSON(), since the `lookup` build below mints fresh uuids for anything missing one
   const removed =
     workflow instanceof Workflow
@@ -128,7 +105,7 @@ export const mapWorkflow = (
 
   const { uuid, ...originalOpenfnProps } = workflow.openfn ?? {};
 
-  if (useUuids && removed.self && uuid) {
+  if (removed.self && uuid) {
     // nothing else about a deleted workflow matters to the provisioner
     return {
       ...originalOpenfnProps,
@@ -150,25 +127,21 @@ export const mapWorkflow = (
     lock_version: workflow.openfn?.lock_version ?? null, // TODO needs testing
   } as Provisioner.Workflow;
 
-  if (useUuids) {
-    wfState.id = (workflow.openfn?.uuid ?? randomUUID()) as any;
-  }
+  wfState.id = (workflow.openfn?.uuid ?? randomUUID()) as any;
 
   if (workflow.name) {
     wfState.name = workflow.name;
   }
 
-  // lookup of local-ids to project-ids (only needed when using UUIDs)
+  // lookup of local-ids to project-ids
   const lookup = workflow.steps.reduce((obj, next) => {
-    if (useUuids) {
-      if (!next.openfn?.uuid) {
-        // If there's no tracked id, we generate one here
-        next.openfn ??= {};
-        next.openfn.uuid = randomUUID();
-      }
-      // @ts-ignore
-      obj[next.id] = next.openfn.uuid;
+    if (!next.openfn?.uuid) {
+      // If there's no tracked id, we generate one here
+      next.openfn ??= {};
+      next.openfn.uuid = randomUUID();
     }
+    // @ts-ignore
+    obj[next.id] = next.openfn.uuid;
     return obj;
   }, {}) as Record<string, string>;
 
@@ -177,7 +150,7 @@ export const mapWorkflow = (
     let isTrigger = false;
     let node: Provisioner.Job | Provisioner.Trigger;
 
-    const isRemoved = useUuids && !!removed.ids[s.id];
+    const isRemoved = !!removed.ids[s.id];
     const nodeUuid = originalUuids[s.id];
 
     if (isRemoved && !nodeUuid) {
@@ -195,7 +168,7 @@ export const mapWorkflow = (
         node = {
           ...rest,
           type: s.type ?? 'webhook', // this is mostly for tests
-          ...(useUuids ? renameKeys(openfn, { uuid: 'id' }) : {}),
+          ...renameKeys(openfn, { uuid: 'id' }),
         } as Provisioner.Trigger;
       }
       wfState.triggers[s.type] = node;
@@ -205,9 +178,7 @@ export const mapWorkflow = (
       } else {
         node = omitBy(pick(s, ['name', 'adaptor']), isNil) as Provisioner.Job;
         const { uuid, ...otherOpenFnProps } = s.openfn ?? {};
-        if (useUuids) {
-          node.id = uuid;
-        }
+        node.id = uuid;
         if (s.expression) {
           node.body = s.expression;
         }
@@ -221,19 +192,15 @@ export const mapWorkflow = (
               const name = getCredentialName(c);
               return name === projectCredentialId;
             });
-            if (mappedCredential && useUuids) {
+            if (mappedCredential) {
               projectCredentialId = mappedCredential.uuid;
             }
 
-            if (useUuids) {
-              otherOpenFnProps.project_credential_id = projectCredentialId;
-            } else {
-              otherOpenFnProps.credential = projectCredentialId;
-            }
+            otherOpenFnProps.project_credential_id = projectCredentialId;
           }
         }
 
-        Object.assign(node, useUuids ? defaultJobProps : {}, otherOpenFnProps);
+        Object.assign(node, defaultJobProps, otherOpenFnProps);
       }
 
       wfState.jobs[s.id ?? slugify(s.name)] = node;
@@ -248,7 +215,7 @@ export const mapWorkflow = (
     Object.keys(s.next ?? {}).forEach((next) => {
       const rules = s.next[next];
 
-      const edgeIsRemoved = useUuids && !!removed.ids[`${s.id}-${next}`];
+      const edgeIsRemoved = !!removed.ids[`${s.id}-${next}`];
       const edgeUuid = originalUuids[`${s.id}-${next}`];
 
       if (edgeIsRemoved && !edgeUuid) {
@@ -265,31 +232,17 @@ export const mapWorkflow = (
 
       const { uuid, ...otherOpenFnProps } = rules.openfn ?? {};
 
-      let e: any;
-      if (useUuids) {
-        e = {
-          id: uuid ?? randomUUID(),
-          target_job_id: lookup[next],
-          enabled: !rules.disabled,
-          source_trigger_id: null, // lightning complains if this isn't set, even if its falsy :(
-        } as Provisioner.Edge;
-        Object.assign(e, otherOpenFnProps);
-        if (isTrigger) {
-          e.source_trigger_id = node.id;
-        } else {
-          e.source_job_id = node.id;
-        }
+      const e: any = {
+        id: uuid ?? randomUUID(),
+        target_job_id: lookup[next],
+        enabled: !rules.disabled,
+        source_trigger_id: null, // lightning complains if this isn't set, even if its falsy :(
+      } as Provisioner.Edge;
+      Object.assign(e, otherOpenFnProps);
+      if (isTrigger) {
+        e.source_trigger_id = node.id;
       } else {
-        e = {
-          enabled: !rules.disabled,
-          target_job: next,
-        };
-        Object.assign(e, otherOpenFnProps);
-        if (isTrigger) {
-          e.source_trigger = s.type;
-        } else {
-          e.source_job = s.id;
-        }
+        e.source_job_id = node.id;
       }
 
       if (rules.label) {
@@ -315,18 +268,16 @@ export const mapWorkflow = (
     });
   });
 
-  if (useUuids) {
-    // Sort edges by UUID (for more predictable comparisons in test)
-    wfState.edges = Object.keys(wfState.edges)
-      // convert edge ids to strings just in case a number creeps in (it might in test)
-      .sort((a, b) =>
-        `${wfState.edges[a].id}`.localeCompare('' + wfState.edges[b].id)
-      )
-      .reduce((obj: any, key) => {
-        obj[key] = wfState.edges[key];
-        return obj;
-      }, {});
-  }
+  // Sort edges by UUID (for more predictable comparisons in test)
+  wfState.edges = Object.keys(wfState.edges)
+    // convert edge ids to strings just in case a number creeps in (it might in test)
+    .sort((a, b) =>
+      `${wfState.edges[a].id}`.localeCompare('' + wfState.edges[b].id)
+    )
+    .reduce((obj: any, key) => {
+      obj[key] = wfState.edges[key];
+      return obj;
+    }, {});
 
   return wfState;
 };

--- a/packages/project/src/serialize/to-app-state.ts
+++ b/packages/project/src/serialize/to-app-state.ts
@@ -222,10 +222,7 @@ export const mapWorkflow = (
               return name === projectCredentialId;
             });
             if (mappedCredential && useUuids) {
-              // the mapped credential might have a uuid or an id depending on how it was fed in to us
-              // but this is bullshit right?
-              projectCredentialId =
-                mappedCredential.uuid ?? mappedCredential.id;
+              projectCredentialId = mappedCredential.uuid;
             }
 
             if (useUuids) {

--- a/packages/project/src/serialize/to-app-state.ts
+++ b/packages/project/src/serialize/to-app-state.ts
@@ -58,6 +58,13 @@ export default function (
     name: c.name,
   }));
 
+  // Ensure each credential has a UUID
+  project.credentials =
+    project.credentials?.map((c) => ({
+      ...c,
+      uuid: c.uuid ?? randomUUID(),
+    })) ?? [];
+
   Object.assign(state, rest, project.options);
   if (options.asSpec) {
     for (const c of project.credentials) {
@@ -71,14 +78,10 @@ export default function (
       };
     }
   } else {
-    const credentialsWithUuids =
-      project.credentials?.map((c) => ({
-        ...c,
-        uuid: (c as CredentialState).uuid ?? randomUUID(),
-      })) ?? [];
-
-    state.project_credentials = credentialsWithUuids.map((c) => ({
-      // note the subtle conversion here
+    state.project_credentials = project.credentials.map((c) => ({
+      // note the subtle conversion here: uuid -> id
+      // That's because the local Project uses the uuid key to track UUIDs
+      // but the provisioner spec uses id
       id: c.uuid as string,
       name: c.name,
       owner: c.owner,
@@ -219,7 +222,10 @@ export const mapWorkflow = (
               return name === projectCredentialId;
             });
             if (mappedCredential && useUuids) {
-              projectCredentialId = mappedCredential.uuid;
+              // the mapped credential might have a uuid or an id depending on how it was fed in to us
+              // but this is bullshit right?
+              projectCredentialId =
+                mappedCredential.uuid ?? mappedCredential.id;
             }
 
             if (useUuids) {

--- a/packages/project/test/parse/from-app-spec.test.ts
+++ b/packages/project/test/parse/from-app-spec.test.ts
@@ -1,0 +1,245 @@
+import test from 'ava';
+
+import { Project } from '../../src/Project';
+import fromAppSpec, { isAppSpec } from '../../src/parse/from-app-spec';
+import toAppSpec from '../../src/serialize/to-app-spec';
+
+// A v1 spec, as the app exports it: no uuids, everything referenced by key.
+// The three-job workflow matters - a single-job workflow parses fine even
+// when edge matching is broken
+const spec: any = {
+  name: 'my-project',
+  description: 'a test project',
+  credentials: {
+    'a@b.org-cred-one': { name: 'cred-one', owner: 'a@b.org' },
+    'a@b.org-cred-two': { name: 'cred-two', owner: 'a@b.org' },
+  },
+  workflows: {
+    'Event-based-workflow': {
+      name: 'Event-based workflow',
+      jobs: {
+        'Transform-data': {
+          name: 'Transform data',
+          adaptor: '@openfn/language-common@latest',
+          credential: 'a@b.org-cred-one',
+          body: 'fn(s => s)',
+        },
+      },
+      triggers: {
+        webhook: { type: 'webhook', enabled: true },
+      },
+      edges: {
+        'webhook->Transform-data': {
+          source_trigger: 'webhook',
+          target_job: 'Transform-data',
+          condition_type: 'always',
+          enabled: true,
+        },
+      },
+    },
+    'my-workflow': {
+      name: 'my workflow',
+      jobs: {
+        A: { name: 'A', adaptor: 'common', credential: null, body: 'get()' },
+        Common: { name: 'Common', adaptor: 'common', body: 'fn()' },
+        'Send-gmail-email': {
+          name: 'Send gmail email',
+          adaptor: 'gmail',
+          body: 'send()',
+        },
+      },
+      triggers: {
+        cron: { type: 'cron', cron_expression: '*/15 * * * *', enabled: false },
+      },
+      edges: {
+        'cron->A': {
+          source_trigger: 'cron',
+          target_job: 'A',
+          condition_type: 'always',
+          enabled: true,
+        },
+        'A->Common': {
+          source_job: 'A',
+          target_job: 'Common',
+          condition_type: 'on_job_success',
+          enabled: true,
+        },
+        'Common->Send-gmail-email': {
+          source_job: 'Common',
+          target_job: 'Send-gmail-email',
+          condition_type: 'on_job_success',
+          enabled: false,
+        },
+      },
+    },
+  },
+};
+
+const getWorkflow = (result: any, id: string) =>
+  result.workflows.find((wf: any) => wf.id === id);
+
+const getStep = (workflow: any, id: string) =>
+  workflow.steps.find((s: any) => s.id === id);
+
+test('isAppSpec: true for a name-keyed spec', (t) => {
+  t.true(isAppSpec(spec));
+});
+
+test('isAppSpec: false for v1 state', (t) => {
+  t.false(
+    isAppSpec({
+      id: 'uuid',
+      project_credentials: [],
+      workflows: {
+        wf: {
+          id: 'wf-uuid',
+          edges: {
+            e: { id: 'edge-uuid', source_trigger_id: 'x', target_job_id: 'y' },
+          },
+        },
+      },
+    })
+  );
+});
+
+test('isAppSpec: true for a spec with no credentials, via its edges', (t) => {
+  t.true(
+    isAppSpec({
+      name: 'p',
+      workflows: {
+        wf: {
+          name: 'wf',
+          edges: { e: { source_trigger: 'webhook', target_job: 'a' } },
+        },
+      },
+    })
+  );
+});
+
+test('credentials become an array with no uuids', (t) => {
+  const result: any = fromAppSpec(spec);
+
+  t.deepEqual(result.credentials, [
+    { name: 'cred-one', owner: 'a@b.org' },
+    { name: 'cred-two', owner: 'a@b.org' },
+  ]);
+});
+
+test('a job credential key becomes an owner|name configuration', (t) => {
+  const result: any = fromAppSpec(spec);
+
+  const wf = getWorkflow(result, 'event-based-workflow');
+  const job = getStep(wf, 'transform-data');
+  t.is(job.configuration, 'a@b.org|cred-one');
+});
+
+test('a job body becomes an expression', (t) => {
+  const result: any = fromAppSpec(spec);
+
+  const wf = getWorkflow(result, 'event-based-workflow');
+  const job = getStep(wf, 'transform-data');
+  t.is(job.expression, 'fn(s => s)');
+  t.is(job.adaptor, '@openfn/language-common@latest');
+  t.falsy(job.body);
+});
+
+test('a trigger becomes a step, and sets the workflow start', (t) => {
+  const result: any = fromAppSpec(spec);
+
+  const wf = getWorkflow(result, 'my-workflow');
+  t.is(wf.start, 'cron');
+
+  const trigger = getStep(wf, 'cron');
+  t.is(trigger.type, 'cron');
+  t.is(trigger.enabled, false);
+  t.is(trigger.cron_expression, '*/15 * * * *');
+});
+
+test('edges hang off their source step, keyed by target', (t) => {
+  const result: any = fromAppSpec(spec);
+
+  const wf = getWorkflow(result, 'my-workflow');
+  t.deepEqual(Object.keys(getStep(wf, 'cron').next), ['a']);
+  t.deepEqual(Object.keys(getStep(wf, 'a').next), ['common']);
+  t.deepEqual(Object.keys(getStep(wf, 'common').next), ['send-gmail-email']);
+
+  // the last step in the chain has nothing downstream
+  t.falsy(getStep(wf, 'send-gmail-email').next);
+});
+
+test('no step is ever wired to itself', (t) => {
+  const result: any = fromAppSpec(spec);
+
+  for (const wf of result.workflows) {
+    for (const step of wf.steps) {
+      for (const target of Object.keys(step.next ?? {})) {
+        t.not(target, step.id);
+      }
+    }
+  }
+});
+
+test('edge conditions and disabled flags are mapped', (t) => {
+  const result: any = fromAppSpec(spec);
+
+  const wf = getWorkflow(result, 'my-workflow');
+  t.is(getStep(wf, 'cron').next.a.condition, 'always');
+
+  const onSuccess = getStep(wf, 'a').next.common;
+  t.is(onSuccess.condition, 'on_job_success');
+  t.falsy(onSuccess.disabled);
+
+  // enabled: false on the wire means disabled locally
+  t.true(getStep(wf, 'common').next['send-gmail-email'].disabled);
+});
+
+test('a js_expression condition keeps its expression', (t) => {
+  const result: any = fromAppSpec({
+    name: 'p',
+    workflows: {
+      wf: {
+        name: 'wf',
+        jobs: { A: { name: 'A', body: 'fn()' }, B: { name: 'B', body: 'fn()' } },
+        triggers: {},
+        edges: {
+          'A->B': {
+            source_job: 'A',
+            target_job: 'B',
+            condition_type: 'js_expression',
+            condition_expression: 'state.x > 1',
+            enabled: true,
+          },
+        },
+      },
+    },
+  });
+
+  const wf = getWorkflow(result, 'wf');
+  t.is(getStep(wf, 'a').next.b.condition, 'state.x > 1');
+});
+
+test('the result loads as a Project', (t) => {
+  const project = new Project(fromAppSpec(spec));
+
+  t.is(project.name, 'my-project');
+  t.is(project.workflows.length, 2);
+  // a spec has nothing stateful in it
+  t.falsy(project.uuid);
+});
+
+test('round trips through to-app-spec', (t) => {
+  const project = new Project(fromAppSpec(spec), {
+    formats: { project: 'json' },
+  });
+  const roundTripped: any = fromAppSpec(
+    toAppSpec(project, { format: 'json' }) as any
+  );
+
+  const wf = getWorkflow(roundTripped, 'my-workflow');
+  t.is(wf.steps.length, 4);
+  t.deepEqual(Object.keys(getStep(wf, 'a').next), ['common']);
+  t.deepEqual(Object.keys(getStep(wf, 'common').next), ['send-gmail-email']);
+
+  const eventWf = getWorkflow(roundTripped, 'event-based-workflow');
+  t.is(getStep(eventWf, 'transform-data').configuration, 'a@b.org|cred-one');
+});

--- a/packages/project/test/parse/from-path.test.ts
+++ b/packages/project/test/parse/from-path.test.ts
@@ -94,6 +94,17 @@ test.serial('should use workspace config', async (t) => {
   t.deepEqual(project.openfn!.uuid, proj.openfn!.uuid);
 });
 
+test.serial('should apply a name override to a loaded project', async (t) => {
+  mock({
+    '/p1/main@openfn.org.yaml': v2.yaml,
+  });
+  const project = await fromPath('/p1/main@openfn.org.yaml', {
+    name: 'My Duplicate',
+  });
+
+  t.is(project.name, 'My Duplicate');
+});
+
 test('extractAliasFromFilename: should extract alias from alias@domain.yaml format', (t) => {
   const alias = extractAliasFromFilename('main@app.openfn.org.yaml');
   t.is(alias, 'main');

--- a/packages/project/test/parse/from-project.test.ts
+++ b/packages/project/test/parse/from-project.test.ts
@@ -243,6 +243,17 @@ test('import v1 with custom config', async (t) => {
   });
 });
 
+test('import from a v1 state with a name override', async (t) => {
+  const proj = await Project.from('project', v1_yaml, { name: 'My Duplicate' });
+  t.is(proj.name, 'My Duplicate');
+});
+
+test('import from a v2 project with a name override', async (t) => {
+  // @ts-ignore
+  const proj = await Project.from('project', v2.json, { name: 'My Duplicate' });
+  t.is(proj.name, 'My Duplicate');
+});
+
 test('import v2 with custom config', async (t) => {
   const config = {
     x: 1234,

--- a/packages/project/test/serialize/to-app-spec.test.ts
+++ b/packages/project/test/serialize/to-app-spec.test.ts
@@ -1,0 +1,136 @@
+import test from 'ava';
+import { cloneDeep } from 'lodash-es';
+
+import { Project } from '../../src/Project';
+import toAppSpec from '../../src/serialize/to-app-spec';
+
+const v2ProjectData: any = {
+  id: 'my-project',
+  name: 'My Project',
+  schema_version: '4.0',
+  workflows: [
+    {
+      id: 'my-workflow',
+      name: 'My Workflow',
+      start: 'webhook',
+      steps: [
+        {
+          id: 'webhook',
+          type: 'webhook',
+          enabled: true,
+          next: { 'transform-data': {} },
+        },
+        {
+          id: 'transform-data',
+          name: 'Transform data',
+          expression: 'fn(s => s)',
+          adaptor: '@openfn/language-common@latest',
+        },
+      ],
+    },
+  ],
+};
+
+const removableWorkflowData: any = {
+  id: 'my-project',
+  workflows: [
+    {
+      id: 'wf',
+      name: 'wf',
+      openfn: { uuid: 'wf-uuid' },
+      steps: [
+        {
+          id: 'trigger',
+          type: 'webhook',
+          openfn: { uuid: 'trigger-uuid' },
+          next: {
+            step: { openfn: { uuid: 'edge-uuid' } },
+          },
+        },
+        {
+          id: 'step',
+          name: 'step',
+          expression: '.',
+          adaptor: 'common',
+          openfn: { uuid: 'step-uuid' },
+        },
+      ],
+    },
+  ],
+};
+
+test('edges use source_trigger/target_job keys, not UUIDs', (t) => {
+  const project = new Project(v2ProjectData, { formats: { project: 'json' } });
+  const result = toAppSpec(project, { format: 'json' }) as any;
+
+  const edge = Object.values(result.workflows['my-workflow'].edges)[0] as any;
+  t.truthy(edge.source_trigger);
+  t.truthy(edge.target_job);
+  t.falsy(edge.source_trigger_id);
+  t.falsy(edge.target_job_id);
+  t.falsy(edge.id);
+});
+
+test('handle credentials', (t) => {
+  const data = cloneDeep(v2ProjectData);
+  data.credentials = [
+    {
+      name: 'x',
+      owner: 'a@b.org,',
+      uuid: '123',
+    },
+  ];
+  data.workflows[0].steps[1].configuration = `a@b.org|x`;
+
+  const project = new Project(data, { formats: { project: 'json' } });
+  const result = toAppSpec(project, { format: 'json' }) as any;
+
+  t.deepEqual(result.credentials, {
+    'a@b.org,|x': { name: 'x', owner: 'a@b.org,' },
+  });
+  t.is(
+    result.workflows['my-workflow'].jobs['transform-data'].credential,
+    'a@b.org|x'
+  );
+});
+
+test('source_trigger matches the trigger key', (t) => {
+  const project = new Project(v2ProjectData, { formats: { project: 'json' } });
+  const result = toAppSpec(project, { format: 'json' }) as any;
+
+  const wf = result.workflows['my-workflow'];
+  const edge = Object.values(wf.edges)[0] as any;
+  t.truthy(wf.triggers[edge.source_trigger]);
+});
+
+test('target_job matches the job key', (t) => {
+  const project = new Project(v2ProjectData, { formats: { project: 'json' } });
+  const result = toAppSpec(project, { format: 'json' }) as any;
+
+  const wf = result.workflows['my-workflow'];
+  const edge = Object.values(wf.edges)[0] as any;
+  t.truthy(wf.jobs[edge.target_job]);
+});
+
+test('triggers and jobs have no generated id', (t) => {
+  const project = new Project(v2ProjectData, { formats: { project: 'json' } });
+  const result = toAppSpec(project, { format: 'json' }) as any;
+
+  const wf = result.workflows['my-workflow'];
+  const trigger = Object.values(wf.triggers)[0] as any;
+  const job = Object.values(wf.jobs)[0] as any;
+  t.falsy(trigger.id);
+  t.falsy(job.id);
+});
+
+test('ignores removed flags', (t) => {
+  const data = cloneDeep(removableWorkflowData);
+  const project = new Project(data);
+  project.getWorkflow('wf')!.remove('step');
+
+  const result = toAppSpec(project, { format: 'json' }) as any;
+
+  // a spec has no notion of delete: true - the step is serialized normally
+  t.truthy(result.workflows['wf'].jobs.step);
+  t.falsy(result.workflows['wf'].jobs.step.delete);
+});

--- a/packages/project/test/serialize/to-app-state.test.ts
+++ b/packages/project/test/serialize/to-app-state.test.ts
@@ -238,7 +238,7 @@ test('should write openfn keys to objects', (t) => {
   t.is(state.workflows['wf'].edges['trigger->step'].x, 1);
 });
 
-test('should handle credentials', (t) => {
+test('should handle credentials with existing UUIDs', (t) => {
   const data = {
     id: 'my-project',
     credentials: [
@@ -279,6 +279,51 @@ test('should handle credentials', (t) => {
   const { step } = state.workflows['wf'].jobs;
   t.is(step.keychain_credential_id, 'k');
   t.is(step.project_credential_id, '123');
+});
+
+test('should handle credentials without UUIDs (ie new credentials)', (t) => {
+  const data = {
+    id: 'my-project',
+    credentials: [
+      {
+        name: 'cred',
+        owner: 'admin@openfn.org',
+      },
+    ],
+    workflows: [
+      {
+        id: 'wf',
+        name: 'wf',
+        steps: [
+          {
+            id: 'trigger',
+            type: 'webhook',
+            next: {
+              step: {},
+            },
+          },
+          {
+            id: 'step',
+            expression: '.',
+            configuration: 'admin@openfn.org|cred',
+            openfn: {
+              keychain_credential_id: 'k',
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  const state = toAppState(new Project(data), {
+    format: 'json',
+  }) as Provisioner.Project_v1;
+  const { step } = state.workflows['wf'].jobs;
+  t.is(step.keychain_credential_id, 'k');
+
+  // Should look like a UUID
+  t.is(typeof step.project_credential_id, 'string');
+  t.is(step.project_credential_id!.length, 36);
 });
 
 test('should force a UUID on project credentials', (t) => {

--- a/packages/project/test/serialize/to-app-state.test.ts
+++ b/packages/project/test/serialize/to-app-state.test.ts
@@ -642,18 +642,6 @@ test('a removed workflow becomes a minimal delete: true entry', (t) => {
   });
 });
 
-test('asSpec ignores removed flags', (t) => {
-  const data = cloneDeep(removableWorkflowData);
-  const project = new Project(data);
-  project.getWorkflow('wf')!.remove('step');
-
-  const result = toAppState(project, { format: 'json', asSpec: true }) as any;
-
-  // asSpec has no notion of delete: true - the step is serialized normally
-  t.truthy(result.workflows['wf'].jobs.step);
-  t.falsy(result.workflows['wf'].jobs.step.delete);
-});
-
 test('should serialize channels to app state', (t) => {
   const channels = [
     {
@@ -804,70 +792,6 @@ const v2ProjectData: any = {
     },
   ],
 };
-
-test('asSpec:true - edges use source_trigger/target_job keys, not UUIDs', (t) => {
-  const project = new Project(v2ProjectData, { formats: { project: 'json' } });
-  const result = toAppState(project, { format: 'json', asSpec: true }) as any;
-
-  const edge = Object.values(result.workflows['my-workflow'].edges)[0] as any;
-  t.truthy(edge.source_trigger);
-  t.truthy(edge.target_job);
-  t.falsy(edge.source_trigger_id);
-  t.falsy(edge.target_job_id);
-  t.falsy(edge.id);
-});
-
-test('asSpec:true - handle credentials', (t) => {
-  const data = cloneDeep(v2ProjectData);
-  data.credentials = [
-    {
-      name: 'x',
-      owner: 'a@b.org,',
-      uuid: '123',
-    },
-  ];
-  data.workflows[0].steps[1].configuration = `a@b.org|x`;
-
-  const project = new Project(data, { formats: { project: 'json' } });
-  const result = toAppState(project, { format: 'json', asSpec: true }) as any;
-
-  t.deepEqual(result.credentials, {
-    'a@b.org,|x': { name: 'x', owner: 'a@b.org,' },
-  });
-  t.is(
-    result.workflows['my-workflow'].jobs['transform-data'].credential,
-    'a@b.org|x'
-  );
-});
-
-test('asSpec:true - source_trigger matches the trigger key', (t) => {
-  const project = new Project(v2ProjectData, { formats: { project: 'json' } });
-  const result = toAppState(project, { format: 'json', asSpec: true }) as any;
-
-  const wf = result.workflows['my-workflow'];
-  const edge = Object.values(wf.edges)[0] as any;
-  t.truthy(wf.triggers[edge.source_trigger]);
-});
-
-test('asSpec:true - target_job matches the job key', (t) => {
-  const project = new Project(v2ProjectData, { formats: { project: 'json' } });
-  const result = toAppState(project, { format: 'json', asSpec: true }) as any;
-
-  const wf = result.workflows['my-workflow'];
-  const edge = Object.values(wf.edges)[0] as any;
-  t.truthy(wf.jobs[edge.target_job]);
-});
-
-test('asSpec:true - triggers and jobs have no generated id', (t) => {
-  const project = new Project(v2ProjectData, { formats: { project: 'json' } });
-  const result = toAppState(project, { format: 'json', asSpec: true }) as any;
-
-  const wf = result.workflows['my-workflow'];
-  const trigger = Object.values(wf.triggers)[0] as any;
-  const job = Object.values(wf.jobs)[0] as any;
-  t.falsy(trigger.id);
-  t.falsy(job.id);
-});
 
 test.skip('should convert a project back to app state in yaml', (t) => {
   // this is a serialized project file


### PR DESCRIPTION
## Short Description

This PR enables users to run a deploy from a file: either an exported project.yaml (from the app) or from A single v2 state file (the thing created when fetching a project).

```
openfn project deploy .projects/main@app.openfn.org.yaml --name my-new-project
```

Note that if you try and deploy a project to the same instance and the same UUID, it'll just override. In this case you have to pass `--new` or set a new name.

A side-effect of this work is that you can now edit a local project.yaml  file and deploy it directly to lightning - previously the CLI didn't allow this because a deploy would re-build the project.yaml from the local filesystem. Being able to modify the yaml directly is probably a useful escape hatch. But one I'll leave undocumented for now.

Fixes #1264

Bonus fix for https://github.com/OpenFn/kit/issues/1523

## QA Notes

To test this ( I recommend running against local or at least staging)

You can set `OPENFN_ENDPOINT` and `OPENFN_API_KEY` env vars to configure deploy targets and access and stuff. `.env` files work.

### Scenario 1 - deploy an exported project

- Go to any project in the app and export it as yaml
- copy the path to the file
- With a superuser API token, deploy that file to an instance: `openfn project deploy downlaoded-project.yaml --name my-duplicate`
- The project should exist on the target server
- Should work with whatever name you pass, or no name
- Should work on the same instance as you exported from, or a different one
- Should work with a new project, or an existing one

### Scenario 2 - re-deploy an existing project

- Fetch a project: `openfn project fetch <uuid> --alias og`
- Note that you'll now have a file like  `og@app.openfn.org.yaml`
- Now, with a superuser API token, deploy that file back: `openfn project deploy ./projects/og@app.openfn.org.yaml --name my-duplicate`
- Should work with whatever name you pass, or no name
- Should work on the same instance as you exported from, or a different one
- - Should work with a new project, or an existing one

## Test Cases

This PR has crept into some sensitive areas so I want to run a really thorough suite of QA against staging:

- [x] Do a regular change and deploy
- [x] deploy checked out as new 
- [x] deploy checked as an update to an existing project
- [ ] ~export a project spec (v1 and v2?) and deploy as new~
- [ ] ~export a project spec (v1 and v2?) and deploy to existing~
- [x] Take a project state and re-deploy as new
- [x] Take a project state and re-deploy to existing

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

