### PR TITLE
fix(ws-worker): suppress credential environment mismatch from sentry

### DIFF
--- a/packages/ws-worker/src/util/ignored-errors.ts
+++ b/packages/ws-worker/src/util/ignored-errors.ts
@@ -8,6 +8,10 @@ type IgnoredError = {
 // list of errors here!
 export const IGNORED_ERROR_PATTERNS: IgnoredError[] = [
   { pattern: /OAuth token has expired/i, severity: 'crash' },
+  // Raised when a project's environment has no matching credential
+  // environment. A configuration mistake for the user to fix, not a worker
+  // fault, and the message already tells them how to fix it.
+  { pattern: /Credential environment mismatch/i },
 ];
 
 const findIgnoredError = (message?: string | null) => {

--- a/packages/ws-worker/test/util/ignored-errors.test.ts
+++ b/packages/ws-worker/test/util/ignored-errors.test.ts
@@ -1,0 +1,43 @@
+import test from 'ava';
+
+import {
+  getIgnoredErrorSeverity,
+  matchesIgnoredError,
+} from '../../src/util/ignored-errors';
+
+test('matches an expired OAuth token', (t) => {
+  t.true(matchesIgnoredError('OAuth token has expired'));
+});
+
+test('matches a credential environment mismatch', (t) => {
+  const message = `[fetch:credential] Credential environment mismatch.
+This project is using 'geda' but credential 'Pius Git Token' does not have a matching environment.`;
+
+  t.true(matchesIgnoredError(message));
+});
+
+test('matches regardless of case', (t) => {
+  t.true(matchesIgnoredError('credential ENVIRONMENT Mismatch'));
+});
+
+test('does not match an unrelated error', (t) => {
+  t.false(matchesIgnoredError('Something else went wrong'));
+});
+
+test('does not match empty or nullish input', (t) => {
+  t.false(matchesIgnoredError(''));
+  t.false(matchesIgnoredError(null));
+  t.false(matchesIgnoredError(undefined));
+});
+
+test('reports the severity override for an expired OAuth token', (t) => {
+  t.is(getIgnoredErrorSeverity('OAuth token has expired'), 'crash');
+});
+
+test('leaves the exit reason alone for a credential environment mismatch', (t) => {
+  t.is(getIgnoredErrorSeverity('Credential environment mismatch'), undefined);
+});
+
+test('reports no severity for an unmatched error', (t) => {
+  t.is(getIgnoredErrorSeverity('Something else went wrong'), undefined);
+});


### PR DESCRIPTION
Closes #1460

Adds `Credential environment mismatch` to `IGNORED_ERROR_PATTERNS`, following the `OAuth token has expired` entry added in #1440.

```js
export const IGNORED_ERROR_PATTERNS: IgnoredError[] = [
  { pattern: /OAuth token has expired/i, severity: 'crash' },
  { pattern: /Credential environment mismatch/i },
];
```

## On the missing severity

The OAuth entry carries `severity: 'crash'`, which `onRunError` uses to override the exit reason. I deliberately left it off here.

The issue asks for this to be suppressed from sentry, and `matchesIgnoredError` alone does that — `getIgnoredErrorSeverity` is a separate lookup, and `onRunError` only overrides when it returns something. So omitting it keeps the change to exactly what was asked and leaves the reason Lightning receives untouched. If you do want an override, say which reason and it's a one-line addition; I did not want to change what the user sees reported without being asked.

## On the wider point in the thread

@josephjclark noted that the more important problem is differentiating these in sentry, since `LightningSocketError` is generic and sentry lumps everything together. That is a bigger change than this and I have not attempted it — this PR only stops this particular message from being reported.

## Tests

`src/util/ignored-errors.ts` had no tests, so this adds the first ones: both patterns, the case-insensitive match, an unrelated message, empty and nullish input, and the severity lookup for both entries — including that a credential mismatch returns no override, which pins the decision above.

- `test/util`: **75 passing**, up from 67. The 4 failures, 1 skip and 3 uncaught exceptions in that directory are identical before and after this change.
- `tsc --noEmit`: output identical before and after (the existing errors are unbuilt workspace deps and some `any` parameters in `wake-up.test.ts`).
- Reverting only the new pattern fails exactly the two credential tests.
