### PR TITLE
attempt to fix a deploy to an existing project

### DIFF
--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -176,13 +176,17 @@ export type SyncResult = {
 // This function is responsible for syncing changes in the user's local project
 // with the remote app version
 // It returns a merged state object
+//
+// skipLocallyChangedCheck: merge every workflow in the source, not just those
+// edited since its own last snapshot (that check is meaningless for a file)
 const syncProjects = async (
   options: DeployOptions,
   config: Required<AuthOptions>,
   ws: Workspace,
   localProject: Project,
   trackedProject: Project, // the project we want to update
-  logger: Logger
+  logger: Logger,
+  skipLocallyChangedCheck = false
 ): Promise<SyncResult | null> => {
   // First step, fetch the latest version and write
   // this may throw!
@@ -227,6 +231,9 @@ const syncProjects = async (
       );
     }
     mergeCandidates = options.workflow;
+  } else if (skipLocallyChangedCheck) {
+    // the source is the spec, so every workflow in it is a candidate
+    mergeCandidates = localProject.workflows.map((w) => w.id);
   } else {
     mergeCandidates = await findLocallyChangedWorkflows(ws, localProject);
   }
@@ -293,10 +300,10 @@ const syncProjects = async (
     mode: localProject.uuid === remoteProject.uuid ? 'replace' : 'sandbox',
     force: true,
   };
-  if (options.workflow?.length) {
-    // If --workflow is passed, force-include exactly the listed workflows via workflowMappings
+  if (options.workflow?.length || skipLocallyChangedCheck) {
+    // force-include exactly the candidate workflows
     mergeOptions.workflowMappings = Object.fromEntries(
-      options.workflow.map((id) => [id, id])
+      mergeCandidates.map((id) => [id, id])
     );
   } else {
     // Otherwise only merge locally updated workflows
@@ -387,9 +394,32 @@ export async function handler(options: DeployOptions, logger: Logger) {
   // If the user passed an explicit target, we need to use that
   // Otherwise just sync with the local project's own tracked remote
   let tracker;
-  if (!options.new) {
+  if (options.new) {
+    // reset all metadata
+    localProject.openfn = {
+      endpoint: config.endpoint,
+    };
+
+    // Enforce a sensible alias for the new project
+    // else it might overwrite the default
+    if (!localProject.alias || localProject.alias === 'main') {
+      alias = options.name?.replace(/\s+/g, '-');
+      localProject.alias = alias ?? null;
+    }
+  } else {
     ws ??= new Workspace(options.workspace || '.');
     tracker = ws.get(targetIdentifier ?? localProject.uuid!);
+
+    // A project loaded from a file already knows which remote it belongs
+    // to, so it can serve as its own deploy destination - we don't need a
+    // locally tracked copy of it to sync against
+    if (!tracker && filePath && localProject.uuid) {
+      logger.debug(
+        'No locally tracked project found: deploying to the remote named in the file'
+      );
+      tracker = localProject;
+    }
+
     if (!tracker) {
       // Is this really an error? Unlikely to happen I think
       console.log(
@@ -405,18 +435,6 @@ export async function handler(options: DeployOptions, logger: Logger) {
       );
 
       throw new Error('Failed to find remote project locally');
-    }
-  } else {
-    // reset all metadata
-    localProject.openfn = {
-      endpoint: config.endpoint,
-    };
-
-    // Enforce a sensible alias for the new project
-    // else it might overwrite the default
-    if (!localProject.alias || localProject.alias === 'main') {
-      alias = options.name?.replace(/\s+/g, '-');
-      localProject.alias = alias ?? null;
     }
   }
 
@@ -452,7 +470,9 @@ export async function handler(options: DeployOptions, logger: Logger) {
       ws!,
       localProject,
       tracker!,
-      logger
+      logger,
+      // a file's own snapshot tells us nothing about the target
+      !!filePath
     );
     if (!syncResult) {
       return;

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -436,6 +436,10 @@ export async function handler(options: DeployOptions, logger: Logger) {
 
       throw new Error('Failed to find remote project locally');
     }
+
+    // the local copy belongs to the project we deployed at, not the one
+    // we deployed from
+    alias ??= tracker.alias ?? undefined;
   }
 
   // Choose the target endpoint we want to deploy to

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -49,13 +49,13 @@ const mockFs = (paths: Record<string, string>) => {
   );
   // undici v8 reads its llhttp WASM from disk on the first request, so keep
   // that dir visible or fetches to the mock server fail with ENOENT
-  const undiciLlhttp = path.join(
+  const undicihttp = path.join(
     path.dirname(require.resolve('undici')),
     'lib/llhttp'
   );
   mock({
     [iconv]: mock.load(iconv, {}),
-    [undiciLlhttp]: mock.load(undiciLlhttp, {}),
+    [undicihttp]: mock.load(undicihttp, {}),
     ...paths,
   });
 };
@@ -205,6 +205,78 @@ test.serial(
     t.regex(mainAfter, new RegExp(`uuid: ${UUID}`));
   }
 );
+
+test.serial(
+  'deploy a file to a different target must use the file, not the checked-out baseline',
+  async (t) => {
+    // "dev" is a separate, already-existing remote project with its own content
+    await server.addProject(two_workflows_yaml);
+
+    // check out "main" - openfn.yaml now tracks MAIN's own fork history,
+    // which has nothing to do with "dev"
+    await setup(projectYaml);
+
+    // track "dev" locally too, alongside "main", without disturbing what's
+    // currently checked out
+    await writeFile('/ws/.projects/dev@localhost.yaml', two_workflows_yaml);
+
+    // deploy main's own (unmodified) file to "dev" - a different target.
+    // Nothing has changed relative to MAIN's own tracked baseline, but
+    // "dev" has completely different content and must be replaced with
+    // what's in the file
+    await deploy(
+      {
+        endpoint: ENDPOINT,
+        apiKey: 'test-api-key',
+        workspace: '/ws',
+        project: '/ws/.projects/main@localhost.yaml',
+        target: 'dev',
+        confirm: false,
+      } as any,
+      logger
+    );
+
+    const devProject: any = server.state.projects[TWO_WORKFLOWS_UUID];
+    const devWorkflows = Object.values(devProject.workflows) as any[];
+
+    // dev must now contain My Workflow (from main's file) - not be left
+    // with only its own original workflow-a/workflow-b
+    const hasMyWorkflow = devWorkflows.some((wf) => wf.name === 'My Workflow');
+    t.true(hasMyWorkflow);
+
+    const success = logger._find('success', /Updated project at/);
+    t.truthy(success);
+  }
+);
+
+test.serial('deploy an updated project direct to an endpoint', async (t) => {
+  const remoteProjectBefore: any = server.state.projects[UUID];
+  const wfBefore = remoteProjectBefore.workflows['my-workflow'];
+  t.is(wfBefore.jobs['transform-data'].body, 'fn()');
+
+  mockFs({
+    '/ws/dev@localhost.yaml': projectYaml.replace('fn()', 'jam()'),
+    '/ws/openfn.yaml': '',
+  });
+
+  // deploy the local project file directly
+  await deploy(
+    {
+      endpoint: ENDPOINT,
+      apiKey: 'test-api-key',
+      workspace: '/ws',
+      project: '/ws/dev@localhost.yaml',
+      target: 'dev',
+      confirm: false,
+      // log: 'debug',
+    } as any,
+    logger
+  );
+
+  const remoteProjectAfter: any = server.state.projects[UUID];
+  const wfAfter = remoteProjectAfter.workflows['my-workflow'];
+  t.is(wfAfter.jobs['transform-data'].body, 'jam()');
+});
 
 test.serial('deploy a new project creates ids for collections', async (t) => {
   const yamlWithCollections = projectYaml.replace(

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -246,6 +246,18 @@ test.serial(
 
     const success = logger._find('success', /Updated project at/);
     t.truthy(success);
+
+    // the deploy landed on dev, so dev's local copy is the one to refresh
+    const devAfter = fs.readFileSync('/ws/.projects/dev@localhost.yaml', 'utf8');
+    t.regex(devAfter, /My Workflow/);
+
+    // and the file we deployed FROM must not be rewritten with dev's state
+    const mainAfter = fs.readFileSync(
+      '/ws/.projects/main@localhost.yaml',
+      'utf8'
+    );
+    t.regex(mainAfter, new RegExp(`uuid: ${UUID}`));
+    t.notRegex(mainAfter, new RegExp(TWO_WORKFLOWS_UUID));
   }
 );
 


### PR DESCRIPTION
Using claude to try and fix deploying from a spec file to an existing project.

```
pnpm openfn project deploy ./.projects/jam3@localhost.yaml  --endpoint http://localhost:4000 --apikey $LOCAL_LIGHTNING_SUPER_PAT --name foo --log debug -f

```

Two problems here: a dubious divergence test (maybe we should ignore divergence when posting cross-domain?),  and then the acutal diff doesn't seem to apply