### PR TITLE
Checkout project yaml rebase

### DIFF
--- a/.changeset/fast-boats-grin.md
+++ b/.changeset/fast-boats-grin.md
@@ -1,0 +1,5 @@
+---
+'@openfn/project': patch
+---
+
+Fix an issue where serializing a project without credential uuids to app state causes credentials on job bodies to be lost

--- a/.changeset/fast-cobras-throw.md
+++ b/.changeset/fast-cobras-throw.md
@@ -1,0 +1,5 @@
+---
+'@openfn/lexicon': patch
+---
+
+Project credentials can optionally have a UUID

--- a/.changeset/fruity-moles-dream.md
+++ b/.changeset/fruity-moles-dream.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+`project deploy`: fix issues removing workflows, steps and edges while deploying.

--- a/.changeset/khaki-jars-relax.md
+++ b/.changeset/khaki-jars-relax.md
@@ -1,0 +1,5 @@
+---
+'@openfn/ws-worker': patch
+---
+
+Fail a run cleanly instead of hanging when Lightning rejects the plan fetch after a claim

--- a/.changeset/metal-words-go.md
+++ b/.changeset/metal-words-go.md
@@ -1,0 +1,5 @@
+---
+'@openfn/lightning-mock': minor
+---
+
+Improve support for removing workflows, steps and edges

--- a/.changeset/shaky-papayas-change.md
+++ b/.changeset/shaky-papayas-change.md
@@ -1,0 +1,5 @@
+---
+'@openfn/project': patch
+---
+
+Enable projects loaded from state files to be stateless

--- a/.changeset/slow-seals-type.md
+++ b/.changeset/slow-seals-type.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Ensure that new projects don't overwrite existing aliases

--- a/.changeset/small-cougars-check.md
+++ b/.changeset/small-cougars-check.md
@@ -1,0 +1,7 @@
+---
+'@openfn/project': patch
+---
+
+- Fix an issue where removing a workflow triggers an error on merge
+- Allow Workflows to track deleted entities internally via the `removed` index
+- Recognise `delete` state on workflows, steps and edges when parsing from/to app state

--- a/.changeset/tidy-hoops-jam.md
+++ b/.changeset/tidy-hoops-jam.md
@@ -1,0 +1,6 @@
+---
+'@openfn/project': patch
+'@openfn/cli': patch
+---
+
+Fix an issue where --name doens't apply to a project loaded from file

--- a/.changeset/upset-cougars-smile.md
+++ b/.changeset/upset-cougars-smile.md
@@ -1,0 +1,5 @@
+---
+'@openfn/lexicon': patch
+---
+
+Recognise delete key in provisioner state

--- a/.changeset/young-brooms-drum.md
+++ b/.changeset/young-brooms-drum.md
@@ -1,0 +1,5 @@
+---
+'@openfn/cli': patch
+---
+
+Enable a v2 project yaml file to be deployed directly, eg, `openfn project deploy .projects/main@app.openfn.org.yaml

--- a/integration-tests/cli/test/deploy.v2.test.ts
+++ b/integration-tests/cli/test/deploy.v2.test.ts
@@ -427,6 +427,91 @@ test.serial('warn when local and remote workflows have diverged', async (t) => {
 });
 
 test.serial(
+  'deploy a pulled v2 state file as a new project',
+  async (t) => {
+    const projectId = 'iiiiiiii';
+    server.addProject(makeProject(projectId) as any);
+
+    const before = Object.keys(server.state.projects);
+
+    // pull with an alias, producing a fetched v2 state file that has a uuid
+    const pullResult = await run(
+      `openfn project pull ${projectId} --alias og --log-json -l debug`
+    );
+    t.falsy(pullResult.stderr);
+
+    const pulledPath = path.join(tmpDir, '.projects', 'og@localhost.yaml');
+
+    // deploy that exact file back as a duplicate
+    const { stdout, stderr } = await run(
+      `openfn project deploy ${pulledPath} --new --name my-duplicate --no-confirm --log-json -l debug`
+    );
+    t.falsy(stderr);
+
+    const logs = extractLogs(stdout);
+    assertLog(t, logs, /Created new project/);
+
+    const after = Object.keys(server.state.projects);
+    t.is(after.length, before.length + 1);
+
+    const newId = after.find((id) => !before.includes(id));
+    t.not(newId, projectId);
+
+    const proj = server.state.projects[newId!];
+    t.is(proj.name, 'my-duplicate');
+
+    const workflows = Object.values(proj.workflows) as any[];
+    t.is(workflows.length, 1);
+    t.is(workflows[0].name, 'My Workflow');
+  }
+);
+
+test.serial(
+  'deploy a pulled state file to a different tracked project',
+  async (t) => {
+    const mainId = 'llllllll-main';
+    const stagingId = 'llllllll-staging';
+
+    server.addProject(makeProject(mainId) as any);
+    const stagingFixture = makeProject(stagingId) as any;
+    // give staging a distinct id/name and content, otherwise it's
+    // indistinguishable from main once both are tracked locally
+    stagingFixture.name = 'staging-project';
+    stagingFixture.workflows[0].jobs[0].body = "post('STAGING')";
+    server.addProject(stagingFixture);
+
+    // track both locally, same as any other pull
+    await run(
+      `openfn project pull ${mainId} --alias main --log-json -l debug`
+    );
+    await run(
+      `openfn project pull ${stagingId} --alias staging --log-json -l debug`
+    );
+
+    const mainPath = path.join(tmpDir, '.projects', 'main@localhost.yaml');
+
+    // deploy main's pulled file, but target staging instead of main
+    const { stdout, stderr } = await run(
+      `openfn project deploy ${mainPath} staging --no-confirm --log-json -l debug`
+    );
+    t.falsy(stderr);
+    assertLog(t, extractLogs(stdout), /Updated project/);
+
+    // staging's remote content now matches main's, replacing its own...
+    const stagingProj = server.state.projects[stagingId];
+    t.is(stagingProj.name, 'staging-project');
+    t.regex(
+      stagingProj.workflows['my-workflow-1'].jobs['my-job'].body,
+      /fn\(s => s\)/
+    );
+
+    // ...while main itself was left untouched
+    const mainProj = server.state.projects[mainId];
+    t.regex(mainProj.workflows[0].jobs[0].body, /fn\(s => s\)/);
+  }
+);
+
+test.serial(
   'deploy collections: add a collection via openfn.yaml',
   async (t) => {
     const projectId = 'gggggggg';

--- a/integration-tests/cli/test/deploy.v2.test.ts
+++ b/integration-tests/cli/test/deploy.v2.test.ts
@@ -426,45 +426,55 @@ test.serial('warn when local and remote workflows have diverged', async (t) => {
   assertLog(t, logs, /Projects have diverged/i);
 });
 
-test.serial(
-  'deploy a pulled v2 state file as a new project',
-  async (t) => {
-    const projectId = 'iiiiiiii';
-    server.addProject(makeProject(projectId) as any);
+test.serial('deploy a pulled v2 state file as a new project', async (t) => {
+  const projectId = 'iiiiiiii';
+  server.addProject(makeProject(projectId) as any);
 
-    const before = Object.keys(server.state.projects);
+  const before = Object.keys(server.state.projects);
 
-    // pull with an alias, producing a fetched v2 state file that has a uuid
-    const pullResult = await run(
-      `openfn project pull ${projectId} --alias og --log-json -l debug`
-    );
-    t.falsy(pullResult.stderr);
+  // pull with an alias, producing a fetched v2 state file that has a uuid
+  const pullResult = await run(
+    `openfn project pull ${projectId} --alias og --log-json -l debug`
+  );
+  t.falsy(pullResult.stderr);
 
-    const pulledPath = path.join(tmpDir, '.projects', 'og@localhost.yaml');
+  const pulledPath = path.join(tmpDir, '.projects', 'og@localhost.yaml');
 
-    // deploy that exact file back as a duplicate
-    const { stdout, stderr } = await run(
-      `openfn project deploy ${pulledPath} --new --name my-duplicate --no-confirm --log-json -l debug`
-    );
-    t.falsy(stderr);
+  // deploy that exact file back as a duplicate
+  const { stdout, stderr } = await run(
+    `openfn project deploy ${pulledPath} --new --name my-duplicate --no-confirm --log-json -l debug`
+  );
+  t.falsy(stderr);
 
-    const logs = extractLogs(stdout);
-    assertLog(t, logs, /Created new project/);
+  const logs = extractLogs(stdout);
+  assertLog(t, logs, /Created new project/);
 
-    const after = Object.keys(server.state.projects);
-    t.is(after.length, before.length + 1);
+  const after = Object.keys(server.state.projects);
+  t.is(after.length, before.length + 1);
 
-    const newId = after.find((id) => !before.includes(id));
-    t.not(newId, projectId);
+  const newId = after.find((id) => !before.includes(id));
+  t.not(newId, projectId);
 
-    const proj = server.state.projects[newId!];
-    t.is(proj.name, 'my-duplicate');
+  const proj = server.state.projects[newId!];
+  t.is(proj.name, 'my-duplicate');
 
-    const workflows = Object.values(proj.workflows) as any[];
-    t.is(workflows.length, 1);
-    t.is(workflows[0].name, 'My Workflow');
-  }
-);
+  const workflows = Object.values(proj.workflows) as any[];
+  t.is(workflows.length, 1);
+  t.is(workflows[0].name, 'My Workflow');
+
+  // --new must strip embedded state, not just the project's own uuid -
+  // the new workflow and step must get fresh ids too, not reuse the
+  // original project's
+  const original = server.state.projects[projectId];
+  const originalWorkflowId = original.workflows[0].id;
+  const originalJobId = original.workflows[0].jobs[0].id;
+
+  const newWorkflowId = Object.keys(proj.workflows)[0];
+  t.not(newWorkflowId, originalWorkflowId);
+
+  const newJobId = workflows[0].jobs['my-job'].id;
+  t.not(newJobId, originalJobId);
+});
 
 test.serial(
   'deploy a pulled state file to a different tracked project',
@@ -481,9 +491,7 @@ test.serial(
     server.addProject(stagingFixture);
 
     // track both locally, same as any other pull
-    await run(
-      `openfn project pull ${mainId} --alias main --log-json -l debug`
-    );
+    await run(`openfn project pull ${mainId} --alias main --log-json -l debug`);
     await run(
       `openfn project pull ${stagingId} --alias staging --log-json -l debug`
     );

--- a/integration-tests/cli/test/deploy.v2.test.ts
+++ b/integration-tests/cli/test/deploy.v2.test.ts
@@ -496,8 +496,6 @@ workflows:
   const exportedPath = path.join(tmpDir, 'exported-project.yaml');
   await fs.writeFile(exportedPath, specYaml);
 
-  // TODO: --name has no effect on file-based deploys yet (deploy.ts only
-  // reads options.name in the workspace/fs branch) - fix and add a test
   const { stdout, stderr } = await run(
     `openfn project deploy ${exportedPath} --name my-duplicate --no-confirm --log-json -l debug`
   );
@@ -511,6 +509,8 @@ workflows:
 
   const newId = after.find((id) => !before.includes(id));
   const proj = server.state.projects[newId!];
+
+  t.is(proj.name, 'my-duplicate');
 
   const workflows = Object.values(proj.workflows) as any[];
   t.is(workflows.length, 1);

--- a/integration-tests/cli/test/deploy.v2.test.ts
+++ b/integration-tests/cli/test/deploy.v2.test.ts
@@ -2,10 +2,8 @@ import test from 'ava';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import run from '../src/run';
-import createLightningServer, {
-  DEFAULT_PROJECT_ID,
-} from '@openfn/lightning-mock';
 import Project, { jsonToYaml, yamlToJson } from '@openfn/project';
+import createLightningServer from '@openfn/lightning-mock';
 import { extractLogs, assertLog } from '../src/util';
 import { rimraf } from 'rimraf';
 import { makeProject, makeMultiProject } from './fixtures/projects';
@@ -190,6 +188,147 @@ test.serial('deploy then pull, change one workflow, deploy', async (t) => {
       log.level === 'always' && /^\s*-\s*my-workflow/.test(`${log.message}`)
   );
   t.falsy(myWorkflowLog);
+});
+
+test.serial('Remove a whole workflow', async (t) => {
+  const projectId = 'remove-workflow';
+  server.addProject(makeMultiProject(projectId) as any);
+
+  // pull multi workflow project
+  const pullResult = await run(
+    `openfn project pull ${projectId} --log-json -l debug`
+  );
+  t.falsy(pullResult.stderr);
+  assertLog(t, extractLogs(pullResult.stdout), /Checked out project locally/i);
+
+  let proj = server.state.projects[projectId];
+  t.is(Object.keys(proj.workflows).length, 2);
+
+  // remove another-workflow locally, like a user deleting the folder
+  await rimraf(path.join(tmpDir, 'workflows/another-workflow'));
+
+  // deploy
+  const { stdout, stderr } = await run(
+    `openfn project deploy --no-confirm --log-json -l debug`
+  );
+  t.falsy(stderr);
+
+  const logs = extractLogs(stdout);
+  assertLog(t, logs, /Updated project/);
+  assertLog(t, logs, /Another Workflow: deleted/);
+
+  // the workflow must actually be gone from the server, not just unmentioned
+  proj = server.state.projects[projectId];
+  const workflows = Object.values(proj.workflows) as any[];
+  t.is(workflows.length, 1);
+  t.is(workflows[0].name, 'My Workflow');
+});
+
+test.serial('remove a step and its edge from a workflow', async (t) => {
+  const projectId = 'remove-step';
+  server.addProject(makeProject(projectId) as any);
+
+  const pullResult = await run(
+    `openfn project pull ${projectId} --log-json -l debug`
+  );
+  t.falsy(pullResult.stderr);
+  assertLog(t, extractLogs(pullResult.stdout), /Checked out project locally/i);
+
+  // Remove my-job and the edge into it, consistently, in the same edit - the
+  // local project file has to do this itself, the CLI won't clean up a
+  // dangling edge left pointing at a step that's no longer there.
+  const workflowYamlPath = path.join(
+    tmpDir,
+    'workflows/my-workflow/my-workflow.yaml'
+  );
+  await fs.writeFile(
+    workflowYamlPath,
+    `id: my-workflow
+name: My Workflow
+start: webhook
+steps:
+  - id: webhook
+    type: webhook
+    enabled: true
+    next: {}
+`
+  );
+  await rimraf(path.join(tmpDir, 'workflows/my-workflow/my-job.js'));
+
+  const { stdout, stderr } = await run(
+    `openfn project deploy --no-confirm --log-json -l debug`
+  );
+  t.falsy(stderr);
+
+  const logs = extractLogs(stdout);
+  assertLog(t, logs, /Updated project/);
+  assertLog(t, logs, /My Job: removed/);
+
+  // the job and its edge must actually be gone from the server
+  const proj = server.state.projects[projectId];
+  const wf = Object.values(proj.workflows).find(
+    (w: any) => w.id === 'my-workflow-1'
+  ) as any;
+  const jobs = Array.isArray(wf.jobs) ? wf.jobs : Object.values(wf.jobs ?? {});
+  const edges = Array.isArray(wf.edges)
+    ? wf.edges
+    : Object.values(wf.edges ?? {});
+  t.is(jobs.length, 0);
+  t.is(edges.length, 0);
+});
+
+test.serial('remove an edge, leaving both steps in place', async (t) => {
+  const projectId = 'remove-edge';
+  server.addProject(makeProject(projectId) as any);
+
+  const pullResult = await run(
+    `openfn project pull ${projectId} --log-json -l debug`
+  );
+  t.falsy(pullResult.stderr);
+  assertLog(t, extractLogs(pullResult.stdout), /Checked out project locally/i);
+
+  // Remove just the edge from webhook -> my-job, keeping both steps as they
+  // are. The local project file drops the `next` entry itself.
+  const workflowYamlPath = path.join(
+    tmpDir,
+    'workflows/my-workflow/my-workflow.yaml'
+  );
+  await fs.writeFile(
+    workflowYamlPath,
+    `id: my-workflow
+name: My Workflow
+start: webhook
+steps:
+  - id: my-job
+    name: My Job
+    adaptor: '@openfn/language-common@latest'
+    expression: ./my-job.js
+  - id: webhook
+    type: webhook
+    enabled: true
+    next: {}
+`
+  );
+
+  const { stdout, stderr } = await run(
+    `openfn project deploy --no-confirm --log-json -l debug`
+  );
+  t.falsy(stderr);
+
+  const logs = extractLogs(stdout);
+  assertLog(t, logs, /Updated project/);
+
+  // both steps survive, but the edge between them must actually be gone
+  const proj = server.state.projects[projectId];
+  const wf = Object.values(proj.workflows).find(
+    (w: any) => w.id === 'my-workflow-1'
+  ) as any;
+  const jobs = Array.isArray(wf.jobs) ? wf.jobs : Object.values(wf.jobs ?? {});
+  const edges = Array.isArray(wf.edges)
+    ? wf.edges
+    : Object.values(wf.edges ?? {});
+  t.is(jobs.length, 1);
+  t.is(edges.length, 0);
 });
 
 /**

--- a/integration-tests/cli/test/deploy.v2.test.ts
+++ b/integration-tests/cli/test/deploy.v2.test.ts
@@ -470,6 +470,65 @@ test.serial(
   }
 );
 
+test.serial('deploy a v2 project spec file as a new project', async (t) => {
+  const before = Object.keys(server.state.projects);
+
+  const specYaml = `id: exported-project
+name: My Exported Project
+schema_version: '4.0'
+workflows:
+  - id: my-workflow
+    name: My Workflow
+    start: webhook
+    steps:
+      - id: webhook
+        type: webhook
+        enabled: true
+        next:
+          transform-data:
+            condition: always
+      - id: transform-data
+        name: Transform data
+        expression: 'fn(s => s)'
+        adaptor: '@openfn/language-common@latest'
+`;
+
+  const exportedPath = path.join(tmpDir, 'exported-project.yaml');
+  await fs.writeFile(exportedPath, specYaml);
+
+  // TODO: --name has no effect on file-based deploys yet (deploy.ts only
+  // reads options.name in the workspace/fs branch) - fix and add a test
+  const { stdout, stderr } = await run(
+    `openfn project deploy ${exportedPath} --name my-duplicate --no-confirm --log-json -l debug`
+  );
+  t.falsy(stderr);
+
+  const logs = extractLogs(stdout);
+  assertLog(t, logs, /Created new project/);
+
+  const after = Object.keys(server.state.projects);
+  t.is(after.length, before.length + 1);
+
+  const newId = after.find((id) => !before.includes(id));
+  const proj = server.state.projects[newId!];
+
+  const workflows = Object.values(proj.workflows) as any[];
+  t.is(workflows.length, 1);
+  t.is(workflows[0].name, 'My Workflow');
+
+  const jobs = Object.values(workflows[0].jobs) as any[];
+  t.is(jobs.length, 1);
+  t.is(jobs[0].body, 'fn(s => s)');
+  t.is(jobs[0].adaptor, '@openfn/language-common@latest');
+
+  const triggers = Object.values(workflows[0].triggers) as any[];
+  t.is(triggers.length, 1);
+  t.is(triggers[0].type, 'webhook');
+
+  const edges = Object.values(workflows[0].edges) as any[];
+  t.is(edges.length, 1);
+});
+
 test.serial(
   'deploy collections: remove a collection via openfn.yaml',
   async (t) => {

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -39,14 +39,17 @@ export type DeployOptions = Pick<
   | 'logJson'
   | 'confirm'
 > & {
-  project?: string; // this is a CLI positional arg, not an option
-  workspace?: string;
-  dryRun?: boolean;
-  new?: boolean;
-  name?: string;
+  // CLI positional args, rather than options
+  project?: string;
+  target?: string;
+
   alias?: string;
+  dryRun?: boolean;
   jsonDiff?: boolean;
+  name?: string;
+  new?: boolean;
   workflow?: string[];
+  workspace?: string;
 };
 
 const options = [
@@ -74,7 +77,7 @@ const printProjectName = (project: Project) =>
   `${project.id} (${project.openfn?.uuid || '<no UUID>'})`;
 
 export const command: yargs.CommandModule<DeployOptions> = {
-  command: 'deploy [project]',
+  command: 'deploy [project] [target]',
   aliases: 'push',
   describe: `Deploy the passed or checked-out project to a Lightning Instance`,
   builder: (yargs: yargs.Argv<DeployOptions>) =>
@@ -83,13 +86,25 @@ export const command: yargs.CommandModule<DeployOptions> = {
         describe:
           'The UUID, local id or local alias of the project to deploy to',
       })
+      .positional('target', {
+        describe:
+          'When deploying a local file, the UUID or alias of the remote project to deploy it to. Defaults to the UUID embedded in the file',
+      })
       .example(
         'deploy',
-        'Deploy the checked-out project its connected remote instance'
+        'Deploy the checked-out project to its connected remote instance'
       )
       .example(
         'deploy staging',
-        'Deploy the checkout-out project to the remote project with alias "staging"'
+        'Deploy the checked-out project to the remote project with alias "staging"'
+      )
+      .example(
+        'deploy project.yaml',
+        'Deploy project.yaml to its own tracked remote project'
+      )
+      .example(
+        'deploy project.yaml staging',
+        'Deploy project.yaml to the remote project with alias "staging"'
       ),
   handler: ensure('project-deploy', options),
 };
@@ -298,15 +313,36 @@ export async function handler(options: DeployOptions, logger: Logger) {
   );
   const config = loadAppAuthConfig(options, logger);
 
+  // Work out what we're deploying (a local file, or the checked-out
+  // workspace project) and, separately, which remote project to deploy it
+  // to. These are independent - a file can target any tracked remote, not
+  // just the one it came from.
+  let filePath: string | undefined;
+  let targetIdentifier: string | undefined;
+
+  if (options.project && options.target) {
+    // two positionals: `deploy <file> <target>` - the first is always a file
+    filePath = options.project;
+    targetIdentifier = options.target;
+  } else if (options.project) {
+    // one positional: a file (`deploy project.yaml`) or a target
+    // (`deploy staging`, deploying the checked-out project)
+    if (/\.(yaml|json)$/.test(options.project)) {
+      filePath = options.project;
+    } else {
+      targetIdentifier = options.project;
+    }
+  }
+
   // The local project that we want to actually deploy
   let localProject: Project;
-  let ws;
+  let ws: Workspace | undefined;
   let alias = options.alias ?? null;
 
-  if (options.project) {
+  if (filePath) {
     const localPath = path.resolve(
       options.workspace ?? process.cwd(),
-      options.project
+      filePath
     );
     logger.debug('Reading project from path ', localPath);
     localProject = await Project.from('path', localPath, {
@@ -342,16 +378,17 @@ export async function handler(options: DeployOptions, logger: Logger) {
   }
 
   // Track the remote we want to target
-  // If the user passed a project alias, we need to use that
-  // Otherwise just sync with the local project
+  // If the user passed an explicit target, we need to use that
+  // Otherwise just sync with the local project's own tracked remote
   let tracker;
   if (!options.new) {
-    tracker = ws?.get(options.project ?? localProject.uuid!);
+    ws ??= new Workspace(options.workspace || '.');
+    tracker = ws.get(targetIdentifier ?? localProject.uuid!);
     if (!tracker) {
-      // Is this really an error? Unlikely to happen I thuink
+      // Is this really an error? Unlikely to happen I think
       console.log(
         `ERROR: Failed to find tracked remote project ${
-          options.project ?? localProject.uuid!
+          targetIdentifier ?? localProject.uuid!
         } locally`
       );
       console.log('To deploy a new project, add --new to the command');
@@ -412,7 +449,7 @@ export async function handler(options: DeployOptions, logger: Logger) {
 
   /**
    * Questions:
-   * 1. When this serializses, should project_credentials have uuids?
+   * 1. When this serializes, should project_credentials have uuids?
    */
   const state = merged.serialize('state', {
     format: 'json',

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -349,6 +349,9 @@ export async function handler(options: DeployOptions, logger: Logger) {
     localProject = await Project.from('path', localPath, {
       name: options.name,
       alias,
+      // deploying an already-stateful file as new must not carry over its
+      // old workflow/step/edge ids - strip them as we parse
+      asSpec: !!options.new,
     });
 
     // If the local project doesn't have stateful stuff,

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -359,13 +359,6 @@ export async function handler(options: DeployOptions, logger: Logger) {
       );
       options.new = true;
 
-      // Enforce a sensible alias for the new project
-      // else it might overwrite the default
-      if (!localProject.alias || localProject.alias === 'main') {
-        alias = options.name?.replace(/\s+/g, '-');
-        localProject.alias = alias ?? null;
-      }
-
       // TODO ensure the alias is unique if we're posting a new project
     }
   } else {
@@ -415,6 +408,13 @@ export async function handler(options: DeployOptions, logger: Logger) {
     localProject.openfn = {
       endpoint: config.endpoint,
     };
+
+    // Enforce a sensible alias for the new project
+    // else it might overwrite the default
+    if (!localProject.alias || localProject.alias === 'main') {
+      alias = options.name?.replace(/\s+/g, '-');
+      localProject.alias = alias ?? null;
+    }
   }
 
   // Choose the target endpoint we want to deploy to

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -76,7 +76,7 @@ const printProjectName = (project: Project) =>
 export const command: yargs.CommandModule<DeployOptions> = {
   command: 'deploy [project]',
   aliases: 'push',
-  describe: `Deploy the checked out project to a Lightning Instance`,
+  describe: `Deploy the passed or checked-out project to a Lightning Instance`,
   builder: (yargs: yargs.Argv<DeployOptions>) =>
     build(options, yargs)
       .positional('project', {
@@ -298,25 +298,52 @@ export async function handler(options: DeployOptions, logger: Logger) {
   );
   const config = loadAppAuthConfig(options, logger);
 
-  // TODO this is the hard way to load the local alias
-  // We need track alias in openfn.yaml to make this easier (and tracked in from fs)
-  const ws = new Workspace(options.workspace || '.');
+  // The local project that we want to actually deploy
+  let localProject: Project;
+  let ws;
+  let alias = options.alias ?? null;
 
-  const active = ws.getTrackedProject();
-  const alias = options.alias ?? active?.alias;
+  if (options.project) {
+    logger.debug('Reading project from path ', options.project);
+    localProject = await Project.from(
+      'path',
+      path.resolve(options.workspace ?? process.cwd(), options.project)
+    );
 
-  const localProject = await Project.from('fs', {
-    root: options.workspace || '.',
-    alias,
-    name: options.name,
-  });
+    // If the local project doesn't have stateful stuff,
+    // flag this as a new upload
+    if (!localProject.uuid) {
+      logger.debug(
+        'Local project does not have a UUID: assuming this is a new project deployment'
+      );
+      options.new = true;
+
+      // TODO ensure the alias is unique if we're posting a new project
+    }
+  } else {
+    logger.debug('Reading checked-out project from workspace');
+    // TODO this is the hard way to load the local alias
+    // We need track alias in openfn.yaml to make this easier (and tracked in from fs)
+    ws = new Workspace(options.workspace || '.');
+
+    const active = ws.getTrackedProject();
+
+    // messy
+    alias ??= active?.alias ?? null;
+
+    localProject = await Project.from('fs', {
+      root: options.workspace || '.',
+      alias,
+      name: options.name,
+    });
+  }
 
   // Track the remote we want to target
   // If the user passed a project alias, we need to use that
   // Otherwise just sync with the local project
   let tracker;
   if (!options.new) {
-    tracker = ws.get(options.project ?? localProject.uuid!);
+    tracker = ws?.get(options.project ?? localProject.uuid!);
     if (!tracker) {
       // Is this really an error? Unlikely to happen I thuink
       console.log(
@@ -369,7 +396,7 @@ export async function handler(options: DeployOptions, logger: Logger) {
     const syncResult = await syncProjects(
       options,
       config,
-      ws,
+      ws!,
       localProject,
       tracker!,
       logger
@@ -382,6 +409,12 @@ export async function handler(options: DeployOptions, logger: Logger) {
 
   const state = merged.serialize('state', {
     format: 'json',
+    // If uploading a new project, serialize to spec, not state
+    // WRONG!!!!!
+    // We DO need to convert this to  v1 state
+    // We just need to ensure that credentials are handled properly
+    // something is wrong in the conversion
+    asSpec: options.new,
   }) as Provisioner.Project_v1;
 
   if (remoteProject) {
@@ -465,11 +498,16 @@ export async function handler(options: DeployOptions, logger: Logger) {
 
     updateForkedFrom(finalProject);
     const configData = finalProject.generateConfig();
+
+    // Write the updated openfn.yaml
+    // TODO: allow us to suppress writing this stuff
+    // (useful if posting from spec)
     await writeFile(
-      path.resolve(options.workspace!, configData.path),
+      path.resolve(options.workspace ?? process.cwd(), configData.path),
       configData.content
     );
 
+    // TODO if this was marked as new, we probably need to ensure a unique alias here
     const finalOutputPath = getSerializePath(localProject, options.workspace!);
     const fullFinalPath = await serialize(finalProject, finalOutputPath);
     logger.debug('Updated local project at ', fullFinalPath);

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -337,7 +337,7 @@ export async function handler(options: DeployOptions, logger: Logger) {
   // The local project that we want to actually deploy
   let localProject: Project;
   let ws: Workspace | undefined;
-  let alias = options.alias ?? null;
+  let alias = options.alias;
 
   if (filePath) {
     const localPath = path.resolve(
@@ -345,8 +345,10 @@ export async function handler(options: DeployOptions, logger: Logger) {
       filePath
     );
     logger.debug('Reading project from path ', localPath);
+
     localProject = await Project.from('path', localPath, {
       name: options.name,
+      alias,
     });
 
     // If the local project doesn't have stateful stuff,
@@ -356,6 +358,13 @@ export async function handler(options: DeployOptions, logger: Logger) {
         'Local project does not have a UUID: assuming this is a new project deployment'
       );
       options.new = true;
+
+      // Enforce a sensible alias for the new project
+      // else it might overwrite the default
+      if (!localProject.alias || localProject.alias === 'main') {
+        alias = options.name?.replace(/\s+/g, '-');
+        localProject.alias = alias ?? null;
+      }
 
       // TODO ensure the alias is unique if we're posting a new project
     }
@@ -367,8 +376,9 @@ export async function handler(options: DeployOptions, logger: Logger) {
 
     const active = ws.getTrackedProject();
 
-    // messy
-    alias ??= active?.alias ?? null;
+    if (!alias && active?.alias) {
+      alias = active.alias;
+    }
 
     localProject = await Project.from('fs', {
       root: options.workspace || '.',
@@ -529,9 +539,11 @@ export async function handler(options: DeployOptions, logger: Logger) {
       result as any,
       {
         endpoint: endpoint,
-        alias,
       },
-      merged.config
+      {
+        ...merged.config,
+        alias: alias as string | undefined,
+      }
     );
 
     updateForkedFrom(finalProject);
@@ -546,7 +558,7 @@ export async function handler(options: DeployOptions, logger: Logger) {
     );
 
     // TODO if this was marked as new, we probably need to ensure a unique alias here
-    const finalOutputPath = getSerializePath(localProject, options.workspace!);
+    const finalOutputPath = getSerializePath(finalProject, options.workspace!);
     const fullFinalPath = await serialize(finalProject, finalOutputPath);
     logger.debug('Updated local project at ', fullFinalPath);
 

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -407,14 +407,12 @@ export async function handler(options: DeployOptions, logger: Logger) {
     ({ merged, remoteProject, locallyChangedWorkflows } = syncResult);
   }
 
+  /**
+   * Questions:
+   * 1. When this serializses, should project_credentials have uuids?
+   */
   const state = merged.serialize('state', {
     format: 'json',
-    // If uploading a new project, serialize to spec, not state
-    // WRONG!!!!!
-    // We DO need to convert this to  v1 state
-    // We just need to ensure that credentials are handled properly
-    // something is wrong in the conversion
-    asSpec: options.new,
   }) as Provisioner.Project_v1;
 
   if (remoteProject) {

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -309,7 +309,9 @@ export async function handler(options: DeployOptions, logger: Logger) {
       options.project
     );
     logger.debug('Reading project from path ', localPath);
-    localProject = await Project.from('path', localPath);
+    localProject = await Project.from('path', localPath, {
+      name: options.name,
+    });
 
     // If the local project doesn't have stateful stuff,
     // flag this as a new upload

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -176,13 +176,17 @@ export type SyncResult = {
 // This function is responsible for syncing changes in the user's local project
 // with the remote app version
 // It returns a merged state object
+//
+// skipLocallyChangedCheck: merge every workflow in the source, not just those
+// edited since its own last snapshot (that check is meaningless for a file)
 const syncProjects = async (
   options: DeployOptions,
   config: Required<AuthOptions>,
   ws: Workspace,
   localProject: Project,
   trackedProject: Project, // the project we want to update
-  logger: Logger
+  logger: Logger,
+  skipLocallyChangedCheck = false
 ): Promise<SyncResult | null> => {
   // First step, fetch the latest version and write
   // this may throw!
@@ -227,6 +231,9 @@ const syncProjects = async (
       );
     }
     mergeCandidates = options.workflow;
+  } else if (skipLocallyChangedCheck) {
+    // the source is the spec, so every workflow in it is a candidate
+    mergeCandidates = localProject.workflows.map((w) => w.id);
   } else {
     mergeCandidates = await findLocallyChangedWorkflows(ws, localProject);
   }
@@ -293,10 +300,10 @@ const syncProjects = async (
     mode: localProject.uuid === remoteProject.uuid ? 'replace' : 'sandbox',
     force: true,
   };
-  if (options.workflow?.length) {
-    // If --workflow is passed, force-include exactly the listed workflows via workflowMappings
+  if (options.workflow?.length || skipLocallyChangedCheck) {
+    // force-include exactly the candidate workflows
     mergeOptions.workflowMappings = Object.fromEntries(
-      options.workflow.map((id) => [id, id])
+      mergeCandidates.map((id) => [id, id])
     );
   } else {
     // Otherwise only merge locally updated workflows
@@ -387,9 +394,32 @@ export async function handler(options: DeployOptions, logger: Logger) {
   // If the user passed an explicit target, we need to use that
   // Otherwise just sync with the local project's own tracked remote
   let tracker;
-  if (!options.new) {
+  if (options.new) {
+    // reset all metadata
+    localProject.openfn = {
+      endpoint: config.endpoint,
+    };
+
+    // Enforce a sensible alias for the new project
+    // else it might overwrite the default
+    if (!localProject.alias || localProject.alias === 'main') {
+      alias = options.name?.replace(/\s+/g, '-');
+      localProject.alias = alias ?? null;
+    }
+  } else {
     ws ??= new Workspace(options.workspace || '.');
     tracker = ws.get(targetIdentifier ?? localProject.uuid!);
+
+    // A project loaded from a file already knows which remote it belongs
+    // to, so it can serve as its own deploy destination - we don't need a
+    // locally tracked copy of it to sync against
+    if (!tracker && filePath && localProject.uuid) {
+      logger.debug(
+        'No locally tracked project found: deploying to the remote named in the file'
+      );
+      tracker = localProject;
+    }
+
     if (!tracker) {
       // Is this really an error? Unlikely to happen I think
       console.log(
@@ -406,18 +436,10 @@ export async function handler(options: DeployOptions, logger: Logger) {
 
       throw new Error('Failed to find remote project locally');
     }
-  } else {
-    // reset all metadata
-    localProject.openfn = {
-      endpoint: config.endpoint,
-    };
 
-    // Enforce a sensible alias for the new project
-    // else it might overwrite the default
-    if (!localProject.alias || localProject.alias === 'main') {
-      alias = options.name?.replace(/\s+/g, '-');
-      localProject.alias = alias ?? null;
-    }
+    // the local copy belongs to the project we deployed at, not the one
+    // we deployed from
+    alias ??= tracker.alias ?? undefined;
   }
 
   // Choose the target endpoint we want to deploy to
@@ -452,7 +474,9 @@ export async function handler(options: DeployOptions, logger: Logger) {
       ws!,
       localProject,
       tracker!,
-      logger
+      logger,
+      // a file's own snapshot tells us nothing about the target
+      !!filePath
     );
     if (!syncResult) {
       return;

--- a/packages/cli/src/projects/deploy.ts
+++ b/packages/cli/src/projects/deploy.ts
@@ -304,11 +304,12 @@ export async function handler(options: DeployOptions, logger: Logger) {
   let alias = options.alias ?? null;
 
   if (options.project) {
-    logger.debug('Reading project from path ', options.project);
-    localProject = await Project.from(
-      'path',
-      path.resolve(options.workspace ?? process.cwd(), options.project)
+    const localPath = path.resolve(
+      options.workspace ?? process.cwd(),
+      options.project
     );
+    logger.debug('Reading project from path ', localPath);
+    localProject = await Project.from('path', localPath);
 
     // If the local project doesn't have stateful stuff,
     // flag this as a new upload

--- a/packages/cli/src/projects/util.ts
+++ b/packages/cli/src/projects/util.ts
@@ -179,12 +179,10 @@ export async function deployProject(
       if (contentType.match('application/json')) {
         const body = await response.json();
         logger?.error(JSON.stringify(body, null, 2));
-        console.log(JSON.stringify(body, null, 2));
       } else {
         const content = await response.text();
         // TODO html errors are too long to be useful... figure this out later
         logger?.error(content);
-        console.log(JSON.stringify(content, null, 2));
       }
       throw new CLIError(
         `Failed to deploy project ${state.name}: ${response.status}`

--- a/packages/cli/src/projects/util.ts
+++ b/packages/cli/src/projects/util.ts
@@ -179,12 +179,13 @@ export async function deployProject(
       if (contentType.match('application/json')) {
         const body = await response.json();
         logger?.error(JSON.stringify(body, null, 2));
+        console.log(JSON.stringify(body, null, 2));
       } else {
         const content = await response.text();
         // TODO html errors are too long to be useful... figure this out later
         logger?.error(content);
+        console.log(JSON.stringify(content, null, 2));
       }
-
       throw new CLIError(
         `Failed to deploy project ${state.name}: ${response.status}`
       );

--- a/packages/cli/test/projects/create-credentials.test.ts
+++ b/packages/cli/test/projects/create-credentials.test.ts
@@ -51,7 +51,7 @@ test('sync-credentials: ignores duplicate references', (t) => {
   t.deepEqual(findCredentialIds(project), ['same']);
 });
 
-test.only('sync-credentials: creates credential yaml file', (t) => {
+test('sync-credentials: creates credential yaml file', (t) => {
   mock({ '/ws': {} });
 
   const project = new Project(

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -111,6 +111,8 @@ test.serial(
   }
 );
 
+// TODO I think this NAUGHTILY overwrites the main alias
+// we probably shouldn't do that.
 test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
   // the server should have 1 registered project by default - that's fine
   t.is(Object.keys(server.state.projects).length, 1);
@@ -167,6 +169,42 @@ test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
   const success = logger._find('success', /Created new project at/);
   t.truthy(success);
 });
+
+test.serial(
+  'deploy a stateful project as new from a file, with an alias',
+  async (t) => {
+    // Set up a project with a UUID
+    mockFs({
+      '/ws/.projects/main@localhost.yaml': projectYaml,
+      '/ws/openfn.yaml': '',
+    });
+
+    // Deploy it elsewhere
+    await deploy(
+      {
+        endpoint: ENDPOINT,
+        apiKey: 'test-api-key',
+        workspace: '/ws',
+        project: '/ws/.projects/main@localhost.yaml',
+        new: true,
+        alias: 'staging',
+      } as any,
+      logger
+    );
+
+    // the new project should be saved locally under the alias we asked
+    // for, not the alias of the file we deployed from
+    t.true(fs.existsSync('/ws/.projects/staging@localhost.yaml'));
+
+    // the file we deployed FROM must not be clobbered with the new
+    // project's state
+    const mainAfter = fs.readFileSync(
+      '/ws/.projects/main@localhost.yaml',
+      'utf8'
+    );
+    t.regex(mainAfter, new RegExp(`uuid: ${UUID}`));
+  }
+);
 
 test.serial('deploy a new project creates ids for collections', async (t) => {
   const yamlWithCollections = projectYaml.replace(

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -25,6 +25,7 @@ import {
   UUID,
   two_workflows_yaml as twowfs,
   TWO_WORKFLOWS_UUID,
+  myProject_spec,
 } from './fixtures';
 import { checkout } from '../../src/projects';
 
@@ -84,24 +85,58 @@ test.beforeEach(() => {
   mock.restore();
 });
 
-test.serial('deploy a new project', async (t) => {
+test.serial(
+  'deploy a project as new from the checked out project',
+  async (t) => {
+    // the server should have 1 registered project by default - that's fine
+    t.is(Object.keys(server.state.projects).length, 1);
+
+    await setup();
+
+    await deploy(
+      {
+        endpoint: ENDPOINT,
+        apiKey: 'test-api-key',
+        workspace: '/ws',
+        new: true,
+      } as any,
+      logger
+    );
+
+    // We should now have a new project with a new UUID
+    t.is(Object.keys(server.state.projects).length, 2);
+
+    const success = logger._find('success', /Created new project at/);
+    t.truthy(success);
+  }
+);
+
+// TODO this generates a UUID for credentials, but that's naughty init
+// Also the credential does not appear to be set on the job
+test.serial.only('deploy a project as new from a v2 spec yaml', async (t) => {
   // the server should have 1 registered project by default - that's fine
   t.is(Object.keys(server.state.projects).length, 1);
 
-  await setup();
+  // skip the usual setup and just set up the filesystem
+  mockFs({
+    '/ws/.projects/main@localhost.yaml': myProject_spec,
+    '/ws/openfn.yaml': '', // TODO this shouldn;'t be neeed
+  });
 
   await deploy(
     {
       endpoint: ENDPOINT,
       apiKey: 'test-api-key',
-      workspace: '/ws',
-      new: true,
+      project: '/ws/.projects/main@localhost.yaml',
     } as any,
     logger
   );
 
+  console.log(logger._history);
+
   // We should now have a new project with a new UUID
   t.is(Object.keys(server.state.projects).length, 2);
+  // TODO more assertions
 
   const success = logger._find('success', /Created new project at/);
   t.truthy(success);

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -111,16 +111,14 @@ test.serial(
   }
 );
 
-// TODO this generates a UUID for credentials, but that's naughty init
-// Also the credential does not appear to be set on the job
-test.serial.only('deploy a project as new from a v2 spec yaml', async (t) => {
+test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
   // the server should have 1 registered project by default - that's fine
   t.is(Object.keys(server.state.projects).length, 1);
 
   // skip the usual setup and just set up the filesystem
   mockFs({
     '/ws/.projects/main@localhost.yaml': myProject_spec,
-    '/ws/openfn.yaml': '', // TODO this shouldn;'t be neeed
+    '/ws/openfn.yaml': '', // TODO this shouldn't be needed
   });
 
   await deploy(
@@ -136,7 +134,10 @@ test.serial.only('deploy a project as new from a v2 spec yaml', async (t) => {
 
   // We should now have a new project with a new UUID
   t.is(Object.keys(server.state.projects).length, 2);
+
   // TODO more assertions
+  // project structure looks right (edges in particular)
+  // - credential is OK
 
   const success = logger._find('success', /Created new project at/);
   t.truthy(success);

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -130,8 +130,6 @@ test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
     logger
   );
 
-  console.log(logger._history);
-
   // We should now have a new project with a new UUID
   t.is(Object.keys(server.state.projects).length, 2);
 

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -133,9 +133,36 @@ test.serial('deploy a project as new from a v2 spec yaml', async (t) => {
   // We should now have a new project with a new UUID
   t.is(Object.keys(server.state.projects).length, 2);
 
-  // TODO more assertions
-  // project structure looks right (edges in particular)
-  // - credential is OK
+  const newUuid = Object.keys(server.state.projects).find((id) => id !== UUID);
+  const newProject = server.state.projects[newUuid!];
+
+  // credential should have been created with a generated uuid
+  t.is(newProject.project_credentials.length, 1);
+  const credential = newProject.project_credentials[0];
+  t.is(credential.name, 'http1');
+  t.is(credential.owner, 'super@openfn.org');
+  t.truthy(credential.id);
+
+  // only one workflow, keyed by a generated uuid rather than 'my-workflow'
+  const workflows = Object.values(newProject.workflows) as any[];
+  t.is(workflows.length, 1);
+  const workflow = workflows[0];
+  t.is(workflow.name, 'My Workflow');
+
+  const job = workflow.jobs['transform-data'];
+  t.is(job.body, 'fn()');
+  t.is(job.adaptor, '@openfn/language-common@latest');
+  // the job's configuration should resolve to the new credential
+  t.is(job.project_credential_id, credential.id);
+
+  const trigger = workflow.triggers['webhook'];
+  t.truthy(trigger);
+  t.is(trigger.type, 'webhook');
+
+  const edge = workflow.edges['webhook->transform-data'];
+  t.truthy(edge);
+  t.is(edge.source_trigger_id, trigger.id);
+  t.is(edge.target_job_id, job.id);
 
   const success = logger._find('success', /Created new project at/);
   t.truthy(success);

--- a/packages/cli/test/projects/deploy.test.ts
+++ b/packages/cli/test/projects/deploy.test.ts
@@ -49,13 +49,13 @@ const mockFs = (paths: Record<string, string>) => {
   );
   // undici v8 reads its llhttp WASM from disk on the first request, so keep
   // that dir visible or fetches to the mock server fail with ENOENT
-  const undiciLlhttp = path.join(
+  const undicihttp = path.join(
     path.dirname(require.resolve('undici')),
     'lib/llhttp'
   );
   mock({
     [iconv]: mock.load(iconv, {}),
-    [undiciLlhttp]: mock.load(undiciLlhttp, {}),
+    [undicihttp]: mock.load(undicihttp, {}),
     ...paths,
   });
 };
@@ -205,6 +205,90 @@ test.serial(
     t.regex(mainAfter, new RegExp(`uuid: ${UUID}`));
   }
 );
+
+test.serial(
+  'deploy a file to a different target must use the file, not the checked-out baseline',
+  async (t) => {
+    // "dev" is a separate, already-existing remote project with its own content
+    await server.addProject(two_workflows_yaml);
+
+    // check out "main" - openfn.yaml now tracks MAIN's own fork history,
+    // which has nothing to do with "dev"
+    await setup(projectYaml);
+
+    // track "dev" locally too, alongside "main", without disturbing what's
+    // currently checked out
+    await writeFile('/ws/.projects/dev@localhost.yaml', two_workflows_yaml);
+
+    // deploy main's own (unmodified) file to "dev" - a different target.
+    // Nothing has changed relative to MAIN's own tracked baseline, but
+    // "dev" has completely different content and must be replaced with
+    // what's in the file
+    await deploy(
+      {
+        endpoint: ENDPOINT,
+        apiKey: 'test-api-key',
+        workspace: '/ws',
+        project: '/ws/.projects/main@localhost.yaml',
+        target: 'dev',
+        confirm: false,
+      } as any,
+      logger
+    );
+
+    const devProject: any = server.state.projects[TWO_WORKFLOWS_UUID];
+    const devWorkflows = Object.values(devProject.workflows) as any[];
+
+    // dev must now contain My Workflow (from main's file) - not be left
+    // with only its own original workflow-a/workflow-b
+    const hasMyWorkflow = devWorkflows.some((wf) => wf.name === 'My Workflow');
+    t.true(hasMyWorkflow);
+
+    const success = logger._find('success', /Updated project at/);
+    t.truthy(success);
+
+    // the deploy landed on dev, so dev's local copy is the one to refresh
+    const devAfter = fs.readFileSync('/ws/.projects/dev@localhost.yaml', 'utf8');
+    t.regex(devAfter, /My Workflow/);
+
+    // and the file we deployed FROM must not be rewritten with dev's state
+    const mainAfter = fs.readFileSync(
+      '/ws/.projects/main@localhost.yaml',
+      'utf8'
+    );
+    t.regex(mainAfter, new RegExp(`uuid: ${UUID}`));
+    t.notRegex(mainAfter, new RegExp(TWO_WORKFLOWS_UUID));
+  }
+);
+
+test.serial('deploy an updated project direct to an endpoint', async (t) => {
+  const remoteProjectBefore: any = server.state.projects[UUID];
+  const wfBefore = remoteProjectBefore.workflows['my-workflow'];
+  t.is(wfBefore.jobs['transform-data'].body, 'fn()');
+
+  mockFs({
+    '/ws/dev@localhost.yaml': projectYaml.replace('fn()', 'jam()'),
+    '/ws/openfn.yaml': '',
+  });
+
+  // deploy the local project file directly
+  await deploy(
+    {
+      endpoint: ENDPOINT,
+      apiKey: 'test-api-key',
+      workspace: '/ws',
+      project: '/ws/dev@localhost.yaml',
+      target: 'dev',
+      confirm: false,
+      // log: 'debug',
+    } as any,
+    logger
+  );
+
+  const remoteProjectAfter: any = server.state.projects[UUID];
+  const wfAfter = remoteProjectAfter.workflows['my-workflow'];
+  t.is(wfAfter.jobs['transform-data'].body, 'jam()');
+});
 
 test.serial('deploy a new project creates ids for collections', async (t) => {
   const yamlWithCollections = projectYaml.replace(

--- a/packages/cli/test/projects/fixtures.ts
+++ b/packages/cli/test/projects/fixtures.ts
@@ -104,6 +104,32 @@ workflows:
     id: my-workflow
     start: webhook`;
 
+export const myProject_spec = `id: my-project
+name: My Project
+schema_version: '4.0'
+description: my lovely project
+collections: []
+credentials:
+  - name: http1
+    owner: super@openfn.org
+workflows:
+  - name: My Workflow
+    steps:
+      - id: transform-data
+        name: Transform data
+        expression: fn()
+        adaptor: '@openfn/language-common@latest'
+        configuration: super@openfn.org|http1
+      - id: webhook
+        type: webhook
+        enabled: true
+        next:
+          transform-data:
+            disabled: false
+            condition: always
+    id: my-workflow
+    start: webhook`;
+
 export const TWO_WORKFLOWS_UUID = '4b09ddf1-35f4-4e40-9aa9-0d80c086dd9e';
 
 export const two_workflows_yaml = `id: my-project

--- a/packages/lexicon/lightning.d.ts
+++ b/packages/lexicon/lightning.d.ts
@@ -351,6 +351,7 @@ export namespace Provisioner {
     source_trigger_id: string | null;
     target_job_id: string;
     enabled?: boolean;
+    delete?: boolean;
   };
 
   export type KafkaConfiguration = {

--- a/packages/lexicon/portability.d.ts
+++ b/packages/lexicon/portability.d.ts
@@ -95,6 +95,7 @@ export interface Trigger extends Step {
 export interface Credential {
   name: string;
   owner: string;
+  uuid?: string | number;
 }
 
 export interface Collection {

--- a/packages/lightning-mock/src/api-dev.ts
+++ b/packages/lightning-mock/src/api-dev.ts
@@ -75,6 +75,20 @@ const setupDevAPI = (
     } else {
       project = JSON.parse(JSON.stringify(project));
     }
+
+    // Give every workflow a baseline version_history
+    const workflows: any[] = Array.isArray((project as any).workflows)
+      ? (project as any).workflows
+      : Object.values((project as any).workflows ?? {});
+
+    for (const wf of workflows) {
+      if (!wf.version_history?.length) {
+        wf.version_history = [
+          generateVersionHash(mapWorkflow(wf) as any, { source: 'app' }),
+        ];
+      }
+    }
+
     // @ts-ignore
     state.projects[project.id] = project;
   };

--- a/packages/lightning-mock/src/api-rest.ts
+++ b/packages/lightning-mock/src/api-rest.ts
@@ -86,16 +86,31 @@ workflows:
 const filterCollections = (incoming: any[] = []): any[] =>
   incoming.filter((c) => !c.delete);
 
+const ensureArray = (x: any): any[] =>
+  Array.isArray(x) ? x : Object.values(x ?? {});
+
+// Removes jobs/triggers/edges with delete: true - Lightning wouldn't persist or
+// return them, so neither should the mock.
+const stripDeleted = (x: any) => {
+  if (!x) return [];
+  if (Array.isArray(x)) {
+    return x.filter((item: any) => !item.delete);
+  }
+  return Object.fromEntries(
+    Object.entries(x).filter(([, item]: any) => !item.delete)
+  );
+};
+
 // Validates a provisioner payload, returning an error body if invalid or null if valid.
 // Mirrors Lightning's error format so deploy code sees realistic rejection responses.
 export function validateProvisionPayload(
-  incoming: any
+  incoming: any,
+  existingProject?: any
 ): Record<string, any> | null {
   const workflowErrors: Record<string, any> = {};
 
-  const wfList: any[] = Array.isArray(incoming.workflows)
-    ? incoming.workflows
-    : Object.values(incoming.workflows ?? {});
+  const wfList: any[] = ensureArray(incoming.workflows);
+  const existingWfList: any[] = ensureArray(existingProject?.workflows);
 
   for (const wf of wfList) {
     const wfErrors: Record<string, any> = {};
@@ -105,9 +120,7 @@ export function validateProvisionPayload(
     }
 
     const edgeErrors: Record<string, any> = {};
-    const edgeList: any[] = Array.isArray(wf.edges)
-      ? wf.edges
-      : Object.values(wf.edges ?? {});
+    const edgeList: any[] = ensureArray(wf.edges);
 
     for (const edge of edgeList) {
       const key = edge.id ?? '->';
@@ -132,9 +145,7 @@ export function validateProvisionPayload(
     }
 
     const jobErrors: Record<string, any> = {};
-    const jobList: any[] = Array.isArray(wf.jobs)
-      ? wf.jobs
-      : Object.values(wf.jobs ?? {});
+    const jobList: any[] = ensureArray(wf.jobs);
 
     for (const job of jobList) {
       if (!job.id) {
@@ -148,9 +159,7 @@ export function validateProvisionPayload(
     }
 
     const triggerErrors: Record<string, any> = {};
-    const triggerList: any[] = Array.isArray(wf.triggers)
-      ? wf.triggers
-      : Object.values(wf.triggers ?? {});
+    const triggerList: any[] = ensureArray(wf.triggers);
 
     for (const trigger of triggerList) {
       if (!trigger.id) {
@@ -166,6 +175,17 @@ export function validateProvisionPayload(
     if (Object.keys(wfErrors).length > 0) {
       const wfKey = wf.name ?? wf.id ?? 'unknown';
       workflowErrors[wfKey] = wfErrors;
+    }
+  }
+
+  // a whole workflow, unlike its jobs/triggers/edges, must be explicit about removal
+  const incomingWfIds = new Set(wfList.map((wf: any) => wf.id));
+  for (const wf of existingWfList) {
+    if (!incomingWfIds.has(wf.id)) {
+      const wfKey = wf.name ?? wf.id ?? 'unknown';
+      workflowErrors[wfKey] = {
+        delete: ['missing from payload - flag delete: true to remove it'],
+      };
     }
   }
 
@@ -215,7 +235,10 @@ export default (
   router.post('/api/provision', (ctx) => {
     const incoming: any = ctx.request.body;
 
-    const validationErrors = validateProvisionPayload(incoming);
+    const validationErrors = validateProvisionPayload(
+      incoming,
+      state.projects[incoming.id]
+    );
     if (validationErrors) {
       ctx.response.status = 422;
       ctx.response.body = validationErrors;
@@ -246,7 +269,12 @@ export default (
       ? incoming.workflows
       : Object.values(incoming.workflows ?? {});
     wfList.forEach((wf: any) => {
-      app.updateWorkflow(incoming.id, wf);
+      app.updateWorkflow(incoming.id, {
+        ...wf,
+        jobs: stripDeleted(wf.jobs),
+        triggers: stripDeleted(wf.triggers),
+        edges: stripDeleted(wf.edges),
+      });
     });
 
     ctx.response.status = 200;

--- a/packages/lightning-mock/test/rest.test.ts
+++ b/packages/lightning-mock/test/rest.test.ts
@@ -115,6 +115,110 @@ test.serial(
   }
 );
 
+test.serial('should actually delete a job flagged delete: true', async (t) => {
+  const response = await fetch(`${endpoint}/api/provision`, {
+    method: 'POST',
+    body: JSON.stringify({
+      id: DEFAULT_PROJECT_ID,
+      name: 'aaa',
+      workflows: [
+        {
+          id: '72ca3eb0-042c-47a0-a2a1-a545ed4a8406',
+          name: 'wf1',
+          jobs: [{ id: '66add020-e6eb-4eec-836b-20008afca816', delete: true }],
+        },
+      ],
+    }),
+    headers: { 'content-type': 'application/json' },
+  });
+  t.is(response.status, 200);
+
+  const res = await fetch(`${endpoint}/api/provision/${DEFAULT_PROJECT_ID}`);
+  const { data: proj } = await res.json();
+  const wf = proj.workflows.find(
+    (w: any) => w.id === '72ca3eb0-042c-47a0-a2a1-a545ed4a8406'
+  );
+  const jobs = Array.isArray(wf.jobs) ? wf.jobs : Object.values(wf.jobs ?? {});
+  t.is(jobs.length, 0);
+});
+
+test.serial(
+  'should delete a job that is simply omitted, same as delete: true',
+  async (t) => {
+    const workflowId = '72ca3eb0-042c-47a0-a2a1-a545ed4a8406';
+
+    // seed a job directly, rather than via a setup deploy
+    server.addNode(DEFAULT_PROJECT_ID, workflowId, {
+      id: 'temp-job',
+      name: 'Temp job',
+      adaptor: 'common',
+      body: 'fn(s => s)',
+    });
+
+    const response = await fetch(`${endpoint}/api/provision`, {
+      method: 'POST',
+      body: JSON.stringify({
+        id: DEFAULT_PROJECT_ID,
+        name: 'aaa',
+        workflows: [{ id: workflowId, name: 'wf1', jobs: [] }],
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    t.is(response.status, 200);
+
+    const res = await fetch(`${endpoint}/api/provision/${DEFAULT_PROJECT_ID}`);
+    const { data: proj } = await res.json();
+    const wf = proj.workflows.find((w: any) => w.id === workflowId);
+    const jobs = Array.isArray(wf.jobs)
+      ? wf.jobs
+      : Object.values(wf.jobs ?? {});
+    t.is(jobs.length, 0);
+  }
+);
+
+test.serial(
+  'should actually delete a whole workflow flagged delete: true',
+  async (t) => {
+    const wf1Id = '72ca3eb0-042c-47a0-a2a1-a545ed4a8406';
+    const tempWorkflowId = 'temp-workflow';
+
+    const first = await fetch(`${endpoint}/api/provision`, {
+      method: 'POST',
+      body: JSON.stringify({
+        id: DEFAULT_PROJECT_ID,
+        name: 'aaa',
+        // wf1 must be included in every payload - a whole workflow (unlike
+        // its jobs/triggers/edges) has to be explicit about its own removal
+        workflows: [
+          { id: wf1Id, name: 'wf1' },
+          { id: tempWorkflowId, name: 'temp workflow' },
+        ],
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    t.is(first.status, 200);
+
+    const second = await fetch(`${endpoint}/api/provision`, {
+      method: 'POST',
+      body: JSON.stringify({
+        id: DEFAULT_PROJECT_ID,
+        name: 'aaa',
+        workflows: [
+          { id: wf1Id, name: 'wf1' },
+          { id: tempWorkflowId, delete: true },
+        ],
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    t.is(second.status, 200);
+
+    const res = await fetch(`${endpoint}/api/provision/${DEFAULT_PROJECT_ID}`);
+    const { data: proj } = await res.json();
+    t.falsy(proj.workflows.find((w: any) => w.id === tempWorkflowId));
+    t.truthy(proj.workflows.find((w: any) => w.id === wf1Id));
+  }
+);
+
 test.serial('should fetch many items from a collection', async (t) => {
   server.collections.createCollection('stuff');
   server.collections.upsert('stuff', 'x', { id: 'x' });
@@ -245,6 +349,127 @@ test('validateProvisionPayload: returns null when there are no edges', (t) => {
     id: 'proj-1',
     workflows: [{ id: 'wf-1', name: 'wf1', edges: [] }],
   };
+  t.is(validateProvisionPayload(payload), null);
+});
+
+// Unlike a whole workflow, an omitted job/trigger/edge is not an error - for
+// these, omission and delete: true mean exactly the same thing.
+test('validateProvisionPayload: a job silently vanishing is not an error', (t) => {
+  const existingProject = {
+    workflows: [
+      {
+        id: 'wf-1',
+        name: 'wf1',
+        jobs: [{ id: 'job-1', name: 'Transform data' }],
+      },
+    ],
+  };
+  const payload = {
+    id: 'proj-1',
+    workflows: [{ id: 'wf-1', name: 'wf1', jobs: [] }],
+  };
+
+  t.is(validateProvisionPayload(payload, existingProject), null);
+});
+
+test('validateProvisionPayload: returns null when a missing job is flagged delete: true', (t) => {
+  const existingProject = {
+    workflows: [
+      {
+        id: 'wf-1',
+        name: 'wf1',
+        jobs: [{ id: 'job-1', name: 'Transform data' }],
+      },
+    ],
+  };
+  const payload = {
+    id: 'proj-1',
+    workflows: [
+      { id: 'wf-1', name: 'wf1', jobs: [{ id: 'job-1', delete: true }] },
+    ],
+  };
+
+  t.is(validateProvisionPayload(payload, existingProject), null);
+});
+
+test('validateProvisionPayload: a trigger silently vanishing is not an error', (t) => {
+  const existingProject = {
+    workflows: [
+      {
+        id: 'wf-1',
+        name: 'wf1',
+        triggers: [{ id: 'trig-1', type: 'webhook' }],
+      },
+    ],
+  };
+  const payload = {
+    id: 'proj-1',
+    workflows: [{ id: 'wf-1', name: 'wf1', triggers: [] }],
+  };
+
+  t.is(validateProvisionPayload(payload, existingProject), null);
+});
+
+test('validateProvisionPayload: an edge silently vanishing is not an error', (t) => {
+  const existingProject = {
+    workflows: [
+      {
+        id: 'wf-1',
+        name: 'wf1',
+        edges: [
+          {
+            id: 'edge-1',
+            source_trigger_id: 'trig-1',
+            target_job_id: 'job-1',
+          },
+        ],
+      },
+    ],
+  };
+  const payload = {
+    id: 'proj-1',
+    workflows: [{ id: 'wf-1', name: 'wf1', edges: [] }],
+  };
+
+  t.is(validateProvisionPayload(payload, existingProject), null);
+});
+
+test('validateProvisionPayload: errors when a whole workflow silently vanishes without delete: true', (t) => {
+  const existingProject = {
+    workflows: [{ id: 'wf-1', name: 'wf1' }],
+  };
+  const payload = { id: 'proj-1', workflows: [] };
+
+  const result = validateProvisionPayload(payload, existingProject);
+  t.deepEqual(result, {
+    errors: {
+      workflows: {
+        wf1: {
+          delete: ['missing from payload - flag delete: true to remove it'],
+        },
+      },
+    },
+  });
+});
+
+test('validateProvisionPayload: returns null when a missing workflow is flagged delete: true', (t) => {
+  const existingProject = {
+    workflows: [{ id: 'wf-1', name: 'wf1' }],
+  };
+  const payload = {
+    id: 'proj-1',
+    workflows: [{ id: 'wf-1', delete: true }],
+  };
+
+  t.is(validateProvisionPayload(payload, existingProject), null);
+});
+
+test('validateProvisionPayload: no existing project means nothing can have vanished', (t) => {
+  const payload = {
+    id: 'proj-1',
+    workflows: [{ id: 'wf-1', name: 'wf1', jobs: [], triggers: [], edges: [] }],
+  };
+
   t.is(validateProvisionPayload(payload), null);
 });
 

--- a/packages/lightning-mock/test/rest.test.ts
+++ b/packages/lightning-mock/test/rest.test.ts
@@ -287,7 +287,43 @@ test('validateProvisionPayload: returns null for a valid edge with source_job_id
   t.is(validateProvisionPayload(payload), null);
 });
 
-test('validateProvisionPayload: returns errors when edge has no source', (t) => {
+test('validateProvisionPayload: returns errors when edge has no source job or trigger id', (t) => {
+  const payload = {
+    id: 'proj-1',
+    workflows: [
+      {
+        name: 'wf1',
+        edges: [
+          {
+            id: 'edge-1',
+            source_trigger_id: null,
+            target_job_id: '',
+            enabled: true,
+          },
+        ],
+      },
+    ],
+  };
+  const result = validateProvisionPayload(payload);
+  t.truthy(result);
+  t.deepEqual(result, {
+    errors: {
+      workflows: {
+        wf1: {
+          edges: {
+            'edge-1': {
+              source_job_id: [
+                'source_job_id or source_trigger_id must be present',
+              ],
+            },
+          },
+        },
+      },
+    },
+  });
+});
+
+test('validateProvisionPayload: for new edges allow source_job', (t) => {
   const payload = {
     id: 'proj-1',
     workflows: [

--- a/packages/lightning-mock/test/rest.test.ts
+++ b/packages/lightning-mock/test/rest.test.ts
@@ -292,6 +292,7 @@ test('validateProvisionPayload: returns errors when edge has no source job or tr
     id: 'proj-1',
     workflows: [
       {
+        id: 'wf-1',
         name: 'wf1',
         edges: [
           {

--- a/packages/project/src/Project.ts
+++ b/packages/project/src/Project.ts
@@ -91,6 +91,7 @@ export class Project {
       alias?: string;
       version?: number;
       name?: string;
+      asSpec?: boolean;
     }
   ): Promise<Project>;
   static async from(

--- a/packages/project/src/Project.ts
+++ b/packages/project/src/Project.ts
@@ -99,7 +99,7 @@ export class Project {
   static async from(
     type: 'path',
     data: string,
-    options?: { config?: FromPathConfig }
+    options?: Partial<FromPathConfig>
   ): Promise<Project>;
   static async from(
     type: 'project' | 'state' | 'path' | 'fs',

--- a/packages/project/src/Project.ts
+++ b/packages/project/src/Project.ts
@@ -87,7 +87,11 @@ export class Project {
   static async from(
     type: 'project',
     data: any,
-    config?: Partial<l.WorkspaceConfig>
+    config?: Partial<l.WorkspaceConfig> & {
+      alias?: string;
+      version?: number;
+      name?: string;
+    }
   ): Promise<Project>;
   static async from(
     type: 'state',

--- a/packages/project/src/Workflow.ts
+++ b/packages/project/src/Workflow.ts
@@ -23,6 +23,10 @@ class Workflow {
       edges: {}, // edges by from-id id
       uuid: {}, // id to uuid
       id: {}, // uuid to ids
+      removed: {
+        self: false,
+        ids: {} as Record<string, boolean>, // step id, or edge's `from-to` id
+      },
     };
 
     this.workflow = clone(workflow);
@@ -126,6 +130,48 @@ class Workflow {
     }
 
     return item;
+  }
+
+  // Flags a step, edge, or (no args) the whole workflow removed - to-app-state reads this to generate delete: true entries
+  remove(): this;
+  remove(stepId: string): this;
+  remove(from: string, to: string): this;
+  remove(a?: string, b?: string): this {
+    if (a === undefined) {
+      this.index.removed.self = true;
+      return this;
+    }
+
+    if (b === undefined) {
+      if (!(a in this.index.steps)) {
+        throw new Error(`step with id "${a}" does not exist in workflow`);
+      }
+      this.index.removed.ids[a] = true;
+    } else {
+      const edgeId = `${a}-${b}`;
+      if (!(edgeId in this.index.edges)) {
+        throw new Error(`edge with id "${edgeId}" does not exist in workflow`);
+      }
+      this.index.removed.ids[edgeId] = true;
+    }
+
+    return this;
+  }
+
+  isRemoved(): boolean;
+  isRemoved(stepId: string): boolean;
+  isRemoved(from: string, to: string): boolean;
+  isRemoved(a?: string, b?: string): boolean {
+    if (a === undefined) {
+      return this.index.removed.self;
+    }
+
+    const id = b === undefined ? a : `${a}-${b}`;
+    return !!this.index.removed.ids[id];
+  }
+
+  get removed(): { self: boolean; ids: Record<string, boolean> } {
+    return this.index.removed;
   }
 
   // TODO needs unit tests and maybe setter

--- a/packages/project/src/merge/merge-project.ts
+++ b/packages/project/src/merge/merge-project.ts
@@ -64,13 +64,13 @@ export function merge(
   const finalWorkflows: Workflow[] = [];
   const usedTargetIds = new Set<string>();
   let sourceWorkflows = source.workflows;
+  let removedWorkflowIds: string[] = [];
 
   const noMappings = isEmpty(options.workflowMappings);
 
   if (options.onlyUpdated) {
-    // only include workflows that have changed (since history or forked_from) in the list
-    // unchanged target workflows will be added to the finalWorkflows list later
-    sourceWorkflows = findChangedWorkflows(source);
+    ({ changed: sourceWorkflows, removed: removedWorkflowIds } =
+      findChangedWorkflows(source));
   }
 
   if (!noMappings) {
@@ -128,7 +128,18 @@ export function merge(
     }
   }
 
-  // do not remove unmapped means include them too.
+  // Flag any workflows which need removing and add to to final workflows
+  for (const removedId of removedWorkflowIds) {
+    const targetWorkflow = target.getWorkflow(removedId);
+    if (targetWorkflow) {
+      usedTargetIds.add(targetWorkflow.id);
+      const deletedWorkflow = new Workflow(targetWorkflow.toJSON() as any);
+      deletedWorkflow.remove();
+      finalWorkflows.push(deletedWorkflow);
+    }
+  }
+
+  // do not remove unmapped means include them too
   if (!options?.removeUnmapped) {
     // workflows from target that didn't get merged
     for (const targetWorkflow of target.workflows) {

--- a/packages/project/src/parse/from-app-state.ts
+++ b/packages/project/src/parse/from-app-state.ts
@@ -4,6 +4,7 @@ import * as l from '@openfn/lexicon';
 import { Provisioner } from '@openfn/lexicon/lightning';
 
 import { Project } from '../Project';
+import Workflow from '../Workflow';
 import renameKeys from '../util/rename-keys';
 import slugify from '../util/slugify';
 import omitNil from '../util/omit-nil';
@@ -77,9 +78,36 @@ export default (
     };
   }
 
-  proj.workflows = Object.values(stateJson.workflows).map((w) =>
-    mapWorkflow(w, proj.credentials)
-  );
+  // Identify any workflows, steps and edges which may have been deleted in the state,
+  // and ensure their deletion is reflected in in the parsed Project
+  proj.workflows = Object.values(stateJson.workflows).map((w) => {
+    const workflow = new Workflow(mapWorkflow(w, proj.credentials));
+
+    if (w.delete) {
+      workflow.remove();
+      return workflow;
+    }
+
+    const deletedUuids = new Set(
+      Object.values(w.jobs as any)
+        .concat(Object.values(w.triggers), Object.values(w.edges))
+        .filter((x: any) => x.delete)
+        .map((x: any) => x.id)
+    );
+
+    for (const step of workflow.steps as any[]) {
+      if (deletedUuids.has(step.openfn?.uuid)) {
+        workflow.remove(step.id);
+      }
+      for (const toId in step.next ?? {}) {
+        if (deletedUuids.has(step.next[toId].openfn?.uuid)) {
+          workflow.remove(step.id, toId);
+        }
+      }
+    }
+
+    return workflow;
+  }) as unknown as l.WorkflowState[];
 
   return new Project(proj as l.ProjectState, config);
 };
@@ -117,6 +145,7 @@ export const mapWorkflow = (
 ) => {
   const { jobs, edges, triggers, name, version_history, ...remoteProps } =
     workflow;
+
   const mapped: l.WorkflowState = {
     name: workflow.name,
     steps: [],
@@ -129,7 +158,7 @@ export const mapWorkflow = (
 
   // TODO what do we do if the condition is disabled?
   // I don't think that's the same as edge condition false?
-  Object.values(workflow.triggers).forEach((trigger: Provisioner.Trigger) => {
+  Object.values(triggers).forEach((trigger: Provisioner.Trigger) => {
     const {
       type,
       enabled,
@@ -173,7 +202,7 @@ export const mapWorkflow = (
     );
   });
 
-  Object.values(workflow.jobs).forEach((step: Provisioner.Job) => {
+  Object.values(jobs).forEach((step: Provisioner.Job) => {
     const outboundEdges = Object.values(edges).filter(
       (e) => e.source_job_id === step.id || e.source_trigger_id === step.id
     );

--- a/packages/project/src/parse/from-path.ts
+++ b/packages/project/src/parse/from-path.ts
@@ -8,6 +8,7 @@ export type FromPathConfig = l.WorkspaceConfig & {
   format: 'json' | 'yaml';
   alias?: string;
   name?: string;
+  asSpec?: boolean;
 };
 
 // Extract alias from filename in format: alias@domain.yaml or alias.yaml

--- a/packages/project/src/parse/from-path.ts
+++ b/packages/project/src/parse/from-path.ts
@@ -7,6 +7,7 @@ import fromProject from './from-project';
 export type FromPathConfig = l.WorkspaceConfig & {
   format: 'json' | 'yaml';
   alias?: string;
+  name?: string;
 };
 
 // Extract alias from filename in format: alias@domain.yaml or alias.yaml

--- a/packages/project/src/parse/from-project.ts
+++ b/packages/project/src/parse/from-project.ts
@@ -17,10 +17,20 @@ export type SerializedWorkflow = l.WorkflowState;
 
 export default (
   data: l.ProjectState | SerializedProject | string,
-  config?: Partial<l.WorkspaceConfig> & { alias?: string; version?: number }
+  config?: Partial<l.WorkspaceConfig> & {
+    alias?: string;
+    version?: number;
+    name?: string;
+  }
 ) => {
   // first ensure the data is in JSON format
   let rawJson = ensureJson<any>(data);
+
+  // an explicit name override (eg deploying a downloaded project.yaml as a
+  // new/duplicate project) applies regardless of source format
+  if (config?.name) {
+    rawJson = { ...rawJson, name: config.name };
+  }
 
   if (detectVersion(rawJson) > 1) {
     return new Project(from_v2(rawJson as SerializedProject), config);

--- a/packages/project/src/parse/from-project.ts
+++ b/packages/project/src/parse/from-project.ts
@@ -21,6 +21,13 @@ export default (
     alias?: string;
     version?: number;
     name?: string;
+    /**
+     * Load this project as a spec, stripping any embedded remote state
+     * (workflow/step/edge uuids) as it's parsed - eg when a stateful,
+     * previously-fetched project.yaml is being deployed as a brand new
+     * project, and its old ids must not carry over.
+     */
+    asSpec?: boolean;
   }
 ) => {
   // first ensure the data is in JSON format
@@ -33,7 +40,10 @@ export default (
   }
 
   if (detectVersion(rawJson) > 1) {
-    return new Project(from_v2(rawJson as SerializedProject), config);
+    return new Project(
+      from_v2(rawJson as SerializedProject, config?.asSpec),
+      config
+    );
   }
 
   return from_v1(rawJson as Provisioner.Project, config as fromAppStateConfig);
@@ -48,10 +58,39 @@ const from_v1 = (
 };
 
 // TODO this should return a Project really!
-const from_v2 = (data: SerializedProject) => {
+const from_v2 = (data: SerializedProject, asSpec?: boolean) => {
   // nothing to do
   // (When we add v3, we'll ned to migrate through this)
+  if (asSpec) {
+    return stripState(data);
+  }
   return {
     ...data,
   };
 };
+
+// Remove embedded remote-state uuids from every workflow, step and edge
+// (but not the project itself - callers handle that separately, since
+// they also need to set a fresh endpoint)
+const stripState = (data: SerializedProject) => ({
+  ...data,
+  workflows: (data.workflows ?? []).map((wf: any) => {
+    const { openfn, steps, ...restWf } = wf;
+    return {
+      ...restWf,
+      steps: (steps ?? []).map((step: any) => {
+        const { openfn: stepOpenfn, next, ...restStep } = step;
+        if (!next) return restStep;
+        return {
+          ...restStep,
+          next: Object.fromEntries(
+            Object.entries(next).map(([id, edge]: [string, any]) => {
+              const { openfn: edgeOpenfn, ...restEdge } = edge;
+              return [id, restEdge];
+            })
+          ),
+        };
+      }),
+    };
+  }),
+});

--- a/packages/project/src/serialize/to-app-state.ts
+++ b/packages/project/src/serialize/to-app-state.ts
@@ -222,10 +222,7 @@ export const mapWorkflow = (
               return name === projectCredentialId;
             });
             if (mappedCredential && useUuids) {
-              // the mapped credential might have a uuid or an id depending on how it was fed in to us
-              // but this is bullshit right?
-              projectCredentialId =
-                mappedCredential.uuid ?? mappedCredential.id;
+              projectCredentialId = mappedCredential.uuid;
             }
 
             if (useUuids) {

--- a/packages/project/src/serialize/to-app-state.ts
+++ b/packages/project/src/serialize/to-app-state.ts
@@ -58,6 +58,13 @@ export default function (
     name: c.name,
   }));
 
+  // Ensure each credential has a UUID
+  project.credentials =
+    project.credentials?.map((c) => ({
+      ...c,
+      uuid: c.uuid ?? randomUUID(),
+    })) ?? [];
+
   Object.assign(state, rest, project.options);
   if (options.asSpec) {
     for (const c of project.credentials) {
@@ -71,14 +78,10 @@ export default function (
       };
     }
   } else {
-    const credentialsWithUuids =
-      project.credentials?.map((c) => ({
-        ...c,
-        uuid: (c as CredentialState).uuid ?? randomUUID(),
-      })) ?? [];
-
-    state.project_credentials = credentialsWithUuids.map((c) => ({
-      // note the subtle conversion here
+    state.project_credentials = project.credentials.map((c) => ({
+      // note the subtle conversion here: uuid -> id
+      // That's because the local Project uses the uuid key to track UUIDs
+      // but the provisioner spec uses id
       id: c.uuid as string,
       name: c.name,
       owner: c.owner,
@@ -219,7 +222,10 @@ export const mapWorkflow = (
               return name === projectCredentialId;
             });
             if (mappedCredential && useUuids) {
-              projectCredentialId = mappedCredential.uuid;
+              // the mapped credential might have a uuid or an id depending on how it was fed in to us
+              // but this is bullshit right?
+              projectCredentialId =
+                mappedCredential.uuid ?? mappedCredential.id;
             }
 
             if (useUuids) {

--- a/packages/project/src/serialize/to-app-state.ts
+++ b/packages/project/src/serialize/to-app-state.ts
@@ -110,12 +110,35 @@ export const mapWorkflow = (
 ) => {
   const useUuids = !options.asSpec;
 
+  // captured before toJSON(), since the `lookup` build below mints fresh uuids for anything missing one
+  const removed =
+    workflow instanceof Workflow
+      ? workflow.removed
+      : { self: false, ids: {} as Record<string, boolean> };
+  const originalUuids: Record<string, string> =
+    workflow instanceof Workflow ? workflow.getUUIDMap() : {};
+
   if (workflow instanceof Workflow) {
     // @ts-ignore
     workflow = workflow.toJSON();
   }
 
   const { uuid, ...originalOpenfnProps } = workflow.openfn ?? {};
+
+  if (useUuids && removed.self && uuid) {
+    // nothing else about a deleted workflow matters to the provisioner
+    return {
+      ...originalOpenfnProps,
+      id: uuid,
+      name: workflow.name,
+      delete: true,
+      jobs: {},
+      triggers: {},
+      edges: {},
+      lock_version: workflow.openfn?.lock_version ?? null,
+    } as Provisioner.Workflow;
+  }
+
   const wfState = {
     ...originalOpenfnProps,
     jobs: {},
@@ -151,55 +174,91 @@ export const mapWorkflow = (
     let isTrigger = false;
     let node: Provisioner.Job | Provisioner.Trigger;
 
+    const isRemoved = useUuids && !!removed.ids[s.id];
+    const nodeUuid = originalUuids[s.id];
+
+    if (isRemoved && !nodeUuid) {
+      // never synced to Lightning - nothing to delete server-side
+      return;
+    }
+
     if (s.type) {
       isTrigger = true;
 
-      const { type, id, next, openfn, ...rest } = s;
-      node = {
-        ...rest,
-        type: s.type ?? 'webhook', // this is mostly for tests
-        ...(useUuids ? renameKeys(openfn, { uuid: 'id' }) : {}),
-      } as Provisioner.Trigger;
-      wfState.triggers[node.type] = node;
+      if (isRemoved) {
+        node = { id: nodeUuid, delete: true } as Provisioner.Trigger;
+      } else {
+        const { type, id, next, openfn, ...rest } = s;
+        node = {
+          ...rest,
+          type: s.type ?? 'webhook', // this is mostly for tests
+          ...(useUuids ? renameKeys(openfn, { uuid: 'id' }) : {}),
+        } as Provisioner.Trigger;
+      }
+      wfState.triggers[s.type] = node;
     } else {
-      node = omitBy(pick(s, ['name', 'adaptor']), isNil) as Provisioner.Job;
-      const { uuid, ...otherOpenFnProps } = s.openfn ?? {};
-      if (useUuids) {
-        node.id = uuid;
-      }
-      if (s.expression) {
-        node.body = s.expression;
-      }
-      if (
-        typeof s.configuration === 'string' &&
-        !s.configuration.endsWith('.json')
-      ) {
-        let projectCredentialId = s.configuration;
-        if (projectCredentialId) {
-          const mappedCredential = credentials.find((c) => {
-            const name = getCredentialName(c);
-            return name === projectCredentialId;
-          });
-          if (mappedCredential && useUuids) {
-            projectCredentialId = mappedCredential.uuid;
-          }
+      if (isRemoved) {
+        node = { id: nodeUuid, delete: true } as Provisioner.Job;
+      } else {
+        node = omitBy(pick(s, ['name', 'adaptor']), isNil) as Provisioner.Job;
+        const { uuid, ...otherOpenFnProps } = s.openfn ?? {};
+        if (useUuids) {
+          node.id = uuid;
+        }
+        if (s.expression) {
+          node.body = s.expression;
+        }
+        if (
+          typeof s.configuration === 'string' &&
+          !s.configuration.endsWith('.json')
+        ) {
+          let projectCredentialId = s.configuration;
+          if (projectCredentialId) {
+            const mappedCredential = credentials.find((c) => {
+              const name = getCredentialName(c);
+              return name === projectCredentialId;
+            });
+            if (mappedCredential && useUuids) {
+              projectCredentialId = mappedCredential.uuid;
+            }
 
-          if (useUuids) {
-            otherOpenFnProps.project_credential_id = projectCredentialId;
-          } else {
-            otherOpenFnProps.credential = projectCredentialId;
+            if (useUuids) {
+              otherOpenFnProps.project_credential_id = projectCredentialId;
+            } else {
+              otherOpenFnProps.credential = projectCredentialId;
+            }
           }
         }
+
+        Object.assign(node, useUuids ? defaultJobProps : {}, otherOpenFnProps);
       }
 
-      Object.assign(node, useUuids ? defaultJobProps : {}, otherOpenFnProps);
-
       wfState.jobs[s.id ?? slugify(s.name)] = node;
+    }
+
+    if (isRemoved) {
+      // a removed step's edges are meaningless without also being removed via workflow.remove(from, to)
+      return;
     }
 
     // create an edge to each linked node
     Object.keys(s.next ?? {}).forEach((next) => {
       const rules = s.next[next];
+
+      const edgeIsRemoved = useUuids && !!removed.ids[`${s.id}-${next}`];
+      const edgeUuid = originalUuids[`${s.id}-${next}`];
+
+      if (edgeIsRemoved && !edgeUuid) {
+        return;
+      }
+
+      if (edgeIsRemoved) {
+        wfState.edges[`${s.id}->${next}`] = {
+          id: edgeUuid,
+          delete: true,
+        } as any;
+        return;
+      }
 
       const { uuid, ...otherOpenFnProps } = rules.openfn ?? {};
 

--- a/packages/project/src/util/find-changed-workflows.ts
+++ b/packages/project/src/util/find-changed-workflows.ts
@@ -1,12 +1,18 @@
 import Project from '../Project';
-import type Workflow from '../Workflow';
+import Workflow from '../Workflow';
 import { generateHash } from './version';
 
+export type ChangedWorkflows = {
+  changed: Workflow[];
+  // ids of workflows present in forked_from/history but no longer in the project
+  removed: string[];
+};
+
 /**
- * For a given Project, identify which workflows have changed
- * Uses forked_from as the base, or history if that's unavailable
+ * Identify which projects have changed or been removed since the last checkpoint.
+ * Prefers to use `forked_from` but will fallback to history
  */
-export default (project: Project) => {
+export default (project: Project): ChangedWorkflows => {
   const base: Record<string, string> =
     project.cli.forked_from ??
     project.workflows.reduce((obj: any, wf) => {
@@ -16,7 +22,7 @@ export default (project: Project) => {
       return obj;
     }, {});
 
-  const changed = [];
+  const changed: Workflow[] = [];
 
   for (const wf of project.workflows) {
     if (wf.id in base) {
@@ -26,17 +32,14 @@ export default (project: Project) => {
       }
       delete base[wf.id];
     } else {
-      // If a workflow doens't appear in forked_from, we assume it's new
+      // If a workflow doesn't appear in forked_from, we assume it's new
       // (and so changed!)
       changed.push(wf);
     }
   }
 
-  // Anything in forked_from that hasn't been handled
-  // must have been removed (and so changed!)
-  for (const removedId in base) {
-    changed.push({ id: removedId, $deleted: true } as unknown as Workflow);
-  }
+  // Anything in forked_from that hasn't been handled must have been removed
+  const removed = Object.keys(base);
 
-  return changed;
+  return { changed, removed };
 };

--- a/packages/project/test/merge/merge-project.test.ts
+++ b/packages/project/test/merge/merge-project.test.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import { randomUUID } from 'node:crypto';
 import type { CredentialState } from '@openfn/lexicon';
 
-import Project from '../../src';
+import Project, { generateVersionHash } from '../../src';
 import {
   merge,
   mergeCollections,
@@ -788,7 +788,7 @@ test('remove a workflow', (t) => {
   t.is(result.workflows.length, 1);
 });
 
-test('remove a workflow with onlyUpdated: true', (t) => {
+test('remove a workflow with onlyUpdated: true and no history', (t) => {
   const wf1 = assignUUIDs({
     name: 'wf1',
     steps: [],
@@ -806,6 +806,111 @@ test('remove a workflow with onlyUpdated: true', (t) => {
 
   const result: any = merge(staging, main, { onlyUpdated: true });
   t.is(result.workflows.length, 1);
+});
+
+test('remove a workflow with onlyUpdated: true and a full history', (t) => {
+  // NB: assignUUIDs hardcodes id: 'wf' on everything it touches, which would
+  // silently collide wf1/wf2 into the same id here - use explicit distinct
+  // ids instead, matching the forked_from keys below, as a real project would
+  const wf1: any = { id: 'wf1', name: 'wf1', openfn: { uuid: randomUUID() }, steps: [] };
+  const wf1Version = generateVersionHash(wf1);
+
+  const wf2: any = { id: 'wf2', name: 'wf2', openfn: { uuid: randomUUID() }, steps: [] };
+  const wf2Version = generateVersionHash(wf2);
+
+  const main = createProject([wf1, wf2], 'a');
+  const staging = createProject([wf1], 'b');
+  // staging needs to have main in its history for this to work
+  // the presence of history makes a big difference with onlyUpdated on
+  staging.workflows[0].history.push(wf1Version);
+
+  // Include forked_from as well, which also affects changed workflows
+  staging.cli.forked_from = {
+    wf1: wf1Version,
+    wf2: wf2Version,
+  };
+
+  t.is(main.workflows.length, 2);
+  t.is(staging.workflows.length, 1);
+
+  const result = merge(staging, main, { onlyUpdated: true });
+
+  // wf1 survives untouched, wf2 survives flagged removed (not dropped)
+  t.is(result.workflows.length, 2);
+  t.false(result.getWorkflow('wf1')!.isRemoved());
+  t.true(result.getWorkflow('wf2')!.isRemoved());
+});
+
+// The tests above all give every workflow the same id ('wf', from assignUUIDs),
+// so they can't tell a real per-workflow removal from an id collision masking
+// a workflow that was simply never re-added. These use distinct ids/names.
+test('deleting a workflow flags it removed, rather than dropping or keeping it', (t) => {
+  const wf1 = {
+    id: 'wf1',
+    name: 'wf1',
+    openfn: { uuid: randomUUID() },
+    steps: [],
+  };
+  const wf2 = {
+    id: 'wf2',
+    name: 'wf2',
+    openfn: { uuid: randomUUID() },
+    steps: [],
+  };
+
+  const main = createProject([wf1, wf2], 'a');
+  const wf1Version = main.getWorkflow('wf1')!.getVersionHash();
+  const wf2Version = main.getWorkflow('wf2')!.getVersionHash();
+
+  // staging represents the local project after wf2 was deleted locally
+  const staging = createProject([wf1], 'b');
+  staging.getWorkflow('wf1')!.history.push(wf1Version);
+  staging.cli.forked_from = { wf1: wf1Version, wf2: wf2Version };
+
+  const result = merge(staging, main, { onlyUpdated: true });
+
+  // wf2 must still be present in the result and flagged removed - dropping it
+  // silently means no delete: true ever reaches the provisioner, and keeping
+  // it un-flagged means it looks unchanged
+  const wf2Result = result.getWorkflow('wf2');
+  t.truthy(wf2Result);
+  t.true(wf2Result!.isRemoved());
+
+  // wf1 was untouched and must survive normally
+  const wf1Result = result.getWorkflow('wf1');
+  t.truthy(wf1Result);
+  t.false(wf1Result!.isRemoved());
+});
+
+test('deleting a workflow produces a delete: true entry when serialized', (t) => {
+  const wf1 = {
+    id: 'wf1',
+    name: 'wf1',
+    openfn: { uuid: randomUUID() },
+    steps: [],
+  };
+  const wf2 = {
+    id: 'wf2',
+    name: 'wf2',
+    openfn: { uuid: randomUUID() },
+    steps: [],
+  };
+
+  const main = createProject([wf1, wf2], 'a');
+  const wf1Version = main.getWorkflow('wf1')!.getVersionHash();
+  const wf2Version = main.getWorkflow('wf2')!.getVersionHash();
+
+  const staging = createProject([wf1], 'b');
+  staging.getWorkflow('wf1')!.history.push(wf1Version);
+  staging.cli.forked_from = { wf1: wf1Version, wf2: wf2Version };
+
+  const result = merge(staging, main, { onlyUpdated: true });
+  const state = result.serialize('state', { format: 'json' }) as any;
+
+  t.true(state.workflows['wf2'].delete);
+  t.deepEqual(state.workflows['wf2'].jobs, {});
+
+  t.falsy(state.workflows['wf1'].delete);
 });
 
 test('id match: same workflow in source and target project', (t) => {

--- a/packages/project/test/parse/from-app-state.test.ts
+++ b/packages/project/test/parse/from-app-state.test.ts
@@ -97,6 +97,63 @@ test('should create a Project from prov state with credentials', (t) => {
   t.deepEqual(project.credentials, []);
 });
 
+test('should load a workflow flagged delete: true and flag it removed', (t) => {
+  const stateWithDeletedWorkflow: any = cloneDeep(state);
+  stateWithDeletedWorkflow.workflows['my-workflow'].delete = true;
+
+  const project = fromAppState(stateWithDeletedWorkflow, meta);
+
+  t.is(project.workflows.length, 1);
+  t.true(project.workflows[0].isRemoved());
+});
+
+test('should load a job flagged delete: true and flag it removed', (t) => {
+  const stateWithDeletedJob: any = cloneDeep(state);
+  stateWithDeletedJob.workflows['my-workflow'].jobs['transform-data'].delete =
+    true;
+
+  const project = fromAppState(stateWithDeletedJob, meta);
+  const wf = project.workflows[0];
+
+  t.truthy(wf.get('transform-data'));
+  t.true(wf.isRemoved('transform-data'));
+});
+
+test('should load a trigger flagged delete: true and flag it removed', (t) => {
+  const stateWithDeletedTrigger: any = cloneDeep(state);
+  stateWithDeletedTrigger.workflows['my-workflow'].triggers.webhook.delete =
+    true;
+
+  const project = fromAppState(stateWithDeletedTrigger, meta);
+  const wf = project.workflows[0];
+
+  t.truthy(wf.get('webhook'));
+  t.true(wf.isRemoved('webhook'));
+});
+
+test('should load an edge flagged delete: true and flag it removed', (t) => {
+  const stateWithDeletedEdge: any = cloneDeep(state);
+  stateWithDeletedEdge.workflows['my-workflow'].edges[
+    'trigger->transform-data'
+  ].delete = true;
+
+  const project = fromAppState(stateWithDeletedEdge, meta);
+  const wf = project.workflows[0];
+
+  t.true(wf.isRemoved('webhook', 'transform-data'));
+});
+
+test('a delete: true job survives a parse -> serialize round trip', (t) => {
+  const stateWithDeletedJob: any = cloneDeep(state);
+  stateWithDeletedJob.workflows['my-workflow'].jobs['transform-data'].delete =
+    true;
+
+  const project = fromAppState(stateWithDeletedJob, meta);
+  const reserialized = project.serialize('state', { format: 'json' }) as any;
+
+  t.true(reserialized.workflows['my-workflow'].jobs['transform-data'].delete);
+});
+
 test('should create a Project from prov state with positions', (t) => {
   const newState = cloneDeep(state);
 
@@ -346,6 +403,43 @@ test('mapWorkflow: map a job with project credentials onto job.configuration', (
       keychain_credential_id: 'k',
     },
   });
+});
+
+// mapWorkflow is a pure mapper - it maps delete: true jobs/triggers/edges just
+// like any other. Flagging them removed on the resulting Workflow is the
+// caller's job (see fromAppState), since that's the only place a uuid can be
+// resolved back to a local id.
+test('mapWorkflow: maps a job flagged delete: true like any other job', (t) => {
+  const wf: any = cloneDeep(state.workflows['my-workflow']);
+  wf.jobs['transform-data'].delete = true;
+
+  const mapped = mapWorkflow(wf);
+
+  const job: any = mapped.steps.find((s: any) => s.id === 'transform-data');
+  t.is(job?.openfn.uuid, '66add020-e6eb-4eec-836b-20008afca816');
+});
+
+test('mapWorkflow: maps a trigger flagged delete: true like any other trigger', (t) => {
+  const wf: any = cloneDeep(state.workflows['my-workflow']);
+  wf.triggers.webhook.delete = true;
+
+  const mapped = mapWorkflow(wf);
+
+  const trigger: any = mapped.steps.find((s: any) => s.id === 'webhook');
+  t.is(trigger?.openfn.uuid, '4a06289c-15aa-4662-8dc6-f0aaacd8a058');
+});
+
+test('mapWorkflow: maps an edge flagged delete: true like any other edge', (t) => {
+  const wf: any = cloneDeep(state.workflows['my-workflow']);
+  wf.edges['trigger->transform-data'].delete = true;
+
+  const mapped = mapWorkflow(wf);
+
+  const [trigger] = mapped.steps as any[];
+  t.is(
+    trigger.next['transform-data'].openfn.uuid,
+    'a9a3adef-b394-4405-814d-3ac4323f4b4b'
+  );
 });
 
 test('mapEdge: map enabled state', (t) => {

--- a/packages/project/test/parse/from-path.test.ts
+++ b/packages/project/test/parse/from-path.test.ts
@@ -94,6 +94,17 @@ test.serial('should use workspace config', async (t) => {
   t.deepEqual(project.openfn!.uuid, proj.openfn!.uuid);
 });
 
+test.serial('should apply a name override to a loaded project', async (t) => {
+  mock({
+    '/p1/main@openfn.org.yaml': v2.yaml,
+  });
+  const project = await fromPath('/p1/main@openfn.org.yaml', {
+    name: 'My Duplicate',
+  });
+
+  t.is(project.name, 'My Duplicate');
+});
+
 test('extractAliasFromFilename: should extract alias from alias@domain.yaml format', (t) => {
   const alias = extractAliasFromFilename('main@app.openfn.org.yaml');
   t.is(alias, 'main');

--- a/packages/project/test/parse/from-project.test.ts
+++ b/packages/project/test/parse/from-project.test.ts
@@ -243,6 +243,17 @@ test('import v1 with custom config', async (t) => {
   });
 });
 
+test('import from a v1 state with a name override', async (t) => {
+  const proj = await Project.from('project', v1_yaml, { name: 'My Duplicate' });
+  t.is(proj.name, 'My Duplicate');
+});
+
+test('import from a v2 project with a name override', async (t) => {
+  // @ts-ignore
+  const proj = await Project.from('project', v2.json, { name: 'My Duplicate' });
+  t.is(proj.name, 'My Duplicate');
+});
+
 test('import v2 with custom config', async (t) => {
   const config = {
     x: 1234,

--- a/packages/project/test/serialize/to-app-state.test.ts
+++ b/packages/project/test/serialize/to-app-state.test.ts
@@ -488,6 +488,127 @@ a-(condition=x)-f
   t.is(a_f.condition_expression, 'x');
 });
 
+const removableWorkflowData: any = {
+  id: 'my-project',
+  workflows: [
+    {
+      id: 'wf',
+      name: 'wf',
+      openfn: { uuid: 'wf-uuid' },
+      steps: [
+        {
+          id: 'trigger',
+          type: 'webhook',
+          openfn: { uuid: 'trigger-uuid' },
+          next: {
+            step: { openfn: { uuid: 'edge-uuid' } },
+          },
+        },
+        {
+          id: 'step',
+          name: 'step',
+          expression: '.',
+          adaptor: 'common',
+          openfn: { uuid: 'step-uuid' },
+        },
+      ],
+    },
+  ],
+};
+
+test('a removed job becomes a minimal delete: true entry', (t) => {
+  const project = new Project(cloneDeep(removableWorkflowData));
+  project.getWorkflow('wf')!.remove('step');
+
+  const state = toAppState(project, { format: 'json' }) as Provisioner.Project;
+
+  t.deepEqual(state.workflows['wf'].jobs.step, {
+    id: 'step-uuid',
+    delete: true,
+  });
+});
+
+test('a removed trigger becomes a minimal delete: true entry', (t) => {
+  const project = new Project(cloneDeep(removableWorkflowData));
+  project.getWorkflow('wf')!.remove('trigger');
+
+  const state = toAppState(project, { format: 'json' }) as Provisioner.Project;
+
+  t.deepEqual(state.workflows['wf'].triggers.webhook, {
+    id: 'trigger-uuid',
+    delete: true,
+  });
+});
+
+test('a removed edge becomes a minimal delete: true entry', (t) => {
+  const project = new Project(cloneDeep(removableWorkflowData));
+  project.getWorkflow('wf')!.remove('trigger', 'step');
+
+  const state = toAppState(project, { format: 'json' }) as Provisioner.Project;
+
+  t.deepEqual(state.workflows['wf'].edges['trigger->step'], {
+    id: 'edge-uuid',
+    delete: true,
+  });
+});
+
+test('removing a job/trigger/edge that was never synced drops it entirely', (t) => {
+  // v2ProjectData's workflow has no openfn.uuid anywhere - nothing to tell
+  // Lightning to delete, so removed items are just dropped rather than sent
+  // with a made-up id
+  const project = new Project(cloneDeep(v2ProjectData), {
+    formats: { project: 'json' },
+  });
+  const wf = project.getWorkflow('my-workflow')!;
+  wf.remove('transform-data');
+  wf.remove('webhook', 'transform-data');
+
+  const state = toAppState(project, { format: 'json' }) as Provisioner.Project;
+
+  t.deepEqual(state.workflows['my-workflow'].jobs, {});
+  t.deepEqual(state.workflows['my-workflow'].edges, {});
+});
+
+test("removing a step doesn't remove its edges automatically", (t) => {
+  const project = new Project(cloneDeep(removableWorkflowData));
+  project.getWorkflow('wf')!.remove('step');
+
+  const state = toAppState(project, { format: 'json' }) as Provisioner.Project;
+
+  // the edge is still serialized normally, since only the step was flagged -
+  // removing connected edges is the caller's job, see Workflow.ts
+  t.falsy(state.workflows['wf'].edges['trigger->step'].delete);
+});
+
+test('a removed workflow becomes a minimal delete: true entry', (t) => {
+  const project = new Project(cloneDeep(removableWorkflowData));
+  project.getWorkflow('wf')!.remove();
+
+  const state = toAppState(project, { format: 'json' }) as Provisioner.Project;
+
+  t.deepEqual(state.workflows['wf'], {
+    id: 'wf-uuid',
+    name: 'wf',
+    delete: true,
+    jobs: {},
+    triggers: {},
+    edges: {},
+    lock_version: null,
+  });
+});
+
+test('asSpec ignores removed flags', (t) => {
+  const data = cloneDeep(removableWorkflowData);
+  const project = new Project(data);
+  project.getWorkflow('wf')!.remove('step');
+
+  const result = toAppState(project, { format: 'json', asSpec: true }) as any;
+
+  // asSpec has no notion of delete: true - the step is serialized normally
+  t.truthy(result.workflows['wf'].jobs.step);
+  t.falsy(result.workflows['wf'].jobs.step.delete);
+});
+
 test('should serialize channels to app state', (t) => {
   const channels = [
     {

--- a/packages/project/test/serialize/to-app-state.test.ts
+++ b/packages/project/test/serialize/to-app-state.test.ts
@@ -238,7 +238,7 @@ test('should write openfn keys to objects', (t) => {
   t.is(state.workflows['wf'].edges['trigger->step'].x, 1);
 });
 
-test('should handle credentials', (t) => {
+test('should handle credentials with existing UUIDs', (t) => {
   const data = {
     id: 'my-project',
     credentials: [
@@ -279,6 +279,51 @@ test('should handle credentials', (t) => {
   const { step } = state.workflows['wf'].jobs;
   t.is(step.keychain_credential_id, 'k');
   t.is(step.project_credential_id, '123');
+});
+
+test('should handle credentials without UUIDs (ie new credentials)', (t) => {
+  const data = {
+    id: 'my-project',
+    credentials: [
+      {
+        name: 'cred',
+        owner: 'admin@openfn.org',
+      },
+    ],
+    workflows: [
+      {
+        id: 'wf',
+        name: 'wf',
+        steps: [
+          {
+            id: 'trigger',
+            type: 'webhook',
+            next: {
+              step: {},
+            },
+          },
+          {
+            id: 'step',
+            expression: '.',
+            configuration: 'admin@openfn.org|cred',
+            openfn: {
+              keychain_credential_id: 'k',
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  const state = toAppState(new Project(data), {
+    format: 'json',
+  }) as Provisioner.Project_v1;
+  const { step } = state.workflows['wf'].jobs;
+  t.is(step.keychain_credential_id, 'k');
+
+  // Should look like a UUID
+  t.is(typeof step.project_credential_id, 'string');
+  t.is(step.project_credential_id!.length, 36);
 });
 
 test('should force a UUID on project credentials', (t) => {

--- a/packages/project/test/util/find-changed-workflows.test.ts
+++ b/packages/project/test/util/find-changed-workflows.test.ts
@@ -13,9 +13,10 @@ test('should return 0 changed workflows from forked_from', (t) => {
     [b.id]: generateHash(b),
   };
 
-  const changed = findChangedWorkflows(project);
+  const { changed, removed } = findChangedWorkflows(project);
 
   t.deepEqual(changed, []);
+  t.deepEqual(removed, []);
 });
 
 test('should return 1 changed workflows from forked_from', (t) => {
@@ -31,12 +32,13 @@ test('should return 1 changed workflows from forked_from', (t) => {
   // Now change b
   b.steps[0].name = 'x1';
 
-  const changed = findChangedWorkflows(project);
+  const { changed, removed } = findChangedWorkflows(project);
   t.is(changed.length, 1);
   t.is(changed[0].id, 'b');
+  t.deepEqual(removed, []);
 });
 
-test('should return 1 removed workflow', (t) => {
+test('should return 1 removed workflow id', (t) => {
   const project = generateProject('proj', ['@id a a-b', '@id b x-y']);
   const [a, b] = project.workflows;
 
@@ -48,9 +50,9 @@ test('should return 1 removed workflow', (t) => {
   // remove workflow b
   project.workflows.pop();
 
-  const changed = findChangedWorkflows(project);
-  t.is(changed.length, 1);
-  t.is(changed[0].id, 'b');
+  const { changed, removed } = findChangedWorkflows(project);
+  t.deepEqual(changed, []);
+  t.deepEqual(removed, ['b']);
 });
 
 test('should return 1 added workflow', (t) => {
@@ -62,9 +64,10 @@ test('should return 1 added workflow', (t) => {
     // Do not include b in forked_from - it's new!
   };
 
-  const changed = findChangedWorkflows(project);
+  const { changed, removed } = findChangedWorkflows(project);
   t.is(changed.length, 1);
   t.is(changed[0].id, 'b');
+  t.deepEqual(removed, []);
 });
 
 test.todo('changed from history');

--- a/packages/project/test/workflow.test.ts
+++ b/packages/project/test/workflow.test.ts
@@ -213,6 +213,127 @@ test('map uuids to ids', (t) => {
   t.deepEqual(w.index.id[uuid_bc], 'b-c');
 });
 
+test('remove - flag a step as removed', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('a');
+
+  t.true(w.removed.ids['a']);
+});
+
+test('remove - flagging a step does not touch the live workflow', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('a');
+
+  t.notThrows(() => w.get('a'));
+  t.is(w.steps.length, 3);
+});
+
+test('remove - flag an edge as removed, via its two endpoints', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('a', 'c');
+
+  t.true(w.removed.ids['a-c']);
+});
+
+test('remove - flagging an edge does not touch the live workflow', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('a', 'c');
+
+  t.notThrows(() => w.get('a-c'));
+  const a: any = w.get('a');
+  t.truthy(a.next.c);
+});
+
+test('remove - flagging a step does not cascade to its edges', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('c');
+
+  t.true(w.removed.ids['c']);
+  t.falsy(w.removed.ids['a-c']);
+  t.falsy(w.removed.ids['b-c']);
+});
+
+test('remove - throws for an unknown step', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.throws(() => w.remove('x'), {
+    message: 'step with id "x" does not exist in workflow',
+  });
+});
+
+test('remove - throws for an unknown edge', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.throws(() => w.remove('a', 'x'), {
+    message: 'edge with id "a-x" does not exist in workflow',
+  });
+});
+
+test('remove - no argument marks the whole workflow removed', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.false(w.removed.self);
+
+  w.remove();
+
+  t.true(w.removed.self);
+});
+
+test('remove - removing the whole workflow leaves its steps untouched', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove();
+
+  t.is(w.steps.length, 3);
+});
+
+test('isRemoved - no argument checks the whole workflow', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.false(w.isRemoved());
+
+  w.remove();
+
+  t.true(w.isRemoved());
+});
+
+test('isRemoved - false for a step/edge that has not been removed', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  t.false(w.isRemoved('a'));
+  t.false(w.isRemoved('a', 'c'));
+});
+
+test('isRemoved - true for a removed step', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('a');
+
+  t.true(w.isRemoved('a'));
+});
+
+test('isRemoved - true for a removed edge', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('a', 'c');
+
+  t.true(w.isRemoved('a', 'c'));
+});
+
+test('isRemoved - does not cascade to edges when their step is removed', (t) => {
+  const w = new Workflow(simpleWorkflow);
+
+  w.remove('c');
+
+  t.false(w.isRemoved('a', 'c'));
+  t.false(w.isRemoved('b', 'c'));
+});
+
 test('canMergeInto: should merge same content source & target', (t) => {
   const main = generateWorkflow('trigger-x');
   const sbox = generateWorkflow('trigger-x');

--- a/packages/ws-worker/src/channels/run.ts
+++ b/packages/ws-worker/src/channels/run.ts
@@ -37,11 +37,16 @@ const joinRunChannel = (
         if (!didReceiveOk) {
           didReceiveOk = true;
           logger.success(`connected to ${channelName}`, e);
-          const run = await sendEvent<GetPlanReply>(
-            { channel, logger, id: runId, options: {} },
-            GET_PLAN
-          );
-          resolve({ channel, run });
+          try {
+            const run = await sendEvent<GetPlanReply>(
+              { channel, logger, id: runId, options: {} },
+              GET_PLAN
+            );
+            resolve({ channel, run });
+          } catch (err) {
+            channel?.leave();
+            reject(err);
+          }
         }
       })
       .receive('error', (err: any) => {

--- a/packages/ws-worker/test/channels/run.test.ts
+++ b/packages/ws-worker/test/channels/run.test.ts
@@ -44,6 +44,30 @@ test('should fail to join an run channel with an invalid token', async (t) => {
   }
 });
 
+test('should reject (not hang) when fetch:plan replies an error', async (t) => {
+  const logger = createMockLogger();
+  const socket = new MockSocket('www', {
+    'run:a': mockChannel({
+      join: () => ({ status: 'ok' }),
+      [GET_PLAN]: () => {
+        throw { reason: 'adaptor_not_ready' };
+      },
+    }),
+  });
+
+  // race against a short timeout so a hang fails fast instead of hanging CI
+  const result = await Promise.race([
+    joinRunChannel(socket, 'x.y.z', 'a', logger).then(
+      () => 'resolved',
+      () => 'rejected'
+    ),
+    new Promise((resolve) => setTimeout(() => resolve('timed-out'), 200)),
+  ]);
+
+  // 'timed-out' would mean joinRunChannel's promise never settled
+  t.is(result, 'rejected');
+});
+
 test('should log an error including channel state when the channel errors', async (t) => {
   const logger = createMockLogger();
   const channel = mockChannel({

--- a/packages/ws-worker/test/util/send-event.test.ts
+++ b/packages/ws-worker/test/util/send-event.test.ts
@@ -306,47 +306,6 @@ test.serial('should report to sentry if the event timesout', async (t) => {
 });
 
 test.serial(
-  'should fingerprint sentry reports by error type and event name',
-  async (t) => {
-    // Without this, every timeout for every event collapses into one sentry
-    // issue - this is the change that would have made the step:complete
-    // pattern visible without digging through raw events. Each event is
-    // checked against a fresh testkit so the two reports cannot be confused
-    // with each other or raced against waitForSentryReport's "at least one"
-    // polling.
-    const channelA = mockChannel({});
-    await t.throwsAsync(() =>
-      sendEvent(
-        { id: 'x', channel: channelA, logger, options: {} },
-        'step:complete',
-        {}
-      )
-    );
-    const [stepReport] = await waitForSentryReport(testkit);
-    t.deepEqual(stepReport.originalReport.fingerprint, [
-      'LightningTimeoutError',
-      'step:complete',
-    ]);
-
-    testkit.reset();
-
-    const channelB = mockChannel({});
-    await t.throwsAsync(() =>
-      sendEvent(
-        { id: 'x', channel: channelB, logger, options: {} },
-        'run:complete',
-        {}
-      )
-    );
-    const [runReport] = await waitForSentryReport(testkit);
-    t.deepEqual(runReport.originalReport.fingerprint, [
-      'LightningTimeoutError',
-      'run:complete',
-    ]);
-  }
-);
-
-test.serial(
   'should report channel and socket state alongside a failed event',
   async (t) => {
     // Distinguishes a genuine failure on a healthy channel from collateral
@@ -388,6 +347,47 @@ test.serial('should report to sentry against the run scope', async (t) => {
   const trail = reports[0].originalReport?.breadcrumbs ?? [];
   t.true(trail.some((b: any) => b.message === 'job-complete'));
 });
+
+test.serial(
+  'should fingerprint sentry reports by error type and event name',
+  async (t) => {
+    // Without this, every timeout for every event collapses into one sentry
+    // issue - this is the change that would have made the step:complete
+    // pattern visible without digging through raw events. Each event is
+    // checked against a fresh testkit so the two reports cannot be confused
+    // with each other or raced against waitForSentryReport's "at least one"
+    // polling.
+    const channelA = mockChannel({});
+    await t.throwsAsync(() =>
+      sendEvent(
+        { id: 'x', channel: channelA, logger, options: {} },
+        'step:complete',
+        {}
+      )
+    );
+    const [stepReport] = await waitForSentryReport(testkit);
+    t.deepEqual(stepReport.originalReport.fingerprint, [
+      'LightningTimeoutError',
+      'step:complete',
+    ]);
+
+    testkit.reset();
+
+    const channelB = mockChannel({});
+    await t.throwsAsync(() =>
+      sendEvent(
+        { id: 'x', channel: channelB, logger, options: {} },
+        'run:complete',
+        {}
+      )
+    );
+    const [runReport] = await waitForSentryReport(testkit);
+    t.deepEqual(runReport.originalReport.fingerprint, [
+      'LightningTimeoutError',
+      'run:complete',
+    ]);
+  }
+);
 
 test.serial(
   'should report caller-supplied sentryExtras alongside a failed event',


### PR DESCRIPTION
## Short Description

This PR adds CLI support to deploy a v1 project.

The base PR adds support for project v2 only, on the assumption that the app is standardising on exporting projects in the v2 style.

But that assumption doesn't work:  production still uses v1 formats. So it's probably worth adding this support in, otherwise the feature is kind of usable for one of its major use-cases

## Implementation Details

This is a bigger  PR than I expected because it makes a change that was probably inevitable.

At the moment, there's a buch of condition logic in `to-app-state` used to serialize a statefile as as v1 spec file. This was pretty horrible really.

This PR splits that logic out in to `to-app-spec` and `from-app-spec`.

That's how we support the 1 file on deploy: we load a v1 spec as a Project, and then simply deploy it with the regular means.


## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
